### PR TITLE
Add NPQs to the qualifications list

### DIFF
--- a/app/components/npq_summary_component.html.erb
+++ b/app/components/npq_summary_component.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) %>

--- a/app/components/npq_summary_component.rb
+++ b/app/components/npq_summary_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class NpqSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  def rows
+    [
+      {
+        key: {
+          text: "Awarded"
+        },
+        value: {
+          text: qualification.awarded_at.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "Certificate"
+        },
+        value: {
+          text:
+            link_to(
+              "Download #{qualification.name} certificate",
+              npq_certificate_path(url: qualification.certificate_url),
+              class: "govuk-link"
+            )
+        }
+      }
+    ]
+  end
+
+  def title
+    qualification.name
+  end
+end

--- a/app/controllers/npq_certificates_controller.rb
+++ b/app/controllers/npq_certificates_controller.rb
@@ -1,0 +1,8 @@
+class NpqCertificatesController < QualificationsInterfaceController
+  def show
+    client = QualificationsApi::Client.new(token: session[:identity_user_token])
+    send_data client.npq_certificate(params[:url]),
+              name: "npq_certificate.pdf",
+              content_type: "application/pdf"
+  end
+end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -22,6 +22,7 @@ class QualificationsController < QualificationsInterfaceController
           "Early years teacher status (EYTS)",
           @teacher.eyts_date
         ) if @teacher.eyts_date.present?
+      @npqs = @teacher.npqs
     end
 
     @user = current_user

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -30,6 +30,17 @@ module QualificationsApi
       end
     end
 
+    def npq_certificate(url)
+      response = client.get("v3/certificates/npq/#{url.split("/").last}")
+
+      case response.status
+      when 200
+        response.body
+      when 401
+        raise QualificationsApi::InvalidTokenError
+      end
+    end
+
     def qts_certificate
       response = client.get("v3/certificates/qts")
 

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -47,6 +47,19 @@ module QualificationsApi
       api_data.fetch("lastName")
     end
 
+    def npqs
+      api_data
+        .fetch("npqQualifications", [])
+        .map do |npq|
+          Struct.new(:name, :certificate_url, :type, :awarded_at).new(
+            npq["type"]["name"],
+            npq["certificateUrl"],
+            npq["type"]["code"],
+            npq["awarded"]&.to_date
+          )
+        end
+    end
+
     def qts_date
       api_data.dig("qts", "awarded")&.to_date
     end

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -9,6 +9,9 @@
         <%= render QtsSummaryComponent.new(qualification: @qts) if @qts %>
         <%= render IttSummaryComponent.new(qualification: @itt) if @itt %>
         <%= render EytsSummaryComponent.new(qualification: @eyts) if @eyts %>
+        <% @npqs.each do |npq| %>
+          <%= render NpqSummaryComponent.new(qualification: npq) %>
+        <% end %>
       </div>
 
       <div class="govuk-grid-column-one-third app__details-menu">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     resource :eyts_certificate, only: [:show]
     resource :identity_user, only: [:show]
+    resource :npq_certificate, only: [:show]
     resource :qualifications, only: [:show]
     resource :qts_certificate, only: [:show]
   end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -33,6 +33,16 @@ class FakeQualificationsApi < Sinatra::Base
             },
             subjects: [{ code: "100079", name: "business studies" }]
           }
+        ],
+        npqQualifications: [
+          {
+            awarded: "2023-02-27",
+            certificateUrl: "/v3/certificates/npq/1",
+            type: {
+              code: "NPQH",
+              name: "NPQ headteacher"
+            }
+          }
         ]
       }.to_json
     when "invalid-token"
@@ -55,6 +65,18 @@ class FakeQualificationsApi < Sinatra::Base
   get "/v3/certificates/eyts" do
     content_type "application/pdf"
     attachment "eyts_certificate.pdf"
+
+    case bearer_token
+    when "token"
+      "pdf data"
+    when "invalid-token"
+      halt 401
+    end
+  end
+
+  get "/v3/certificates/npq/:id" do
+    content_type "application/pdf"
+    attachment "npq_certificate.pdf"
 
     case bearer_token
     when "token"

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -15,6 +15,8 @@ RSpec.feature "User views their qualifications", type: :system do
     then_i_see_my_itt_details
     then_i_see_my_eyts_details
     and_my_eyts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
   end
 
   private
@@ -65,5 +67,18 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("28 January 2023")
     expect(page).to have_content("Pass")
     expect(page).to have_content("10 to 16 years")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("NPQ headteacher")
+    expect(page).to have_content("Awarded")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQ headteacher certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQ headteacher certificate"
+    expect(page.response_headers["Content-Type"]).to eq("application/pdf")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
   end
 end


### PR DESCRIPTION
The DQT API now returns all the NPQs associated with the teacher.

We can display this using a similar approach to the other
qualifications.

One difference is the certificates URL. As there can be multiple
certificates, we need to rely on the value returned for the specific NPQ
and pass that to the client as the download link.

### Link to Trello card

https://trello.com/c/THIzW32K/817-add-npq-summaries-from-the-api-to-the-qualifications-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="724" alt="Screenshot 2023-03-17 at 12 25 44 pm" src="https://user-images.githubusercontent.com/3126/225916124-2c17c736-9016-4c1f-b9cd-2a0131be35f8.png">
