### PR TITLE
Add basic failure handling and debug info to user sign in

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,6 +9,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_identity(auth)
     sign_in @user
     session[:identity_user_token] = auth.credentials.token
+    session[:identity_user_token_expiry] = auth.credentials.expires_at
+    log_auth_credentials_in_development(auth)
     flash[:notice] = "Signed in successfully."
     redirect_to root_path
   end
@@ -17,14 +19,24 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   #   super
   # end
 
-  # def failure
-  #   super
-  # end
+  def failure
+    flash[:warning] = "There was a problem. Please try signing in again"
+    super
+  end
 
-  # protected
+  protected
 
   # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+  def after_omniauth_failure_path_for(_scope)
+    sign_in_path
+  end
+
+  private
+
+  def log_auth_credentials_in_development(auth)
+    if Rails.env.development?
+      Rails.logger.debug auth.credentials.token
+      Rails.logger.debug Time.zone.at auth.credentials.expires_at
+    end
+  end
 end


### PR DESCRIPTION

### Context
This is tangential to the work in https://trello.com/c/mLEDYS6X, but make it easier to retrieve access tokens when manually testing against the Qualifications API.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- If something goes wrong during the Identity auth flow, redirect back to the sign in screen
- Print the auth credentials to the log when in development mode, to help with debugging

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/mLEDYS6X
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
