### PR TITLE
Staff login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ end
 group :test do
   gem "capybara"
   gem "cuprite"
+  gem "factory_bot_rails"
   gem "shoulda-matchers"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.2.1"
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "devise"
+gem "devise_invitable"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "govuk_feature_flags",

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ end
 group :test do
   gem "capybara"
   gem "cuprite"
+  gem "shoulda-matchers"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise_invitable (2.0.7)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -363,6 +366,7 @@ DEPENDENCIES
   cuprite
   debug
   devise
+  devise_invitable
   dotenv-rails
   govuk-components
   govuk_design_system_formbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,11 @@ GEM
       railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ferrum (0.13)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -368,6 +373,7 @@ DEPENDENCIES
   devise
   devise_invitable
   dotenv-rails
+  factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder
   govuk_feature_flags!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.11.0)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     solargraph (0.48.0)
       backport (~> 1.2)
       benchmark
@@ -376,6 +378,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  shoulda-matchers
   solargraph
   solargraph-rails
   syntax_tree

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
-  http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),
-                               password: ENV.fetch("SUPPORT_PASSWORD", nil)
+  http_basic_authenticate_with(
+    name: ENV.fetch("SUPPORT_USERNAME", nil),
+    password: ENV.fetch("SUPPORT_PASSWORD", nil),
+    unless: -> { FeatureFlags::FeatureFlag.active?("service_open") }
+  )
 end

--- a/app/controllers/staff/confirmations_controller.rb
+++ b/app/controllers/staff/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Staff::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Staff::InvitationsController < Devise::InvitationsController
+  protect_from_forgery prepend: true
+
+  protected
+
+  def invite_resource(&block)
+    if current_inviter.is_an?(AnonymousSupportUser)
+      resource_class.invite!(invite_params, &block)
+    else
+      super
+    end
+  end
+
+  def after_invite_path_for(inviter, invitee)
+    invitee.is_a?(Staff) ? support_interface_staff_index_path : super
+  end
+
+  def after_accept_path_for(resource)
+    resource.is_a?(Staff) ? support_interface_staff_index_path : super
+  end
+end

--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Staff::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Staff::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/staff/unlocks_controller.rb
+++ b/app/controllers/staff/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Staff::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,10 +3,6 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     layout "support_layout"
 
-    http_basic_authenticate_with name: ENV["SUPPORT_USERNAME"],
-                                 password: ENV["SUPPORT_PASSWORD"]
-
-    def index
-    end
+    before_action :authenticate_staff!
   end
 end

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -1,0 +1,50 @@
+class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
+  def valid?
+    FeatureFlags::FeatureFlag.active?(:staff_http_basic_auth) || !Staff.exists?
+  end
+
+  def store?
+    false
+  end
+
+  def authenticate!
+    auth = Rack::Auth::Basic::Request.new(env)
+
+    return success!(ANONYMOUS_SUPPORT_USER) if credentials_valid?(auth)
+
+    custom!(
+      [
+        401,
+        {
+          "Content-Type" => "text/plain",
+          "Content-Length" => "0",
+          "WWW-Authenticate" => "Basic realm=\"Application\""
+        },
+        []
+      ]
+    )
+  end
+
+  private
+
+  SUPPORT_USERNAME =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
+  SUPPORT_PASSWORD =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
+
+  ANONYMOUS_SUPPORT_USER = AnonymousSupportUser.new
+
+  def credentials_valid?(auth)
+    return false unless auth.provided? && auth.basic? && auth.credentials
+
+    valid_comparison?(SUPPORT_USERNAME, auth.credentials.first) &&
+      valid_comparison?(SUPPORT_PASSWORD, auth.credentials.last)
+  end
+
+  def valid_comparison?(correct_value, given_value)
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(given_value),
+      correct_value
+    )
+  end
+end

--- a/app/models/anonymous_support_user.rb
+++ b/app/models/anonymous_support_user.rb
@@ -1,0 +1,9 @@
+class AnonymousSupportUser
+  def has_invitations_left?
+    true
+  end
+
+  def devise_scope
+    :staff
+  end
+end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -5,7 +5,6 @@ class Staff < ApplicationRecord
     :invitable,
     :lockable,
     :recoverable,
-    :registerable,
     :rememberable,
     :timeoutable,
     :trackable,

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,0 +1,13 @@
+class Staff < ApplicationRecord
+  devise(
+    :confirmable,
+    :database_authenticatable,
+    :lockable,
+    :registerable,
+    :recoverable,
+    :rememberable,
+    :timeoutable,
+    :trackable,
+    :validatable
+  )
+end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -2,9 +2,10 @@ class Staff < ApplicationRecord
   devise(
     :confirmable,
     :database_authenticatable,
+    :invitable,
     :lockable,
-    :registerable,
     :recoverable,
+    :registerable,
     :rememberable,
     :timeoutable,
     :trackable,

--- a/app/views/staff/confirmations/new.html.erb
+++ b/app/views/staff/confirmations/new.html.erb
@@ -1,0 +1,18 @@
+<h1 class="govuk-heading-l">Resend confirmation instructions</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= f.govuk_email_field(
+        :email, 
+        autofocus: true, 
+        autocomplete: "email", 
+        value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), 
+        label: { text: "Email" } 
+      %>
+      <%= f.govuk_submit "Resend confirmation instructions" %>
+    <% end %>
+
+    <%= render "staff/shared/links" %>
+  </div>
+</div>

--- a/app/views/staff/invitations/edit.html.erb
+++ b/app/views/staff/invitations/edit.html.erb
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-l"><%= t "devise.invitations.edit.header" %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+      <%= f.hidden_field :invitation_token, readonly: true %>
+
+      <% if f.object.class.require_password_on_accepting %>
+        <%= f.govuk_password_field :password, label: { text: "Password" } %>
+        <%= f.govuk_password_field :password_confirmation, label: { text: "Password confirmation" } %>
+      <% end %>
+
+      <%= f.govuk_submit t("devise.invitations.edit.submit_button") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/staff/invitations/new.html.erb
+++ b/app/views/staff/invitations/new.html.erb
@@ -1,0 +1,13 @@
+<h1 class="govuk-heading-l"><%= t "devise.invitations.new.header" %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+      <% resource.class.invite_key_fields.each do |field| -%>
+        <%= f.govuk_text_field field, label: { text: field.to_s.humanize } %>
+      <% end -%>
+
+      <%= f.govuk_submit t("devise.invitations.new.submit_button") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/staff/mailer/confirmation_instructions.html.erb
+++ b/app/views/staff/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/staff/mailer/email_changed.html.erb
+++ b/app/views/staff/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/staff/mailer/invitation_instructions.html.erb
+++ b/app/views/staff/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/staff/mailer/invitation_instructions.text.erb
+++ b/app/views/staff/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/app/views/staff/mailer/password_change.html.erb
+++ b/app/views/staff/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/staff/mailer/reset_password_instructions.html.erb
+++ b/app/views/staff/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/staff/mailer/unlock_instructions.html.erb
+++ b/app/views/staff/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/staff/passwords/edit.html.erb
+++ b/app/views/staff/passwords/edit.html.erb
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-l">Change your password</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= f.hidden_field :reset_password_token %>
+
+      <%= f.govuk_password_field :password, autocomplete: "new-password", label: { text: "Password" } %>
+      <%= f.govuk_password_field :password_confirmation, autocomplete: "new-password", label: { text: "Password confirmation" } %>
+
+      <%= f.govuk_submit "Change my password" %>
+    <% end %>
+
+    <%= render "staff/shared/links" %>
+  </div>
+</div>

--- a/app/views/staff/passwords/new.html.erb
+++ b/app/views/staff/passwords/new.html.erb
@@ -1,0 +1,12 @@
+<h1 class="govuk-heading-l">Forgot your password?</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_submit "Send me reset password instructions" %>
+    <% end %>
+
+    <%= render "staff/shared/links" %>
+  </div>
+</div>

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -1,0 +1,28 @@
+<h1 class="govuk-heading-l">Log in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
+
+      <% if devise_mapping.rememberable? %>
+        <%= f.govuk_check_boxes_fieldset :remember_me, multiple: false, legend: nil do %>
+          <%= f.govuk_check_box(
+            :remember_me, 
+            1, 
+            0, 
+            multiple: false, 
+            link_errors: true, 
+            small: true, 
+            label: { text: "Remember me?" }
+          ) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Log in" %>
+    <% end %>
+
+    <%= render "staff/shared/links" %>
+  </div>
+</div>

--- a/app/views/staff/shared/_links.html.erb
+++ b/app/views/staff/shared/_links.html.erb
@@ -1,0 +1,27 @@
+<p class="govuk-body">
+  <%- if controller_name != 'sessions' %>
+    <%= govuk_link_to "Log in", new_session_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= govuk_link_to "Sign up", new_registration_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= govuk_link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= govuk_link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= govuk_link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <% end %>
+  <% end %>
+</p>

--- a/app/views/staff/unlocks/new.html.erb
+++ b/app/views/staff/unlocks/new.html.erb
@@ -1,0 +1,12 @@
+<h1 class="govuk-heading-l">Resend unlock instructions</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_submit "Resend unlock instructions" %>
+    <% end %>
+
+    <%= render "staff/shared/links" %>
+  </div>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = { from: "mail@example.com" }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -8,3 +8,8 @@ feature_flags:
       always be inactive on non-production deployments, to prevent accidental
       access by members of the public. Once the service goes live, this flag
       should always be active on production.
+  staff_http_basic_auth:
+    author: Felix Clack
+    description: Allow signing in as a staff user using HTTP Basic
+      authentication. This is useful before staff users have been created, but
+      should otherwise be inactive.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -326,10 +326,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
+    manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -134,6 +134,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  config.invite_for = 1.week
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "DfE"
+  inflect.uncountable %w[staff]
+end

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,12 @@
 Rails.application.routes.draw do
-  devise_for :staff
+  devise_for :staff,
+             controllers: {
+               confirmations: "staff/confirmations",
+               invitations: "staff/invitations",
+               passwords: "staff/passwords",
+               sessions: "staff/sessions",
+               unlocks: "staff/unlocks"
+             }
 
   root to: "pages#home"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :staff
+
   root to: "pages#home"
 
   namespace :support_interface, path: "/support" do

--- a/db/migrate/20230221112241_devise_create_staff.rb
+++ b/db/migrate/20230221112241_devise_create_staff.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DeviseCreateStaff < ActiveRecord::Migration[7.0]
+  def change
+    create_table :staff do |t|
+      ## Database authenticatable
+      t.string :email, null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+
+      ## Confirmable
+      t.string :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      t.integer :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :staff, :email, unique: true
+    add_index :staff, :reset_password_token, unique: true
+    add_index :staff, :confirmation_token, unique: true
+    add_index :staff, :unlock_token, unique: true
+  end
+end

--- a/db/migrate/20230221113319_add_devise_invitable_to_staff.rb
+++ b/db/migrate/20230221113319_add_devise_invitable_to_staff.rb
@@ -1,0 +1,16 @@
+class AddDeviseInvitableToStaff < ActiveRecord::Migration[7.0]
+  def change
+    change_table :staff, bulk: true do |t|
+      t.datetime :invitation_accepted_at
+      t.datetime :invitation_created_at
+      t.datetime :invitation_sent_at
+      t.integer :invitation_limit
+      t.integer :invitations_count, default: 0
+      t.references :invited_by, polymorphic: true
+      t.string :invitation_token
+
+      t.index :invitation_token, unique: true
+      t.index :invited_by_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_091733) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_112241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_091733) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+  create_table "staff", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_staff_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_staff_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_21_112241) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_113319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,8 +70,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_112241) do
     t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "invitation_accepted_at", precision: nil
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.integer "invitation_limit"
+    t.integer "invitations_count", default: 0
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.string "invitation_token"
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
+    t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true
+    t.index ["invited_by_id"], name: "index_staff_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_staff_on_invited_by"
     t.index ["reset_password_token"], name: "index_staff_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :staff do
+    email { "staff@example.com" }
+    password { "password" }
+
+    trait :confirmed do
+      confirmed_at { Time.current }
+    end
+  end
+end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe StaffHttpBasicAuthStrategy do
+  subject(:staff_http_basic_auth_strategy) { described_class.new(env) }
+
+  let(:env) { {} }
+
+  describe "#valid?" do
+    subject(:valid?) { staff_http_basic_auth_strategy.valid? }
+
+    context "with staff users" do
+      before { create(:staff) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when feature is active" do
+      before { FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when there are no staff users" do
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#store?" do
+    subject(:store?) { staff_http_basic_auth_strategy.store? }
+
+    it { is_expected.to eq(false) }
+  end
+
+  describe "#authenticate!" do
+    before { staff_http_basic_auth_strategy.authenticate! }
+
+    it "halts the strategy" do
+      expect(staff_http_basic_auth_strategy).to be_halted
+    end
+
+    it "is not successful" do
+      expect(staff_http_basic_auth_strategy).not_to be_successful
+    end
+
+    it "sets a custom response" do
+      expect(staff_http_basic_auth_strategy.custom_response).to eq(
+        [
+          401,
+          {
+            "Content-Length" => "0",
+            "Content-Type" => "text/plain",
+            "WWW-Authenticate" => "Basic realm=\"Application\""
+          },
+          []
+        ]
+      )
+    end
+
+    context "with valid credentials" do
+      let(:env) do
+        { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
+      end
+
+      it "is successful" do
+        expect(staff_http_basic_auth_strategy).to be_successful
+      end
+    end
+  end
+end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Staff, type: :model do
+  it { is_expected.to be_a(Devise::Models::Confirmable) }
+  it { is_expected.to be_a(Devise::Models::DatabaseAuthenticatable) }
+  it { is_expected.to be_a(Devise::Models::Lockable) }
+  it { is_expected.to be_a(Devise::Models::Registerable) }
+  it { is_expected.to be_a(Devise::Models::Recoverable) }
+  it { is_expected.to be_a(Devise::Models::Rememberable) }
+  it { is_expected.to be_a(Devise::Models::Timeoutable) }
+  it { is_expected.to be_a(Devise::Models::Trackable) }
+  it { is_expected.to be_a(Devise::Models::Validatable) }
+
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_presence_of(:password) }
+end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Staff, type: :model do
   it { is_expected.to be_a(Devise::Models::Confirmable) }
   it { is_expected.to be_a(Devise::Models::DatabaseAuthenticatable) }
   it { is_expected.to be_a(Devise::Models::Lockable) }
-  it { is_expected.to be_a(Devise::Models::Registerable) }
   it { is_expected.to be_a(Devise::Models::Recoverable) }
   it { is_expected.to be_a(Devise::Models::Rememberable) }
   it { is_expected.to be_a(Devise::Models::Timeoutable) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,9 +36,7 @@ Capybara.javascript_driver = :cuprite
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each do |f|
-  require f
-end
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,9 @@ Capybara.javascript_driver = :cuprite
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each do |f|
+  require f
+end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::IntegrationHelpers, type: :system
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,1 @@
+RSpec.configure { |config| config.include FactoryBot::Syntax::Methods }

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Shoulda::Matchers::ActiveModel, type: :model
+end

--- a/spec/support/system/activate_features_steps.rb
+++ b/spec/support/system/activate_features_steps.rb
@@ -1,0 +1,9 @@
+module ActivateFeaturesSteps
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_staff_http_basic_is_active
+    FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth)
+  end
+end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -1,0 +1,6 @@
+module AuthenticationSteps
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+end

--- a/spec/support/system/authorization_steps.rb
+++ b/spec/support/system/authorization_steps.rb
@@ -1,0 +1,12 @@
+module AuthorizationSteps
+  def when_i_am_authorized_with_basic_auth
+    page.driver.basic_authorize(
+      ENV.fetch("SUPPORT_USERNAME", "test"),
+      ENV.fetch("SUPPORT_PASSWORD", "test")
+    )
+  end
+
+  def then_i_am_unauthorized
+    expect(page.status_code).to eq(401)
+  end
+end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -1,0 +1,13 @@
+module CommonSteps
+  include AuthenticationSteps
+  include AuthorizationSteps
+  include ActivateFeaturesSteps
+
+  def when_i_visit_the_service
+    visit root_path
+  end
+
+  def when_i_visit_the_support_interface
+    visit support_interface_path
+  end
+end

--- a/spec/system/support/basic_auth_user_spec.rb
+++ b/spec/system/support/basic_auth_user_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Basic auth user" do
+  include CommonSteps
+
+  scenario "Access is restricted by basic auth", type: :system do
+    given_the_service_is_open
+    and_staff_http_basic_is_active
+
+    when_i_visit_the_support_interface
+    then_i_am_unauthorized
+
+    when_i_am_authorized_with_basic_auth
+    when_i_refresh_and_try_again
+    then_i_see_the_support_interface
+  end
+
+  private
+
+  def when_i_refresh_and_try_again
+    page.driver.refresh
+  end
+
+  def then_i_see_the_support_interface
+    expect(page).to have_content("Support")
+  end
+end

--- a/spec/system/support/staff_http_flag_spec.rb
+++ b/spec/system/support/staff_http_flag_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Staff HTTP feature flag" do
+  include CommonSteps
+
+  scenario "Feature flag is disabled and no Staff accounts exist" do
+    given_the_service_is_open
+
+    when_i_visit_the_support_interface
+    then_i_am_unauthorized
+
+    when_i_am_authorized_with_basic_auth
+    and_i_refresh_and_try_again
+    then_i_see_the_support_interface
+  end
+
+  private
+
+  def and_i_refresh_and_try_again
+    page.driver.refresh
+  end
+
+  def then_i_see_the_support_interface
+    expect(page).to have_content("Support")
+  end
+end

--- a/spec/system/support/staff_login_spec.rb
+++ b/spec/system/support/staff_login_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.feature "Staff login" do
+  include CommonSteps
+
+  scenario "Staff user logs in" do
+    given_the_service_is_open
+    and_a_staff_user_exists
+    when_i_visit_the_support_interface
+    then_i_see_the_staff_login_page
+
+    when_i_enter_my_credentials
+    and_i_click_on_the_login_button
+    then_i_see_the_support_interface
+  end
+
+  def and_a_staff_user_exists
+    @staff_user = create(:staff, :confirmed)
+  end
+
+  def then_i_see_the_staff_login_page
+    expect(page).to have_content("Log in")
+  end
+
+  def when_i_enter_my_credentials
+    fill_in "Email", with: @staff_user.email
+    fill_in "Password", with: "password"
+  end
+
+  def and_i_click_on_the_login_button
+    click_on "Log in"
+  end
+
+  def then_i_see_the_support_interface
+    expect(page).to have_content("Support")
+  end
+end


### PR DESCRIPTION
The Staff user can be used to log in to the support interface.

This change customises the default Devise views to the GOVUK style.

It also enables using either a basic auth feature flag for support or
the Staff model.

Assumptions:
* we will handle creating invites in a future change

### Link to Trello card

https://trello.com/c/DFEpaOhz/671-add-staff-login

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
