### PR TITLE
Setup Notify

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+GOVUK_NOTIFY_API_KEY=override-locally
 HOSTING_DOMAIN=localhost:3000
 HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
+GOVUK_NOTIFY_API_KEY=override-locally
 HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally
 IDENTITY_CLIENT_ID=override-locally

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ RUN yarn install --frozen-lockfile --check-files
 COPY . .
 
 # Precompile assets
-RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used \
+RUN RAILS_ENV=production \
+    SECRET_KEY_BASE=required-to-run-but-not-used \
+    GOVUK_NOTIFY_API_KEY=required-to-run-but-not-used \
     bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "govuk_feature_flags",
     tag: "v1.0.1"
 gem "govuk_markdown"
 gem "jsbundling-rails"
+gem "mail-notify"
 gem "omniauth-oauth2", "~> 1.8"
 gem "omniauth-rails_csrf_protection"
 gem "pg", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,13 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mail-notify (1.1.0)
+      actionmailer (>= 5.2.4.6)
+      actionpack (>= 5.2.7.1)
+      actionview (>= 5.2.7.1)
+      activesupport (>= 5.2.4.6)
+      notifications-ruby-client (~> 5.1)
+      rack (>= 2.1.4.1)
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -198,6 +205,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
+    notifications-ruby-client (5.4.0)
+      jwt (>= 1.5, < 3)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -410,6 +419,7 @@ DEPENDENCIES
   govuk_feature_flags!
   govuk_markdown
   jsbundling-rails
+  mail-notify
   omniauth-oauth2 (~> 1.8)
   omniauth-rails_csrf_protection
   pg (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ The following feature flags are required for normal operation of the site and ar
 FeatureFlags::Feature.create(name: :service_open, active: true)
 ```
 
+### Notify
+
+If you want to test and simulate sending emails locally, you need to be added
+to the TRA digital Notify account. Then, go to
+`API integration > API keys > Create an API key` and create a new key, such as
+`Myname - local test` and set the type to `Test - pretends to send messages`.
+
+Add this key to your local development secrets:
+
+```bash
+$ vim .env.development.local
+GOVUK_NOTIFY_API_KEY=me__local_test-abcefgh-1234-abcdefgh
+```
+
+When you send an email locally, the email should appear in the message log in
+the Notify dashboard in the `API integration` section.
+
+_Note:_ You can set `GOVUK_NOTIFY_API_KEY=fake-key` when running locally if you don't need to use Notify.
+
 ### Linting
 
 To run the linters:

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class ApplicationMailer < Mail::Notify::Mailer
+  GENERIC_NOTIFY_TEMPLATE = "5e1842e6-d806-49ce-ba19-0483a056e367"
+
+  def notify_email(headers)
+    headers =
+      headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
+    view_mail(GENERIC_NOTIFY_TEMPLATE, headers)
+  end
+end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,9 @@
+class DeviseMailer < Devise::Mailer
+  def devise_mail(record, action, opts = {}, &_block)
+    initialize_from_record(record)
+    view_mail(
+      ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
+      headers_for(action, opts)
+    )
+  end
+end

--- a/app/validators/valid_for_notify_validator.rb
+++ b/app/validators/valid_for_notify_validator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class ValidForNotifyValidator < ActiveModel::EachValidator
+  NUMBERS_AND_LETTERS =
+    "a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ"
+  CHINESE_JAPANESE_AND_KOREAN_CHARS =
+    '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'
+  ALPHANUMERIC = NUMBERS_AND_LETTERS + CHINESE_JAPANESE_AND_KOREAN_CHARS
+  EMAIL_REGEX =
+    %r{\A[#{ALPHANUMERIC}.!\#$%&'*+/=?^_`{|}~-] # Local part
+                  +@[#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-] # Domain name
+                  {0,61}[#{ALPHANUMERIC}])?(?:\. # Allow periods in domain name
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61}[#{ALPHANUMERIC}])?)*\.
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61} # # End of domain
+                  [#{ALPHANUMERIC}])\z}x
+
+  def validate_each(record, attribute, value)
+    return unless value.blank? || !value.match?(EMAIL_REGEX)
+
+    record.errors.add(
+      attribute,
+      I18n.t("validation_errors.email_address_format")
+    )
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,14 @@ module AccessYourTeachingCertificates
     config.assets.paths << Rails.root.join(
       "node_modules/govuk-frontend/govuk/assets"
     )
+
+    config.action_mailer.notify_settings = {
+      api_key:
+        ENV.fetch("GOVUK_NOTIFY_API_KEY") do
+          raise "'GOVUK_NOTIFY_API_KEY' should be configured in " \
+                  ".env.*environment* file. Please refer to " \
+                  "https://github.com/DFE-Digital/refer-serious-misconduct/#notify"
+        end
+    }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.action_mailer.delivery_method = :notify
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.delivery_method = :notify
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,6 +50,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_options = { from: "mail@example.com" }
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -29,10 +29,10 @@ Devise.setup do |config|
   config.mailer_sender = ENV.fetch("DEVISE_MAILER_SENDER", "test@example.com")
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = "DeviseMailer"
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = "Mail::Notify::Mailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,6 @@ en:
     email: my-service@email
     feedback_form: https://forms.gle/mroZH7aVYGPrB37G6
     url: https://access-your-teaching-certificates.digital.education.gov.uk
+
+  validation_errors:
+    email_address_format: Enter an email address in the correct format, like name@example.com

--- a/spec/validators/valid_for_notify_validator_spec.rb
+++ b/spec/validators/valid_for_notify_validator_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ValidForNotifyValidator do
+  before do
+    stub_const("Validatable", Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :email_address
+      validates :email_address, valid_for_notify: true
+    end
+  end
+
+  context "when an email address has a valid format" do
+    let(:model) { Validatable.new }
+    let(:valid_emails) do
+      %w[
+        email@domain.com
+        email@domain.COM
+        firstname.lastname@domain.com
+        firstname.o'lastname@domain.com
+        email@subdomain.domain.com
+        firstname+lastname@domain.com
+        1234567890@domain.com
+        email@domain-one.com
+        _______@domain.com
+        email@domain.name
+        email@domain.superlongtld
+        email@domain.co.jp
+        firstname-lastname@domain.com
+        info@german-financial-services.vermögensberatung
+        info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase
+        japanese-info@例え.テスト
+      ]
+    end
+
+    it "returns valid" do
+      valid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).to be_valid
+      end
+    end
+  end
+
+  context "when an email address is in an invalid format" do
+    let(:model) { Validatable.new }
+    let(:invalid_emails) do
+      [
+        "email@[123.123.123.123]",
+        "plainaddress",
+        "@no-local-part.com",
+        "Outlook Contact <outlook-contact@domain.com>",
+        "no-at.domain.com",
+        "no-tld@domain",
+        ";beginning-semicolon@domain.co.uk",
+        "middle-semicolon@domain.co;uk",
+        "trailing-semicolon@domain.com;",
+        '"email+leading-quotes@domain.com',
+        'email+middle"-quotes@domain.com',
+        '"quoted-local-part"@domain.com',
+        '"quoted@domain.com"',
+        "lots-of-dots@domain..gov..uk",
+        "multiple@domains@domain.com",
+        "spaces in local@domain.com",
+        "spaces-in-domain@dom ain.com",
+        "underscores-in-domain@dom_ain.com",
+        "pipe-in-domain@example.com|gov.uk",
+        "comma,in-local@gov.uk",
+        "comma-in-domain@domain,gov.uk",
+        "pound-sign-in-local£@domain.com",
+        "local-with-’-apostrophe@domain.com",
+        "local-with-”-quotes@domain.com",
+        "domain-starts-with-a-dot@.domain.com",
+        "brackets(in)local@domain.com"
+      ]
+    end
+
+    it "returns invalid" do
+      invalid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).to be_invalid
+      end
+    end
+
+    it "returns the correct error message" do
+      model.email_address = "foo"
+      model.validate(:no_context)
+      expect(model.errors[:email_address]).to include(
+        "Enter an email address in the correct format, like name@example.com"
+      )
+    end
+  end
+end


### PR DESCRIPTION
We want to use the GOVUK Notifications service to send emails.

This sets up Notify using the `mail-notify` gem and the configuration
used in other projects as the base (see [Refer](https://github.com/DFE-Digital/refer-serious-misconduct/commit/abb08d0c18336a1e07976e9b5123929d2161cc05) and [Find](https://github.com/DFE-Digital/find-a-lost-trn/pull/120)).

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
