### PR TITLE
Add basic sign in / sign out flow

### DIFF
--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -1,4 +1,6 @@
 class QualificationsController < ApplicationController
+  before_action :authenticate_user!
+
   def show
     @user =
       current_user ||

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     session[:identity_user_token_expiry] = auth.credentials.expires_at
     log_auth_credentials_in_development(auth)
     flash[:notice] = "Signed in successfully."
-    redirect_to root_path
+    redirect_to qualifications_path
   end
 
   # def passthru

--- a/app/controllers/users/sign_in_controller.rb
+++ b/app/controllers/users/sign_in_controller.rb
@@ -1,4 +1,10 @@
 class Users::SignInController < ApplicationController
+  before_action :redirect_to_qualifications, if: :user_signed_in?
+
   def new
+  end
+
+  def redirect_to_qualifications
+    redirect_to qualifications_path
   end
 end

--- a/app/controllers/users/sign_out_controller.rb
+++ b/app/controllers/users/sign_out_controller.rb
@@ -1,0 +1,5 @@
+class Users::SignOutController < ApplicationController
+  def new
+    sign_out(:user) if user_signed_in?
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,13 @@ module ApplicationHelper
             text: "Sign out"
           )
         end
+      else
+        if current_user
+          header.with_navigation_item(
+            href: main_app.sign_out_path,
+            text: "Sign out"
+          )
+        end
       end
     end
   end

--- a/app/views/users/sign_in/new.html.erb
+++ b/app/views/users/sign_in/new.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-l">Sign in</h1>
-
 <%=
   govuk_button_to(
     "Sign in with Identity",

--- a/app/views/users/sign_out/new.html.erb
+++ b/app/views/users/sign_out/new.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You are now signed out</h1>
+
+    <%= govuk_button_link_to "Back to GOV.UK", root_path  %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
                omniauth_callbacks: "users/omniauth_callbacks"
              }
   get "/sign-in", to: "users/sign_in#new"
+  get "/sign-out", to: "users/sign_out#new"
 
   devise_scope :user do
     resource :qualifications, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
-  root to: "pages#home"
+  root to: "users/sign_in#new"
 
   devise_for :staff,
              controllers: {


### PR DESCRIPTION
### Context

It isn't currently possible to easily access sign in / sign out functionality.

The designs indicate the following:

- The GOV.UK page for this service will take the user straight to Identity, at which point a successful authentication will result in a redirect to the service
- If the user signs out, they see an interstitial page on Identity that prompts them to sign back in.

Neither of these pages exist, and in the case of the former we probably won't ever want to navigate away to gov.uk when in development mode.

As such, in addition to a sign out link in the header, we need some basic screens to:
- start the Identity auth flow
- confirm sign out after the link is clicked
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add rudimentary sign in page
- Redirect to this page when trying to access the quals list unauthenticated
- Redirect to the quals list when trying to access the sign in page authenticated
- Add a sign out link in the header
- Add a sign out confirmation page
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/sQXPHqpW
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
