### PR TITLE
Add pages for cookies, privacy and accessibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "govuk_design_system_formbuilder"
 gem "govuk_feature_flags",
     git: "https://github.com/DFE-Digital/govuk_feature_flags.git",
     tag: "v1.0.1"
+gem "govuk_markdown"
 gem "jsbundling-rails"
 gem "pg", "~> 1.1"
 gem "propshaft"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
+    govuk_markdown (2.0.0)
+      activesupport
+      redcarpet
     haml (6.1.1)
       temple (>= 0.8.2)
       thor
@@ -221,6 +224,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rbs (2.8.4)
+    redcarpet (3.6.0)
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -347,6 +351,7 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   govuk_feature_flags!
+  govuk_markdown
   jsbundling-rails
   pg (~> 1.1)
   prettier_print

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class StaticController < ApplicationController
+  layout "two_thirds"
+end

--- a/app/views/layouts/two_thirds.html.erb
+++ b/app/views/layouts/two_thirds.html.erb
@@ -1,0 +1,9 @@
+<% content_for :content do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= yield %>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/base' %>

--- a/app/views/static/accessibility.html.md
+++ b/app/views/static/accessibility.html.md
@@ -1,0 +1,93 @@
+<% content_for :page_title, 'Accessibility statement' %>
+
+# Accessibility statement for <%= t('service.name') %>
+
+This page only contains information about the <%= t('service.name') %>
+service, available at: <a href="<%= t('service.url') %>" class="govuk-link
+govuk-link--no-visited-state"><%= t('service.url') %> </a>
+
+## Using this service
+
+This service is run by the Department for Education. We want as many people as
+possible to be able to use this service.
+
+For example, that means you should be able to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- get from the start of the service to the end using just a keyboard
+- get from the start of the service to the end using speech recognition
+  software
+- listen to the service using a screen reader (including the most recent
+  versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the text in the service as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device
+easier to use if you have a disability.
+
+## How accessible this service is
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+## Feedback and contact information
+
+If you have difficulty using this service, email: <a href="mailto:<%=
+t('service.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
+t('service.email') %></a>
+
+As part of providing this service, we may need to send you messages or
+documents. We'll ask you how you want us to send messages or documents to you,
+but contact us if you need them in a different format, for example, large print,
+audio recording or braille.
+
+## Reporting accessibility problems with this service
+
+We’re always looking to improve the accessibility of this service.
+
+If you find any problems that are not listed on this page or think we’re not
+meeting accessibility requirements, email: <a href="mailto:<%= t('service.email')
+%>" class="govuk-link govuk-link--no-visited-state"><%= t('service.email') %></a>
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing
+the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+Accessibility Regulations 2018 (the ‘accessibility regulations’).
+
+If you’re not happy with how we respond to your complaint, contact [the
+Equality Advisory and Support Service
+(EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this service’s accessibility
+
+The Department for Education is committed to making this service accessible, in
+accordance with the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+## What we are doing to improve accessibility
+
+We’ll carry out ongoing internal audits to check the accessibility of this
+service as well as taking feedback from users.
+
+Any required changes will be planned into our continuous improvement work for
+this service.
+
+This accessibility statement will be updated based on any issues we identify or
+any changes we make to address any issues raised.
+
+We're also planning a full accessibility audit on the service by the Digital
+Accessibility Centre (DAC) before March 2023.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on Monday 21 November 2022. It was last reviewed on
+Monday 20 February 2023.
+
+Last updated: Monday 20 February 2023

--- a/app/views/static/cookies.md
+++ b/app/views/static/cookies.md
@@ -1,0 +1,38 @@
+<% content_for :page_title, 'Cookies' %>
+
+# Cookies
+
+Cookies are small files saved on your phone, tablet or computer when you visit
+a website.
+
+We use cookies to make the <%= t('service.name') %> service work and
+collect information about how you use our service.
+
+## Essential cookies
+
+Essential cookies keep your information secure while you use the <%=
+t('service.name') %> service. We do not need to ask permission to use them.
+
+<table class="govuk-table">
+  <caption class="govuk-visually-hidden">Essential cookies</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Name</th>
+      <th class="govuk-table__header">Purpose</th>
+      <th class="govuk-table__header">Expires</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        _session_id
+      </td>
+      <td class="govuk-table__cell" width="50%">
+        Used to keep you signed in
+      </td>
+      <td class="govuk-table__cell">
+        2 hours
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/static/privacy.md
+++ b/app/views/static/privacy.md
@@ -1,0 +1,78 @@
+<% content_for :page_title, 'Privacy notice' %>
+
+# Privacy notice
+
+## Who we are
+
+The <%= t('service.name') %> service is run by the [Teaching Regulation Agency
+(TRA)](https://www.gov.uk/government/organisations/teaching-regulation-agency/about),
+an executive agency of the Department for Education (DfE).
+
+Our service allows anyone to access their teaching certificates.
+
+For the purpose of data protection legislation, DfE is the data controller for
+the data we hold and process.
+
+## What data we collect
+
+We do not collect any personal data about you when you use this service.
+
+## Our legal basis for processing your data
+
+So that our use of your personal data is lawful, we need to meet one (or more)
+conditions in the data protection legislation. For our service, this is:
+
+- article 6(1)(e) UK General Data Protection Regulation (UK GDPR), to perform a
+  public task carried out in the public interest as part of our function as a
+  department
+
+## Your data protection rights
+
+You have the right:
+
+- to ask us what information we hold about you
+- to have your personal data rectified if it is inaccurate or incomplete
+- to request the deletion or removal of personal data where there is no
+  compelling reason for its continued processing
+- to restrict our processing of your personal data (for instance allow us to
+  store it but not process it further)
+- to object to direct marketing (including profiling) and processing for the
+  purposes of scientific or historical research and statistics
+- not to be subject to decisions based purely on automated processing where it
+  produces a legal or similarly significant effect on you
+
+If you have any questions about how we’ll use your personal information,
+email [qts.enquiries@education.gov.uk](mailto:qts.enquiries@education.gov.uk)
+and enter ‘Data protection enquiry’ as a reference.
+
+You can also contact the Data Protection Office by emailing
+[dataprotection.office@education.gov.uk](mailto:dataprotection.office@education.gov.uk).
+
+You can find further information about your data protection rights on
+the [Information Commissioner’s
+website](https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/).
+
+### Consent and how to make a complaint
+
+As we have a clear purpose for processing your personal data, we would not
+explicitly seek your consent to process your data.
+
+If you’re unhappy with our use of your personal data, please
+email [qts.enquiries@education.gov.uk](mailto:qts.enquiries@education.gov.uk).
+
+You can also contact the DfE Data Protection Office:
+
+Deputy Director, Departmental Data Protection Officer<br />
+Wellington Place<br />
+Leeds<br />
+LS1 4AP<br />
+[data.protection@education.gov.uk](mailto:data.protection@education.gov.uk)
+
+Alternatively, you have the right to raise any concerns with the [Information
+Commissioner’s Office (ICO)](https://ico.org.uk/concerns/).
+
+## Changes to this notice
+
+We’ll update this privacy notice when required. You should review it at least once a year.
+
+This version was last updated on 20 February 2023.

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MarkdownTemplate
+  def self.call(template, source)
+    erb_handler = ActionView::Template.registered_template_handler(:erb)
+    compiled_source = erb_handler.call(template, source)
+    "GovukMarkdown.render(begin;#{compiled_source};end).html_safe"
+  end
+end
+
+ActionView::Template.register_template_handler :md, MarkdownTemplate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,4 @@ en:
     name: Access your teaching certificates
     email: my-service@email
     feedback_form: https://forms.gle/mroZH7aVYGPrB37G6
+    url: https://access-your-teaching-certificates.digital.education.gov.uk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,8 @@ Rails.application.routes.draw do
 
     mount FeatureFlags::Engine => "/features"
   end
+
+  get "/accessibility", to: "static#accessibility"
+  get "/cookies", to: "static#cookies"
+  get "/privacy", to: "static#privacy"
 end


### PR DESCRIPTION
The static pages don't contain any custom HTML and are simple text
documents.

It makes most sense to write them in markdown to allow for ease of
reading and writing in development.

The markdown rendering implementation is similar to the one implemented
in [Find a Lost TRN](DFE-Digital/find-a-lost-trn#21).

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
