### PR TITLE
Display the EYTS qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A service that allows people to access their teaching qualifications.
 
 ### Links and application names
 
-| Name       | URL                                                          |
-| ---------- | ------------------------------------------------------------ |
-| Production | not deployed         |
+| Name       | URL          |
+| ---------- | ------------ |
+| Production | not deployed |
 | Preprod    | not deployed |
-| Test       | not deployed    |
+| Test       | not deployed |
 | Dev        | in testing   |
 
 All environments have continuous deployment, the state of which can be inspected in Github Actions.
@@ -23,7 +23,6 @@ All environments have continuous deployment, the state of which can be inspected
 | Preprod    | For internal use by DfE to test deploys       |
 | Test       | For external use by 3rd parties to run audits |
 | Dev        | For internal use by DfE for testing           |
-
 
 ## Dependencies
 

--- a/app/components/eyts_summary_component.html.erb
+++ b/app/components/eyts_summary_component.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) %>

--- a/app/components/eyts_summary_component.rb
+++ b/app/components/eyts_summary_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class EytsSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  def rows
+    [
+      {
+        key: {
+          text: "Awarded"
+        },
+        value: {
+          text: qualification.awarded_at.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "Certificate"
+        },
+        value: {
+          text:
+            link_to(
+              "Download EYTS certificate",
+              eyts_certificate_path,
+              class: "govuk-link"
+            )
+        }
+      }
+    ]
+  end
+
+  def title
+    qualification.name
+  end
+end

--- a/app/controllers/eyts_certificates_controller.rb
+++ b/app/controllers/eyts_certificates_controller.rb
@@ -1,0 +1,8 @@
+class EytsCertificatesController < QualificationsInterfaceController
+  def show
+    client = QualificationsApi::Client.new(token: session[:identity_user_token])
+    send_data client.eyts_certificate,
+              name: "eyts_certificate.pdf",
+              content_type: "application/pdf"
+  end
+end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -17,6 +17,11 @@ class QualificationsController < QualificationsInterfaceController
           @teacher.qts_date
         )
       @itt = @teacher.itt
+      @eyts =
+        Struct.new(:name, :awarded_at).new(
+          "Early years teacher status (EYTS)",
+          @teacher.eyts_date
+        ) if @teacher.eyts_date.present?
     end
 
     @user = current_user

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -8,6 +8,17 @@ module QualificationsApi
       @token = token
     end
 
+    def eyts_certificate
+      response = client.get("v3/certificates/eyts")
+
+      case response.status
+      when 200
+        response.body
+      when 401
+        raise QualificationsApi::InvalidTokenError
+      end
+    end
+
     def teacher
       response = client.get("v3/teacher")
 

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -6,6 +6,10 @@ module QualificationsApi
       @api_data = api_data
     end
 
+    def eyts_date
+      api_data.dig("eyts", "awarded")&.to_date
+    end
+
     def first_name
       api_data.fetch("firstName")
     end

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -8,6 +8,7 @@
         <%= render InductionSummaryComponent.new(qualification: @induction) if @induction %>
         <%= render QtsSummaryComponent.new(qualification: @qts) if @qts %>
         <%= render IttSummaryComponent.new(qualification: @itt) if @itt %>
+        <%= render EytsSummaryComponent.new(qualification: @eyts) if @eyts %>
       </div>
 
       <div class="govuk-grid-column-one-third app__details-menu">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   get "/sign-out", to: "users/sign_out#new"
 
   devise_scope :user do
+    resource :eyts_certificate, only: [:show]
     resource :identity_user, only: [:show]
     resource :qualifications, only: [:show]
     resource :qts_certificate, only: [:show]

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -76,4 +76,20 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       expect(itt.age_range).to eq("10 to 16 years")
     end
   end
+
+  describe "#eyts_date" do
+    subject { teacher.eyts_date }
+
+    let(:api_data) do
+      {
+        "eyts" => {
+          "awarded" => "2015-11-01",
+          "certificateUrl" => "https://example.com/certificate.pdf"
+        }
+      }
+    end
+    let(:teacher) { described_class.new(api_data) }
+
+    it { is_expected.to eq(Date.new(2015, 11, 1)) }
+  end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -8,6 +8,10 @@ class FakeQualificationsApi < Sinatra::Base
         trn: "3000299",
         firstName: "Terry",
         lastName: "Walsh",
+        eyts: {
+          awarded: "2022-04-01",
+          certificateUrl: "http://example.com/eyts-certificate.pdf"
+        },
         qts: {
           awarded: "2023-02-27"
         },
@@ -39,6 +43,18 @@ class FakeQualificationsApi < Sinatra::Base
   get "/v3/certificates/qts" do
     content_type "application/pdf"
     attachment "qts_certificate.pdf"
+
+    case bearer_token
+    when "token"
+      "pdf data"
+    when "invalid-token"
+      halt 401
+    end
+  end
+
+  get "/v3/certificates/eyts" do
+    content_type "application/pdf"
+    attachment "eyts_certificate.pdf"
 
     case bearer_token
     when "token"

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature "User views their qualifications", type: :system do
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
     then_i_see_my_itt_details
+    then_i_see_my_eyts_details
+    and_my_eyts_certificate_is_downloadable
   end
 
   private
@@ -34,8 +36,21 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Download QTS certificate")
   end
 
+  def then_i_see_my_eyts_details
+    expect(page).to have_content("Early years teacher status (EYTS)")
+    expect(page).to have_content("Awarded")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download EYTS certificate")
+  end
+
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    expect(page.response_headers["Content-Type"]).to eq("application/pdf")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
+  end
+
+  def and_my_eyts_certificate_is_downloadable
+    click_on "Download EYTS certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
     expect(page.response_headers["Content-Disposition"]).to eq("attachment")
   end


### PR DESCRIPTION
The teacher API returns details for the EYTS qualification so we can
display it in the list.

Assumptions:

* if the eyts date is empty then the qualification is not available to
  display

### Link to Trello card

https://trello.com/c/sTrmzDL2/815-add-eyts-details-from-api-to-qualifications-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="694" alt="Screenshot 2023-03-16 at 11 23 02 am" src="https://user-images.githubusercontent.com/3126/225602830-3b829930-778d-4b06-8f5c-a933522eeabf.png">
