### PR TITLE
Add the UI for qualifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "govuk_feature_flags",
 gem "govuk_markdown"
 gem "jsbundling-rails"
 gem "mail-notify"
+gem "name_of_person"
 gem "okcomputer"
 gem "omniauth-oauth2", "~> 1.8"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
@@ -105,6 +105,7 @@ GEM
       capybara (~> 3.0)
       ferrum (~> 0.13.0)
     date (3.3.3)
+    deep_merge (1.2.2)
     devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -137,15 +138,15 @@ GEM
       websocket-driver (>= 0.6, < 0.8)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    govuk-components (3.3.0)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
-      pagy (~> 5.10.1)
-      view_component (~> 2.74.1)
-    govuk_design_system_formbuilder (3.3.0)
+    govuk-components (4.0.0a2)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (~> 6.0)
+      view_component (~> 3.0.0rc1)
+    govuk_design_system_formbuilder (3.0.2)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
+      deep_merge (~> 1.2.1)
     govuk_markdown (2.0.0)
       activesupport
       redcarpet
@@ -155,7 +156,7 @@ GEM
       tilt
     hashdiff (1.0.1)
     hashie (5.0.0)
-    html-attributes-utils (0.9.2)
+    html-attributes-utils (1.0.0)
       activesupport (>= 6.1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -194,6 +195,8 @@ GEM
     multi_xml (0.6.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    name_of_person (1.1.1)
+      activesupport (>= 5.2.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -229,8 +232,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    pagy (5.10.1)
-      activesupport
+    pagy (6.0.2)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
@@ -283,9 +285,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    rbs (2.8.4)
+    rbs (3.0.2)
     redcarpet (3.6.0)
-    redis-client (0.12.2)
+    redis-client (0.13.0)
       connection_pool
     regexp_parser (2.7.0)
     responders (3.1.0)
@@ -345,7 +347,7 @@ GEM
     rubocop-rspec (2.18.1)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.12.0)
     ruby2_keywords (0.0.5)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
@@ -392,14 +394,14 @@ GEM
       syntax_tree (>= 2.0.1)
     temple (0.10.0)
     thor (1.2.1)
-    tilt (2.0.11)
+    tilt (2.1.0)
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     version_gem (1.1.1)
-    view_component (2.74.1)
-      activesupport (>= 5.0.0, < 8.0)
+    view_component (3.0.0.rc2)
+      activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -444,6 +446,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   mail-notify
+  name_of_person
   okcomputer
   omniauth-oauth2 (~> 1.8)
   omniauth-rails_csrf_protection

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,3 +3,24 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
+
+.app__details-menu {
+  h3 {
+    border-bottom: 2px solid #1d70b8;
+    padding-bottom: 10px;
+  }
+
+  p {
+    font-size: 1rem;
+  }
+}
+
+.app__induction-details {
+  border-top: 1px solid #b1b4b6;
+  margin-bottom: 0;
+  padding-top: 10px;
+}
+
+.app__induction-details-list {
+  font-size: 1rem;
+}

--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -3,6 +3,6 @@
   classes: classes,
   html_attributes: { role: role },
 ) do |notification_banner| %>
-  <% notification_banner.heading(text: heading) %>
+  <% notification_banner.with_heading(text: heading) %>
   <%= body %>
 <% end %>

--- a/app/components/induction_summary_component.html.erb
+++ b/app/components/induction_summary_component.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title"><%= title %></h2>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+    <%= render GovukComponent::DetailsComponent.new(classes: detail_classes, summary_text: "Induction history") do %>
+      <%= render GovukComponent::SummaryListComponent.new(classes: list_classes, rows: history) %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class InductionSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  def detail_classes
+    "app__induction-details"
+  end
+
+  def list_classes
+    "app__induction-details-list"
+  end
+
+  def history
+    [
+      {
+        key: {
+          text: "Appropriate body"
+        },
+        value: {
+          text: "Westminster School"
+        }
+      },
+      {
+        key: {
+          text: "Start date"
+        },
+        value: {
+          text: Date.new(2014, 1, 14).to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "End date"
+        },
+        value: {
+          text: Date.new(2015, 10, 1).to_fs(:long_uk)
+        }
+      },
+      { key: { text: "Number of terms" }, value: { text: 3 } }
+    ]
+  end
+
+  def rows
+    [
+      {
+        key: {
+          text: "Status"
+        },
+        value: {
+          text: qualification.status.to_s.humanize
+        }
+      },
+      {
+        key: {
+          text: "Completed"
+        },
+        value: {
+          text: qualification.completed_at.to_fs(:long_uk)
+        }
+      }
+    ]
+  end
+
+  def title
+    qualification.name
+  end
+end

--- a/app/components/itt_summary_component.html.erb
+++ b/app/components/itt_summary_component.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) %>

--- a/app/components/itt_summary_component.rb
+++ b/app/components/itt_summary_component.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class IttSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  def rows
+    [
+      {
+        key: {
+          text: "Qualification"
+        },
+        value: {
+          text: qualification.qualification_name
+        }
+      },
+      {
+        key: {
+          text: "ITT provider"
+        },
+        value: {
+          text: qualification.provider_name
+        }
+      },
+      {
+        key: {
+          text: "Training type"
+        },
+        value: {
+          text: qualification.training_type
+        }
+      },
+      {
+        key: {
+          text: "Subjects"
+        },
+        value: {
+          text: qualification.subjects.join(", ")
+        }
+      },
+      {
+        key: {
+          text: "Start date"
+        },
+        value: {
+          text: qualification.start_date.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "End date"
+        },
+        value: {
+          text: qualification.end_date.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "Result"
+        },
+        value: {
+          text: qualification.result.to_s.humanize
+        }
+      },
+      { key: { text: "Age range" }, value: { text: qualification.age_range } }
+    ]
+  end
+
+  def title
+    qualification.name
+  end
+end

--- a/app/components/qts_summary_component.html.erb
+++ b/app/components/qts_summary_component.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) %>

--- a/app/components/qts_summary_component.rb
+++ b/app/components/qts_summary_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class QtsSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  def rows
+    [
+      {
+        key: {
+          text: "Awarded"
+        },
+        value: {
+          text: qualification.awarded_at.to_fs(:long_uk)
+        }
+      }
+    ]
+  end
+
+  def title
+    qualification.name
+  end
+end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -1,0 +1,14 @@
+class QualificationsController < ApplicationController
+  def show
+    @user =
+      current_user ||
+        User.new(
+          date_of_birth: Date.new(2000, 1, 1),
+          name: "Jane Smith",
+          trn: "1234567"
+        )
+    @qts = @user.qts
+    @induction = @user.induction
+    @itt = @user.itt
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,18 +7,18 @@ module ApplicationHelper
     govuk_header(service_name: t("service.name")) do |header|
       case current_namespace
       when "support"
-        header.navigation_item(
+        header.with_navigation_item(
           active: current_page?(main_app.support_interface_feature_flags_path),
           href: main_app.support_interface_feature_flags_path,
           text: "Features"
         )
-        header.navigation_item(
+        header.with_navigation_item(
           active: request.path.start_with?("/support/staff"),
           text: "Staff",
           href: main_app.support_interface_staff_index_path
         )
         if current_staff
-          header.navigation_item(
+          header.with_navigation_item(
             href: main_app.staff_sign_out_path,
             text: "Sign out"
           )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,48 @@ class User < ApplicationRecord
     )
     user.tap(&:save!)
   end
+
+  def induction
+    Struct.new(:name, :status, :completed_at).new(
+      "Induction",
+      :pass,
+      Date.new(2015, 11, 1)
+    )
+  end
+
+  def itt
+    Struct.new(
+      :name,
+      :qualification_name,
+      :provider_name,
+      :training_type,
+      :subjects,
+      :start_date,
+      :end_date,
+      :result,
+      :age_range
+    ).new(
+      "Initial teacher training (ITT)",
+      "Postgraduate Certificate in Education (PGCE)",
+      "West London University",
+      "HEI",
+      %w[English Maths],
+      Date.new(2015, 10, 1),
+      Date.new(2018, 6, 23),
+      :pass,
+      "7 to 18 years"
+    )
+  end
+
+  def name
+    ::NameOfPerson::PersonName.full(self[:name])
+  end
+
+  def qts
+    Struct.new(:name, :status, :awarded_at).new(
+      "Qualified teacher status (QTS)",
+      :awarded,
+      Date.new(2014, 9, 1)
+    )
+  end
 end

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl"><%= @user.name.possessive %></span>
+    <h1 class="govuk-heading-xl">Teaching qualifications</h1>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= render InductionSummaryComponent.new(qualification: @induction) if @induction %>
+        <%= render QtsSummaryComponent.new(qualification: @qts) if @qts %>
+        <%= render IttSummaryComponent.new(qualification: @itt) if @itt %>
+      </div>
+
+      <div class="govuk-grid-column-one-third app__details-menu">
+        <h3 class="govuk-heading-m">Your details</h3>
+        <p>
+          Name on certificates<br /> 
+          <strong><%= @user.name.full %></strong>
+        </p>
+
+        <p>
+          Date of birth<br /> 
+          <strong><%= @user.date_of_birth.to_fs(:long_uk) %></strong>  
+        </p>
+
+        <p>
+          Teacher Reference number (TRN)<br /> 
+          <strong><%= @user.trn %></strong>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -10,16 +10,16 @@
   <h2 class="govuk-heading-m"><%= staff.email %></h2>
 
   <%= govuk_summary_list do |summary_list|
-    summary_list.row do |row|
-      row.key { 'Created at' }
-      row.value { staff.created_at.to_s }
+    summary_list.with_row do |row|
+      row.with_key { 'Created at' }
+      row.with_value { staff.created_at.to_s }
     end
 
     if staff.created_by_invite?
-      summary_list.row do |row|
-        row.key { 'Invitation status' }
+      summary_list.with_row do |row|
+        row.with_key { 'Invitation status' }
 
-        row.value do
+        row.with_value do
           if staff.invitation_accepted?
              govuk_tag(text: "Accepted", colour: "green")
           else
@@ -28,15 +28,15 @@
         end
       end
 
-      summary_list.row do |row|
-        row.key { 'Invited at' }
-        row.value { staff.invitation_sent_at.to_s }
+      summary_list.with_row do |row|
+        row.with_key { 'Invited at' }
+        row.with_value { staff.invitation_sent_at.to_s }
       end
     end
 
-    summary_list.row do |row|
-      row.key { 'Last signed in at' }
-      row.value { staff.last_sign_in_at.to_s }
+    summary_list.with_row do |row|
+      row.with_key { 'Last signed in at' }
+      row.with_value { staff.last_sign_in_at.to_s }
     end
   end %>
 <% end %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:long_uk] = "%e %B %Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,11 @@ Rails.application.routes.draw do
                omniauth_callbacks: "users/omniauth_callbacks"
              }
   get "/sign-in", to: "users/sign_in#new"
+
+  devise_scope :user do
+    resource :qualifications, only: [:show]
+  end
+
   get "/accessibility", to: "static#accessibility"
   get "/cookies", to: "static#cookies"
   get "/privacy", to: "static#privacy"

--- a/spec/components/itt_summary_component_spec.rb
+++ b/spec/components/itt_summary_component_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IttSummaryComponent, type: :component do
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,8 @@ FactoryBot.define do
     sequence :email do |n|
       "user_#{n}@example.com"
     end
+    name { "John Smith" }
+    trn { "1234567" }
+    date_of_birth { Date.new(2000, 1, 1) }
   end
 end

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+
+  scenario "when they have qualifications" do
+    given_the_service_is_open
+    and_i_am_signed_in
+
+    when_i_visit_the_qualifications_page
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    then_i_see_my_itt_details
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Pass")
+    expect(page).to have_content("1 November 2015")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Awarded")
+    expect(page).to have_content("1 September 2014")
+  end
+
+  def then_i_see_my_itt_details
+    expect(page).to have_content("Initial teacher training (ITT)")
+    expect(page).to have_content("Postgraduate Certificate in Education (PGCE)")
+    expect(page).to have_content("West London University")
+    expect(page).to have_content("HEI")
+    expect(page).to have_content("English, Maths")
+    expect(page).to have_content("1 October 2015")
+    expect(page).to have_content("23 June 2018")
+    expect(page).to have_content("Pass")
+    expect(page).to have_content("7 to 18 years")
+  end
+end


### PR DESCRIPTION
The prototype has a [design for the qualifications screen](https://qualifications-prototype.herokuapp.com/landing-pages/v2/qualifications).

We want to recreate this in the app.

A lot of the data being displayed isn't present as it will be fetched
from the Qualifications API.

In order to allow us to build the views, I opted to stub out the data
with values from the prototype. The aim would be to replace these with
the data from the API once that connection is setup.

I upgraded the `govuk-components` dependency to the `4.0.0a2` version so
that we have access to the new summary card component.

This requires a few changes elsewhere in the views due to breaking
changes there.

<img width="1076" alt="Screenshot 2023-03-02 at 1 11 40 pm" src="https://user-images.githubusercontent.com/3126/222438358-ec13f477-3a89-4e59-bf0e-50457b2c69fa.png">

### Link to Trello card

https://trello.com/c/JSVZFZ6b/672-add-qualification-list-ui

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
