### PR TITLE
Fetch the ITT data from the API

### DIFF
--- a/app/components/itt_summary_component.rb
+++ b/app/components/itt_summary_component.rb
@@ -28,7 +28,7 @@ class IttSummaryComponent < ViewComponent::Base
           text: "Training type"
         },
         value: {
-          text: qualification.training_type
+          text: qualification.programme_type
         }
       },
       {
@@ -36,7 +36,7 @@ class IttSummaryComponent < ViewComponent::Base
           text: "Subjects"
         },
         value: {
-          text: qualification.subjects.join(", ")
+          text: qualification.subjects.map(&:titleize).join(", ")
         }
       },
       {

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -2,8 +2,14 @@ class QualificationsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    client = QualificationsApi::Client.new(token: session[:identity_user_token])
-    teacher = client.teacher
+    begin
+      client =
+        QualificationsApi::Client.new(token: session[:identity_user_token])
+      teacher = client.teacher
+    rescue QualificationsApi::InvalidTokenError
+      redirect_to sign_out_path
+      return
+    end
 
     if teacher
       @qts =
@@ -12,6 +18,7 @@ class QualificationsController < ApplicationController
           teacher.qts_date.present? ? :awarded : :not_awarded,
           teacher.qts_date
         )
+      @itt = teacher.itt
     end
 
     @user =
@@ -22,6 +29,5 @@ class QualificationsController < ApplicationController
           trn: "1234567"
         )
     @induction = @user.induction
-    @itt = @user.itt
   end
 end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -6,12 +6,37 @@ module QualificationsApi
       @api_data = api_data
     end
 
-    def trn
-      api_data.fetch("trn")
-    end
-
     def first_name
       api_data.fetch("firstName")
+    end
+
+    def itt
+      teaching_training_response = api_data.dig("initialTeacherTraining", 0)
+      return if teaching_training_response.nil?
+
+      Struct.new(
+        :name,
+        :qualification_name,
+        :provider_name,
+        :programme_type,
+        :subjects,
+        :start_date,
+        :end_date,
+        :result,
+        :age_range
+      ).new(
+        "Initial teacher training (ITT)",
+        teaching_training_response.dig("qualification", "name"),
+        teaching_training_response.dig("provider", "name"),
+        teaching_training_response["programmeType"],
+        teaching_training_response["subjects"].map do |subject|
+          subject["name"]
+        end,
+        teaching_training_response["startDate"]&.to_date,
+        teaching_training_response["endDate"]&.to_date,
+        teaching_training_response["result"]&.humanize,
+        teaching_training_response.dig("ageRange", "description")
+      )
     end
 
     def last_name
@@ -20,6 +45,10 @@ module QualificationsApi
 
     def qts_date
       api_data.fetch("qtsDate")&.to_date
+    end
+
+    def trn
+      api_data.fetch("trn")
     end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -15,4 +15,65 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#itt" do
+    subject(:itt) { teacher.itt }
+
+    let(:api_data) do
+      {
+        "initialTeacherTraining" => [
+          {
+            "qualification" => {
+              "name" => "BA"
+            },
+            "startDate" => "2022-02-28",
+            "endDate" => "2023-01-28",
+            "programmeType" => "HEI",
+            "result" => "Pass",
+            "ageRange" => {
+              "description" => "10 to 16 years"
+            },
+            "provider" => {
+              "name" => "Earl Spencer Primary School",
+              "ukprn" => nil
+            },
+            "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+          }
+        ]
+      }
+    end
+    let(:teacher) { described_class.new(api_data) }
+
+    it "returns a qualification name" do
+      expect(itt.qualification_name).to eq("BA")
+    end
+
+    it "returns a provider name" do
+      expect(itt.provider_name).to eq("Earl Spencer Primary School")
+    end
+
+    it "returns a programme type" do
+      expect(itt.programme_type).to eq("HEI")
+    end
+
+    it "returns the subjects" do
+      expect(itt.subjects).to eq(["business studies"])
+    end
+
+    it "returns the start date" do
+      expect(itt.start_date).to eq(Date.new(2022, 2, 28))
+    end
+
+    it "returns the end date" do
+      expect(itt.end_date).to eq(Date.new(2023, 1, 28))
+    end
+
+    it "returns the result" do
+      expect(itt.result).to eq("Pass")
+    end
+
+    it "returns the age range" do
+      expect(itt.age_range).to eq("10 to 16 years")
+    end
+  end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -8,7 +8,26 @@ class FakeQualificationsApi < Sinatra::Base
         trn: "3000299",
         firstName: "Terry",
         lastName: "Walsh",
-        qtsDate: "2023-02-27"
+        qtsDate: "2023-02-27",
+        initialTeacherTraining: [
+          {
+            qualification: {
+              name: "BA"
+            },
+            startDate: "2022-02-28",
+            endDate: "2023-01-28",
+            programmeType: "HEI",
+            result: "Pass",
+            ageRange: {
+              description: "10 to 16 years"
+            },
+            provider: {
+              name: "Earl Spencer Primary School",
+              ukprn: nil
+            },
+            subjects: [{ code: "100079", name: "business studies" }]
+          }
+        ]
       }.to_json
     when "invalid-token"
       halt 401

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -49,13 +49,13 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_itt_details
     expect(page).to have_content("Initial teacher training (ITT)")
-    expect(page).to have_content("Postgraduate Certificate in Education (PGCE)")
-    expect(page).to have_content("West London University")
+    expect(page).to have_content("BA")
+    expect(page).to have_content("Earl Spencer Primary School")
     expect(page).to have_content("HEI")
-    expect(page).to have_content("English, Maths")
-    expect(page).to have_content("1 October 2015")
-    expect(page).to have_content("23 June 2018")
+    expect(page).to have_content("Business Studies")
+    expect(page).to have_content("28 February 2022")
+    expect(page).to have_content("28 January 2023")
     expect(page).to have_content("Pass")
-    expect(page).to have_content("7 to 18 years")
+    expect(page).to have_content("10 to 16 years")
   end
 end


### PR DESCRIPTION
The API now returns the initial teacher training data to be displayed on
the qualifications page.

This change adds support for retrieving the data via the API client and
returns it in the format expected by the UI.

### Link to Trello card

https://trello.com/c/JSVZFZ6b/672-add-qualification-list-ui

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally

<img width="680" alt="Screenshot 2023-03-10 at 12 02 29 pm" src="https://user-images.githubusercontent.com/3126/224311289-3a69771e-ee4a-4c3e-8894-57d54889df61.png">

