### PR TITLE
Add /v3/certificates/qts support to API client

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -19,6 +19,17 @@ module QualificationsApi
       end
     end
 
+    def qts_certificate
+      response = client.get("v3/certificates/qts")
+
+      case response.status
+      when 200
+        response.body
+      when 401
+        raise QualificationsApi::InvalidTokenError
+      end
+    end
+
     def client
       @client ||=
         Faraday.new(

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -28,7 +28,7 @@ module Omniauth
 
       extra { { "raw_info" => raw_info } }
 
-      credentials { { token: access_token } }
+      credentials { { token: access_token.token } }
 
       def raw_info
         @raw_info ||= access_token.get("connect/userinfo").parsed

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -20,4 +20,23 @@ RSpec.describe QualificationsApi::Client do
       end
     end
   end
+
+  describe "#qts_certificate" do
+    it "returns a PDF certificate" do
+      client = described_class.new(token: "token")
+      response = client.qts_certificate
+
+      expect(response).to eq "pdf data"
+    end
+
+    context "with an invalid token" do
+      it "raises an error" do
+        client = described_class.new(token: "invalid-token")
+
+        expect { client.teacher }.to raise_error(
+          QualificationsApi::InvalidTokenError
+        )
+      end
+    end
+  end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -15,6 +15,18 @@ class FakeQualificationsApi < Sinatra::Base
     end
   end
 
+  get "/v3/certificates/qts" do
+    content_type "application/pdf"
+    attachment "qts_certificate.pdf"
+
+    case bearer_token
+    when "token"
+      "pdf data"
+    when "invalid-token"
+      halt 401
+    end
+  end
+
   private
 
   def bearer_token


### PR DESCRIPTION
### Context
We need to be able to retrieve QTS certificates. The Qualifications API exposes an endpoint for this.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add a method to the client that GETs the qts certificate endpoint
- Update the API fake so that we can test the basic success and failure scenarios
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
We'll need to iterate on this behaviour, but this presents a starting point for retrieving the data. For example, we may need to handle the case of a user not having QTS (is that scenario possible?). 
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/mLEDYS6X
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
