### PR TITLE
Fetch QTS for the current user

### DIFF
--- a/app/components/qts_summary_component.rb
+++ b/app/components/qts_summary_component.rb
@@ -14,6 +14,19 @@ class QtsSummaryComponent < ViewComponent::Base
         value: {
           text: qualification.awarded_at.to_fs(:long_uk)
         }
+      },
+      {
+        key: {
+          text: "Certificate"
+        },
+        value: {
+          text:
+            link_to(
+              "Download QTS certificate",
+              qts_certificate_path,
+              class: "govuk-link"
+            )
+        }
       }
     ]
   end

--- a/app/controllers/qts_certificates_controller.rb
+++ b/app/controllers/qts_certificates_controller.rb
@@ -1,0 +1,10 @@
+class QtsCertificatesController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    client = QualificationsApi::Client.new(token: session[:identity_user_token])
+    send_data client.qts_certificate,
+              name: "qts_certificate.pdf",
+              content_type: "application/pdf"
+  end
+end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -2,6 +2,18 @@ class QualificationsController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    client = QualificationsApi::Client.new(token: session[:identity_user_token])
+    teacher = client.teacher
+
+    if teacher
+      @qts =
+        Struct.new(:name, :status, :awarded_at).new(
+          "Qualified teacher status (QTS)",
+          teacher.qts_date.present? ? :awarded : :not_awarded,
+          teacher.qts_date
+        )
+    end
+
     @user =
       current_user ||
         User.new(
@@ -9,7 +21,6 @@ class QualificationsController < ApplicationController
           name: "Jane Smith",
           trn: "1234567"
         )
-    @qts = @user.qts
     @induction = @user.induction
     @itt = @user.itt
   end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -19,7 +19,7 @@ module QualificationsApi
     end
 
     def qts_date
-      api_data.fetch("qtsDate")
+      api_data.fetch("qtsDate")&.to_date
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,11 @@ class User < ApplicationRecord
     email = auth_data.info.email
     user = find_or_initialize_by(email:)
     user.assign_attributes(
-      name: auth_data.info.name,
-      given_name: auth_data.info.given_name,
+      date_of_birth: auth_data.info.date_of_birth,
       family_name: auth_data.info.family_name,
-      trn: auth_data.info.trn,
-      date_of_birth: auth_data.info.date_of_birth
+      given_name: auth_data.info.given_name,
+      name: auth_data.info.name,
+      trn: auth_data.info.trn
     )
     user.tap(&:save!)
   end
@@ -48,13 +48,5 @@ class User < ApplicationRecord
 
   def name
     ::NameOfPerson::PersonName.full(self[:name])
-  end
-
-  def qts
-    Struct.new(:name, :status, :awarded_at).new(
-      "Qualified teacher status (QTS)",
-      :awarded,
-      Date.new(2014, 9, 1)
-    )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     resource :qualifications, only: [:show]
+    resource :qts_certificate, only: [:show]
   end
 
   get "/accessibility", to: "static#accessibility"

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -5,8 +5,8 @@ module Omniauth
 
       option :client_options,
              {
-               site: ENV.fetch("IDENTITY_API_DOMAIN"),
                authorize_url: "/connect/authorize",
+               site: ENV.fetch("IDENTITY_API_DOMAIN"),
                token_url: "/connect/token"
              }
       option :pkce, true
@@ -16,13 +16,13 @@ module Omniauth
 
       info do
         {
+          date_of_birth: raw_info["birthdate"],
           email: raw_info["email"].downcase,
           email_verified: parsed_email_verified,
-          name: raw_info["name"],
-          given_name: raw_info["given_name"],
           family_name: raw_info["family_name"],
-          trn: raw_info["trn"],
-          date_of_birth: raw_info["birthdate"]
+          given_name: raw_info["given_name"],
+          name: raw_info["name"],
+          trn: raw_info["trn"]
         }
       end
 

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe QualificationsApi::Teacher, type: :model do
+  describe "#qts_date" do
+    subject(:qts_date) { teacher.qts_date }
+
+    let(:api_data) { { "qtsDate" => "2015-11-01" } }
+    let(:teacher) { described_class.new(api_data) }
+
+    it { is_expected.to eq(Date.new(2015, 11, 1)) }
+
+    context "when the qtsDate is nil" do
+      let(:api_data) { { "qtsDate" => nil } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -3,4 +3,38 @@ module AuthenticationSteps
     @user = create(:user)
     sign_in(@user)
   end
+
+  def and_i_am_signed_in_via_identity
+    given_identity_auth_is_mocked
+    when_i_go_to_the_sign_in_page
+    and_click_the_sign_in_button
+  end
+
+  def given_identity_auth_is_mocked
+    OmniAuth.config.mock_auth[:identity] = OmniAuth::AuthHash.new(
+      {
+        provider: "identity",
+        info: {
+          date_of_birth: "1986-01-02",
+          email: "test@example.com",
+          family_name: "User",
+          given_name: "Test",
+          name: "Test User",
+          trn: "123456"
+        },
+        credentials: {
+          token: "token"
+        }
+      }
+    )
+  end
+  alias_method :and_identity_auth_is_mocked, :given_identity_auth_is_mocked
+
+  def when_i_go_to_the_sign_in_page
+    visit sign_in_path
+  end
+
+  def and_click_the_sign_in_button
+    click_button "Sign in with Identity"
+  end
 end

--- a/spec/system/user_signs_in_via_identity_spec.rb
+++ b/spec/system/user_signs_in_via_identity_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 
 RSpec.feature "Identity auth", type: :system do
   include CommonSteps
+  include AuthenticationSteps
 
   around do |example|
     OmniAuth.config.test_mode = true
@@ -20,33 +21,6 @@ RSpec.feature "Identity auth", type: :system do
   end
 
   private
-
-  def and_identity_auth_is_mocked
-    OmniAuth.config.mock_auth[:identity] = OmniAuth::AuthHash.new(
-      {
-        provider: "identity",
-        info: {
-          email: "test@example.com",
-          name: "Test User",
-          given_name: "Test",
-          family_name: "User",
-          trn: "123456",
-          date_of_birth: "1986-01-02"
-        },
-        credentials: {
-          token: SecureRandom.hex
-        }
-      }
-    )
-  end
-
-  def when_i_go_to_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_click_the_sign_in_button
-    click_button "Sign in with Identity"
-  end
 
   def then_i_am_signed_in_after_successfully_authenticating_with_identity
     expect(page).to have_content "Signed in successfully"

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -2,14 +2,23 @@ require "rails_helper"
 
 RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
+  include AuthenticationSteps
+
+  around do |example|
+    OmniAuth.config.test_mode = true
+    example.run
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:identity] = nil
+  end
 
   scenario "when they have qualifications" do
     given_the_service_is_open
-    and_i_am_signed_in
+    and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
     then_i_see_my_induction_details
     then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
     then_i_see_my_itt_details
   end
 
@@ -28,7 +37,14 @@ RSpec.feature "User views their qualifications", type: :system do
   def then_i_see_my_qts_details
     expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Awarded")
-    expect(page).to have_content("1 September 2014")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["Content-Type"]).to eq("application/pdf")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
   end
 
   def then_i_see_my_itt_details


### PR DESCRIPTION
When a user views their qualifications page, we want to display the
details about their QTS as returned by the API.

This change replaces the mocked data with real data from the API.

Assumptions:

* if the qtsDate attribute is null this means the user doesn't have a
  QTS

### Link to Trello card

https://trello.com/c/JSVZFZ6b/672-add-qualification-list-ui

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="719" alt="Screenshot 2023-03-10 at 11 16 20 am" src="https://user-images.githubusercontent.com/3126/224306998-90f7e259-4232-4011-a0a4-2dd1ee23ff6c.png">

