### PR TITLE
Display a landing page to view user details

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -24,3 +24,30 @@ $govuk-assets-path: "/";
 .app__induction-details-list {
   font-size: 1rem;
 }
+
+.app-panel--interruption {
+  background-color: #1d70b8;
+  text-align: left;
+
+  p {
+    color: #fff;
+    margin-bottom: govuk-spacing(6);
+  }
+}
+
+.app-button--inverse,
+.app-button--inverse:link,
+.app-button--inverse:visited {
+  background-color: #ffffff;
+  box-shadow: 0 2px 0 #144e81;
+  color: #1d70b8;
+}
+
+.app-button--inverse:hover {
+  background-color: #e8f1f8;
+  color: #1d70b8;
+}
+
+.app__two-thirds {
+  width: 66.66%;
+}

--- a/app/controllers/identity_users_controller.rb
+++ b/app/controllers/identity_users_controller.rb
@@ -1,0 +1,6 @@
+class IdentityUsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,11 @@ module ApplicationHelper
       else
         if current_user
           header.with_navigation_item(
+            active: current_page?(main_app.identity_user_path),
+            href: main_app.identity_user_path,
+            text: "Account"
+          )
+          header.with_navigation_item(
             href: main_app.sign_out_path,
             text: "Sign out"
           )

--- a/app/views/identity_users/show.html.erb
+++ b/app/views/identity_users/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :back_link_url, root_path %>
+
+<%= govuk_panel(title_text: "DfE Identity account", classes: "app-panel--interruption") do %>
+  <div class="app__two-thirds">
+    <p>
+      You can change sign in and personal details in your DfE Identity account.
+    </p>
+    <p>
+      You use your DfE Identity account to sign in to <b>'Access your teaching qualifications'</b>.
+    </p>
+
+    <%= govuk_button_to "Access your DfE Identity account", "#", class: "app-button--inverse govuk-!-margin-bottom-0", method: :get %>
+  </div>
+<% end %>

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -26,6 +26,8 @@
           Teacher Reference number (TRN)<br /> 
           <strong><%= @user.trn %></strong>
         </p>
+
+        <%= govuk_link_to "View and update details", identity_user_path %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   get "/sign-out", to: "users/sign_out#new"
 
   devise_scope :user do
+    resource :identity_user, only: [:show]
     resource :qualifications, only: [:show]
     resource :qts_certificate, only: [:show]
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,4 +89,11 @@ RSpec.configure do |config|
       FakeQualificationsApi
     )
   end
+
+  config.around(:each, test: :with_stubbed_auth) do |example|
+    OmniAuth.config.test_mode = true
+    example.run
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:identity] = nil
+  end
 end

--- a/spec/system/user_views_and_updates_their_details_spec.rb
+++ b/spec/system/user_views_and_updates_their_details_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.feature "User views and updates their details" do
+  include CommonSteps
+  include AuthenticationSteps
+
+  scenario "User updates their details", test: :with_stubbed_auth do
+    given_the_service_is_open
+    and_i_am_signed_in_via_identity
+    when_i_visit_view_and_update_details
+    then_i_see_the_landing_page
+  end
+
+  private
+
+  def when_i_visit_view_and_update_details
+    click_link "View and update details"
+  end
+
+  def then_i_see_the_landing_page
+    expect(page).to have_text("DfE Identity account")
+    expect(page).to have_button("Access your DfE Identity account")
+  end
+end


### PR DESCRIPTION
The user details screen is managed by Identity. The designs call for a
landing page to make this clear.

As the destination page on Identity is not ready yet, this change
implements the screen but leaves the link as `#`.

We will update the link href when it is available.

### Link to Trello card

https://trello.com/c/aGIBNiMF/796-add-landing-page-for-view-and-update-details

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1034" alt="Screenshot 2023-03-13 at 12 04 01 pm" src="https://user-images.githubusercontent.com/3126/224696616-85553d7f-e744-49fd-b1bf-4c110c397669.png">
