### PR TITLE
Fetch name & TRN from DQT API

### DIFF
--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -5,20 +5,20 @@ class QualificationsController < ApplicationController
     begin
       client =
         QualificationsApi::Client.new(token: session[:identity_user_token])
-      teacher = client.teacher
+      @teacher = client.teacher
     rescue QualificationsApi::InvalidTokenError
       redirect_to sign_out_path
       return
     end
 
-    if teacher
+    if @teacher
       @qts =
         Struct.new(:name, :status, :awarded_at).new(
           "Qualified teacher status (QTS)",
-          teacher.qts_date.present? ? :awarded : :not_awarded,
-          teacher.qts_date
+          @teacher.qts_date.present? ? :awarded : :not_awarded,
+          @teacher.qts_date
         )
-      @itt = teacher.itt
+      @itt = @teacher.itt
     end
 
     @user =

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -14,7 +14,7 @@
         <h3 class="govuk-heading-m">Your details</h3>
         <p>
           Name on certificates<br /> 
-          <strong><%= @user.name.full %></strong>
+          <strong><%= [@teacher.first_name, @teacher.last_name].join(" ") %></strong>
         </p>
 
         <p>
@@ -24,7 +24,7 @@
 
         <p>
           Teacher Reference number (TRN)<br /> 
-          <strong><%= @user.trn %></strong>
+          <strong><%= @teacher.trn %></strong>
         </p>
       </div>
     </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,4 +89,11 @@ RSpec.configure do |config|
       FakeQualificationsApi
     )
   end
+
+  config.around(:each, test: :with_stubbed_auth) do |example|
+    OmniAuth.config.test_mode = true
+    example.run
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:identity] = nil
+  end
 end

--- a/spec/system/user_signs_in_via_identity_spec.rb
+++ b/spec/system/user_signs_in_via_identity_spec.rb
@@ -5,14 +5,7 @@ RSpec.feature "Identity auth", type: :system do
   include CommonSteps
   include AuthenticationSteps
 
-  around do |example|
-    OmniAuth.config.test_mode = true
-    example.run
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth[:identity] = nil
-  end
-
-  scenario "User signs in via Identity" do
+  scenario "User signs in via Identity", test: :with_stubbed_auth do
     given_the_service_is_open
     and_identity_auth_is_mocked
     when_i_go_to_the_sign_in_page

--- a/spec/system/user_views_their_details_spec.rb
+++ b/spec/system/user_views_their_details_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "User views their details" do
+  include CommonSteps
+  include AuthenticationSteps
+
+  scenario "The details are retrieved from the API", test: :with_stubbed_auth do
+    given_the_service_is_open
+    and_i_am_signed_in_via_identity
+    then_i_see_my_details_as_returned_by_the_api
+  end
+
+  def then_i_see_my_details_as_returned_by_the_api
+    expect(page).to have_content("Terry Walsh")
+    expect(page).to have_content("3000299")
+  end
+end

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -4,14 +4,7 @@ RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
   include AuthenticationSteps
 
-  around do |example|
-    OmniAuth.config.test_mode = true
-    example.run
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth[:identity] = nil
-  end
-
-  scenario "when they have qualifications" do
+  scenario "when they have qualifications", test: :with_stubbed_auth do
     given_the_service_is_open
     and_i_am_signed_in_via_identity
 


### PR DESCRIPTION
The user details that get returned in the authentication process aren't
guaranteed to match those stored in DQT.

We want to display the DQT data in this service.

### Link to Trello card

https://trello.com/c/fMyKdIKv/761-use-quals-api-to-populate-your-details

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
