### PR TITLE
Use the updated service name everywhere

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-- @DFE-Digital/access-your-teaching-certificates
-  /.github/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-certificates
-  /terraform/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-certificates
-  Makefile @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-certificates
+- @DFE-Digital/access-your-teaching-qualifications
+  /.github/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-qualifications
+  /terraform/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-qualifications
+  Makefile @DFE-Digital/teacher-services-infrastructure @DFE-Digital/access-your-teaching-qualifications

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Access your teaching certificates
+# Access your teaching qualifications
 
-A service that allows people to access their teaching certificates.
+A service that allows people to access their teaching qualifications.
 
 ## Dependencies
 
@@ -12,7 +12,7 @@ A service that allows people to access their teaching certificates.
 
 ## How the application works
 
-Access your teaching certificates is a monolithic Rails app built with the GOVUK Design System.
+Access your teaching qualifications is a monolithic Rails app built with the GOVUK Design System.
 
 The application has a number of different interfaces for different types of users:
 

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -21,13 +21,7 @@ class QualificationsController < ApplicationController
       @itt = @teacher.itt
     end
 
-    @user =
-      current_user ||
-        User.new(
-          date_of_birth: Date.new(2000, 1, 1),
-          name: "Jane Smith",
-          trn: "1234567"
-        )
+    @user = current_user
     @induction = @user.induction
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,30 +22,6 @@ class User < ApplicationRecord
     )
   end
 
-  def itt
-    Struct.new(
-      :name,
-      :qualification_name,
-      :provider_name,
-      :training_type,
-      :subjects,
-      :start_date,
-      :end_date,
-      :result,
-      :age_range
-    ).new(
-      "Initial teacher training (ITT)",
-      "Postgraduate Certificate in Education (PGCE)",
-      "West London University",
-      "HEI",
-      %w[English Maths],
-      Date.new(2015, 10, 1),
-      Date.new(2018, 6, 23),
-      :pass,
-      "7 to 18 years"
-    )
-  end
-
   def name
     ::NameOfPerson::PersonName.full(self[:name])
   end

--- a/app/views/static/privacy.md
+++ b/app/views/static/privacy.md
@@ -8,7 +8,7 @@ The <%= t('service.name') %> service is run by the [Teaching Regulation Agency
 (TRA)](https://www.gov.uk/government/organisations/teaching-regulation-agency/about),
 an executive agency of the Department for Education (DfE).
 
-Our service allows anyone to access their teaching certificates.
+Our service allows anyone to access their teaching qualifications.
 
 For the purpose of data protection legislation, DfE is the data controller for
 the data we hold and process.

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module AccessYourTeachingCertificates
+module AccessYourTeachingQualifications
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
@@ -40,7 +40,7 @@ module AccessYourTeachingCertificates
         ENV.fetch("GOVUK_NOTIFY_API_KEY") do
           raise "'GOVUK_NOTIFY_API_KEY' should be configured in " \
                   ".env.*environment* file. Please refer to " \
-                  "https://github.com/DFE-Digital/refer-serious-misconduct/#notify"
+                  "https://github.com/DFE-Digital/access-your-teaching-qualifications/#notify"
         end
     }
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: access_your_teaching_certificates_production
+  channel_prefix: access_your_teaching_qualifications_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "access_your_teaching_certificates_production"
+  # config.active_job.queue_name_prefix = "access_your_teaching_qualifications_production"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,9 @@
 en:
   service:
-    name: Access your teaching certificates
+    name: Access your teaching qualifications
     email: my-service@email
     feedback_form: https://forms.gle/mroZH7aVYGPrB37G6
-    url: https://access-your-teaching-certificates.digital.education.gov.uk
+    url: https://access-your-teaching-qualifications.digital.education.gov.uk
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com


### PR DESCRIPTION
After completing some of the initial project setup tasks, the service
was renamed.

We want to ensure that we refer to the updated service name in our code
to avoid any confusion in the future.

### Link to Trello card

https://trello.com/c/k5ce5hpb/799-rename-remaining-references-to-access-your-teaching-certificates

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
