### PR TITLE
Update handling of QTS data

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -44,7 +44,7 @@ module QualificationsApi
     end
 
     def qts_date
-      api_data.fetch("qtsDate")&.to_date
+      api_data.dig("qts", "awarded")&.to_date
     end
 
     def trn

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
   describe "#qts_date" do
     subject(:qts_date) { teacher.qts_date }
 
-    let(:api_data) { { "qtsDate" => "2015-11-01" } }
+    let(:api_data) { { "qts" => { "awarded" => "2015-11-01" } } }
     let(:teacher) { described_class.new(api_data) }
 
     it { is_expected.to eq(Date.new(2015, 11, 1)) }
 
-    context "when the qtsDate is nil" do
-      let(:api_data) { { "qtsDate" => nil } }
+    context "when the qts awarded date is nil" do
+      let(:api_data) { { "qts" => { "awarded" => nil } } }
 
       it { is_expected.to be_nil }
     end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -8,7 +8,9 @@ class FakeQualificationsApi < Sinatra::Base
         trn: "3000299",
         firstName: "Terry",
         lastName: "Walsh",
-        qtsDate: "2023-02-27",
+        qts: {
+          awarded: "2023-02-27"
+        },
         initialTeacherTraining: [
           {
             qualification: {


### PR DESCRIPTION

### Context
The shape of this data in the Qualifications API /v3/teacher endpoint has changed. 
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Update our API client to match.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
The quals page should correctly display the QTS awarded date.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/kxIPilVa/808-update-retrieval-of-qts-data
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
