### PR TITLE
Add route constraint for AYTQ service

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 GOVUK_NOTIFY_API_KEY=override-locally
+HOSTING_DOMAIN=http://127.0.0.1
 HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally
 IDENTITY_CLIENT_ID=override-locally

--- a/app/models/hosting_environment.rb
+++ b/app/models/hosting_environment.rb
@@ -7,6 +7,10 @@ module HostingEnvironment
     ENV.fetch("HOSTING_DOMAIN")
   end
 
+  def self.aytq_domain
+    host
+  end
+
   def self.environment_name
     ENV.fetch("HOSTING_ENVIRONMENT_NAME", "unknown-environment")
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 require "sidekiq/web"
+require "route_constraints/access_your_teaching_qualifications_constraint"
 
 Rails.application.routes.draw do
-  root to: "users/sign_in#new"
-
   devise_for :staff,
              controllers: {
                confirmations: "staff/confirmations",
@@ -28,21 +27,7 @@ Rails.application.routes.draw do
     mount FeatureFlags::Engine => "/features"
   end
 
-  devise_for :users,
-             controllers: {
-               omniauth_callbacks: "users/omniauth_callbacks"
-             }
-  get "/sign-in", to: "users/sign_in#new"
-  get "/sign-out", to: "users/sign_out#new"
-
-  devise_scope :user do
-    resources :certificates, only: [:show]
-    resource :identity_user, only: [:show]
-    resource :npq_certificate, only: [:show]
-    resource :qualifications, only: [:show]
-  end
-
-  get "/accessibility", to: "static#accessibility"
-  get "/cookies", to: "static#cookies"
-  get "/privacy", to: "static#privacy"
+  constraints(
+    RouteConstraints::AccessYourTeachingQualificationsConstraint.new
+  ) { draw(:aytq) }
 end

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+root to: "users/sign_in#new"
+
+devise_for :users,
+           controllers: {
+             omniauth_callbacks: "users/omniauth_callbacks"
+           }
+get "/sign-in", to: "users/sign_in#new"
+get "/sign-out", to: "users/sign_out#new"
+
+devise_scope :user do
+  resources :certificates, only: [:show]
+  resource :identity_user, only: [:show]
+  resource :npq_certificate, only: [:show]
+  resource :qualifications, only: [:show]
+end
+
+get "/accessibility", to: "static#accessibility"
+get "/cookies", to: "static#cookies"
+get "/privacy", to: "static#privacy"

--- a/lib/route_constraints/access_your_teaching_qualifications_constraint.rb
+++ b/lib/route_constraints/access_your_teaching_qualifications_constraint.rb
@@ -1,0 +1,8 @@
+module RouteConstraints
+  class AccessYourTeachingQualificationsConstraint
+    def matches?(request)
+      request.host.in?(HostingEnvironment.aytq_domain) ||
+        request.host.include?("aytq-review-pr")
+    end
+  end
+end


### PR DESCRIPTION




### Context
We're planning to build a Check teacher records service. We've decided to implement it as part of this repo.
Following a pattern established by DFE-Digital/publish-teacher-training, we can use route constraints to ensure routes for a given service are only accessible via requests to the appropriate hostname. This allows the two services to live at different URLs and use the same codebase without any conflicts.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
In this commit:

- Introduce the route constraint for AYTQ
- Move AYTQ routes into their own file, and apply the constraint
- Assume for now that support / staff routes will be shared between the two services
- Add HOSTING_DOMAIN to .env.test so that system specs pass

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
The system specs passing is a pretty clear indicator that routes are accessible as expected. Manually altering the value of `HostingEnvironment.aytq_domain` will render them inaccessible.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/c6MZPvFp
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
