### PR TITLE
Add yarn to the setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,14 +13,12 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  puts "== Installing Ruby dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
+  puts "== Installing JavaScript dependencies =="
+  system! "yarn"
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"


### PR DESCRIPTION
The current bin/setup script doesn't install the JS dependencies.

Assuming you already have yarn installed, bin/setup will ensure that the
yarn command runs on setup as well.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
