### PR TITLE
Add OkComputer for a health check endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "govuk_feature_flags",
 gem "govuk_markdown"
 gem "jsbundling-rails"
 gem "mail-notify"
+gem "okcomputer"
 gem "omniauth-oauth2", "~> 1.8"
 gem "omniauth-rails_csrf_protection"
 gem "pg", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    okcomputer (1.18.4)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -420,6 +421,7 @@ DEPENDENCIES
   govuk_markdown
   jsbundling-rails
   mail-notify
+  okcomputer
   omniauth-oauth2 (~> 1.8)
   omniauth-rails_csrf_protection
   pg (~> 1.4)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,10 @@
+require_relative "../../lib/ok_computer_checks/notify_check"
+
+OkComputer.logger = Rails.logger
+OkComputer.mount_at = "health"
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "version", OkComputer::AppVersionCheck.new
+OkComputer::Registry.register "notify", OkComputerChecks::NotifyCheck.new
+
+OkComputer.make_optional %w[version]

--- a/lib/ok_computer_checks/notify_check.rb
+++ b/lib/ok_computer_checks/notify_check.rb
@@ -1,0 +1,21 @@
+module OkComputerChecks
+  class NotifyCheck < OkComputer::Check
+    TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk".freeze
+
+    def check
+      client = Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
+      client.send_email(
+        email_address: TEST_EMAIL,
+        personalisation: {
+          body: "Test",
+          subject: "Test"
+        },
+        template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE
+      )
+      mark_message "Notify is connected"
+    rescue StandardError => e
+      mark_failure
+      mark_message e.message
+    end
+  end
+end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Health check", type: :request do
+  describe "GET /health" do
+    it "responds successfully" do
+      get "/health"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/all" do
+    before do
+      allow(Notifications::Client).to receive(:new).and_return(
+        double(:client, send_email: true)
+      )
+    end
+
+    it "responds successfully" do
+      get "/health/all"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/postgresql" do
+    it "responds successfully" do
+      get "/health/postgresql"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/version" do
+    it "responds successfully" do
+      get "/health/version"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  it "checks Notify integration health" do
+    allow(Notifications::Client).to receive(:new).and_return(
+      double(:client, send_email: true)
+    )
+    get "/health/notify"
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
We want a way to ping an endpoint for a system status message.

This allows us to automate monitoring of the service status.

OkComputer has been used in other projects (Find and Refer) and this
implementation follows the configuration there.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
