### PR TITLE
Add adapter class for Qualifications API

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,5 +4,6 @@ HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally
 IDENTITY_CLIENT_ID=override-locally
 IDENTITY_CLIENT_SECRET=override-locally
+QUALIFICATIONS_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test

--- a/.env.test
+++ b/.env.test
@@ -3,5 +3,6 @@ HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally
 IDENTITY_CLIENT_ID=override-locally
 IDENTITY_CLIENT_SECRET=override-locally
+QUALIFICATIONS_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,11 @@ group :test do
   gem "cuprite"
   gem "factory_bot_rails"
   gem "shoulda-matchers"
+  gem "webmock"
 end
 
 group :test, :development do
   gem "rspec"
   gem "rspec-rails"
+  gem "sinatra"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "devise"
 gem "devise_invitable"
+gem "faraday"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "govuk_feature_flags",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     connection_pool (2.3.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
@@ -151,6 +153,7 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    hashdiff (1.0.1)
     hashie (5.0.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
@@ -189,6 +192,8 @@ GEM
     minitest (5.17.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
     net-imap (0.3.4)
       date
       net-protocol
@@ -349,6 +354,11 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
+    sinatra (3.0.5)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.5)
+      tilt (~> 2.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -399,6 +409,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -445,6 +459,7 @@ DEPENDENCIES
   rubocop-govuk
   shoulda-matchers
   sidekiq
+  sinatra
   solargraph
   solargraph-rails
   syntax_tree
@@ -452,6 +467,7 @@ DEPENDENCIES
   syntax_tree-rbs
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ DEPENDENCIES
   devise_invitable
   dotenv-rails
   factory_bot_rails
+  faraday
   govuk-components
   govuk_design_system_formbuilder
   govuk_feature_flags!

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -1,0 +1,31 @@
+module QualificationsApi
+  class Client
+    TIMEOUT_IN_SECONDS = 5
+
+    attr_reader :token
+
+    def initialize(token:)
+      @token = token
+    end
+
+    def teacher
+      response = client.get("v3/teacher")
+      QualificationsApi::Teacher.new response.body
+    end
+
+    def client
+      @client ||=
+        Faraday.new(
+          url: ENV.fetch("QUALIFICATIONS_API_URL"),
+          request: {
+            timeout: TIMEOUT_IN_SECONDS
+          }
+        ) do |faraday|
+          faraday.request :authorization, "Bearer", token
+          faraday.request :json
+          faraday.response :json
+          faraday.adapter Faraday.default_adapter
+        end
+    end
+  end
+end

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -10,7 +10,13 @@ module QualificationsApi
 
     def teacher
       response = client.get("v3/teacher")
-      QualificationsApi::Teacher.new response.body
+
+      case response.status
+      when 200
+        QualificationsApi::Teacher.new response.body
+      when 401
+        raise QualificationsApi::InvalidTokenError
+      end
     end
 
     def client

--- a/app/lib/qualifications_api/invalid_token_error.rb
+++ b/app/lib/qualifications_api/invalid_token_error.rb
@@ -1,0 +1,2 @@
+class QualificationsApi::InvalidTokenError < StandardError
+end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -1,0 +1,25 @@
+module QualificationsApi
+  class Teacher
+    attr_reader :api_data
+
+    def initialize(api_data)
+      @api_data = api_data
+    end
+
+    def trn
+      api_data.fetch("trn")
+    end
+
+    def first_name
+      api_data.fetch("firstName")
+    end
+
+    def last_name
+      api_data.fetch("lastName")
+    end
+
+    def qts_date
+      api_data.fetch("qtsDate")
+    end
+  end
+end

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe QualificationsApi::Client do
+  describe "#teacher" do
+    it "returns details for the currently authenticated teacher" do
+      client = described_class.new(token: "token")
+      response = client.teacher
+
+      expect(response).to be_a(QualificationsApi::Teacher)
+      expect(response.first_name).to eq "Terry"
+    end
+
+    context "with an invalid token" do
+      it "raises an error" do
+        client = described_class.new(token: "invalid-token")
+
+        expect { client.teacher }.to raise_error(
+          QualificationsApi::InvalidTokenError
+        )
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,9 @@ require "rspec/rails"
 require "capybara/rspec"
 require "capybara/cuprite"
 require "sidekiq/testing"
+require "webmock/rspec"
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
@@ -80,4 +83,10 @@ RSpec.configure do |config|
   config.before(:each, type: :system) { driven_by(:cuprite) }
   config.before { Sidekiq::Worker.clear_all }
   config.include ActiveJob::TestHelper
+
+  config.before(:each) do
+    stub_request(:any, /preprod-teacher-qualifications-api/).to_rack(
+      FakeQualificationsApi
+    )
+  end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -1,0 +1,24 @@
+class FakeQualificationsApi < Sinatra::Base
+  get "/v3/teacher" do
+    content_type :json
+
+    case bearer_token
+    when "token"
+      {
+        trn: "3000299",
+        firstName: "Terry",
+        lastName: "Walsh",
+        qtsDate: "2023-02-27"
+      }.to_json
+    when "invalid-token"
+      halt 401
+    end
+  end
+
+  private
+
+  def bearer_token
+    auth_header = request.env.fetch("HTTP_AUTHORIZATION")
+    auth_header.delete_prefix("Bearer ")
+  end
+end


### PR DESCRIPTION
### Context
An initial implementation of an API client, covering just the `/v3/teacher` endpoint in this PR. We'll need this to populate data in the frontend.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
See commits for a detailed summary, but in essence:

- Add an adapter class with a method that hits the teacher endpoint
- Add an API fake to stub out responses in our specs
- Add some basic handling of invalid access tokens within the client 

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/mLEDYS6X
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
