### PR TITLE
Fetch Induction data from the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,14 @@ inherit_mode:
   merge:
     - Exclude
 
+Style/BlockDelimiters:
+  Exclude:
+    - app/components/induction_summary_component.rb
+
+Style/MethodCalledOnDoEndBlock:
+  Exclude:
+    - app/components/induction_summary_component.rb
+
 Style/NumericLiterals:
   Exclude:
     - db/schema.rb

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -5,6 +5,8 @@ class InductionSummaryComponent < ViewComponent::Base
 
   attr_accessor :qualification
 
+  delegate :awarded_at, :details, :name, to: :qualification
+
   def detail_classes
     "app__induction-details"
   end
@@ -14,22 +16,47 @@ class InductionSummaryComponent < ViewComponent::Base
   end
 
   def history
-    [
-      { key: { text: "Appropriate body" }, value: { text: "Westminster School" } },
-      { key: { text: "Start date" }, value: { text: Date.new(2014, 1, 14).to_fs(:long_uk) } },
-      { key: { text: "End date" }, value: { text: Date.new(2015, 10, 1).to_fs(:long_uk) } },
-      { key: { text: "Number of terms" }, value: { text: 3 } }
-    ]
+    details
+      .periods
+      .map do |period|
+        [
+          { key: { text: "Appropriate body" }, value: { text: period.appropriate_body.name } },
+          {
+            key: {
+              text: "Start date"
+            },
+            value: {
+              text: period.start_date.to_date.to_fs(:long_uk)
+            }
+          },
+          { key: { text: "End date" }, value: { text: period.end_date.to_date.to_fs(:long_uk) } },
+          { key: { text: "Number of terms" }, value: { text: period.terms } }
+        ]
+      end
+      .flatten
   end
 
   def rows
     [
-      { key: { text: "Status" }, value: { text: qualification.status.to_s.humanize } },
-      { key: { text: "Completed" }, value: { text: qualification.completed_at.to_fs(:long_uk) } }
+      { key: { text: "Status" }, value: { text: details.status.to_s.humanize } },
+      { key: { text: "Completed" }, value: { text: awarded_at.to_fs(:long_uk) } },
+      {
+        key: {
+          text: "Certificate"
+        },
+        value: {
+          text:
+            link_to(
+              "Download Induction certificate",
+              certificate_path(:induction),
+              class: "govuk-link"
+            )
+        }
+      }
     ]
   end
 
   def title
-    qualification.name
+    name
   end
 end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -9,6 +9,5 @@ class QualificationsController < QualificationsInterfaceController
     end
 
     @user = current_user
-    @induction = @user.induction
   end
 end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -51,6 +51,15 @@ module QualificationsApi
           )
         end
 
+      if api_data.induction&.end_date&.present?
+        @qualifications << Qualification.new(
+          awarded_at: api_data.induction.end_date.to_date,
+          details: api_data.induction,
+          name: "Induction",
+          type: :induction
+        )
+      end
+
       @qualifications.flatten!.sort_by!(&:awarded_at).reverse!
     end
   end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -14,6 +14,10 @@ class Qualification
     @certificate_url&.split("/")&.last
   end
 
+  def induction?
+    type == :induction
+  end
+
   def itt?
     type == :itt
   end

--- a/app/views/qualifications/show.html.erb
+++ b/app/views/qualifications/show.html.erb
@@ -6,10 +6,12 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <% @teacher.qualifications.each do |qualification| %>
-          <%= render QualificationSummaryComponent.new(qualification:) %>
+          <% if qualification.induction? %>
+            <%= render InductionSummaryComponent.new(qualification:) %>
+          <% else %>
+            <%= render QualificationSummaryComponent.new(qualification:) %>
+          <% end %>
         <% end %>
-
-        <%= render InductionSummaryComponent.new(qualification: @induction) if @induction %>
       </div>
 
       <div class="govuk-grid-column-one-third app__details-menu">

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     let(:api_data) do
       {
+        "induction" => {
+          "startDate" => "2015-01-01",
+          "endDate" => "2015-07-01",
+          "status" => "complete",
+          "certificateUrl" => "https",
+          "periods" => [
+            {
+              "startDate" => "string",
+              "endDate" => "string",
+              "terms" => "integer",
+              "appropriateBody" => {
+                "name" => "string"
+              }
+            }
+          ]
+        },
         "initialTeacherTraining" => [
           {
             "qualification" => {
@@ -55,7 +71,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     let(:teacher) { described_class.new(api_data) }
 
     it "sorts the qualifications in reverse chronological order by date of award" do
-      expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts itt])
+      expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts induction itt])
     end
   end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe Qualification, type: :model do
     end
   end
 
+  describe "#induction?" do
+    subject { qualification.induction? }
+
+    let(:qualification) { described_class.new(type:) }
+    let(:type) { :qts }
+
+    it { is_expected.to be_falsey }
+
+    context "when the qualification type is induction" do
+      let(:type) { :induction }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe "#itt?" do
     subject { qualification.itt? }
 

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -15,6 +15,22 @@ class FakeQualificationsApi < Sinatra::Base
         qts: {
           awarded: "2023-02-27"
         },
+        induction: {
+          startDate: "2022-09-01",
+          endDate: "2022-10-01",
+          status: "pass",
+          certificateUrl: "string",
+          periods: [
+            {
+              startDate: "2022-09-01",
+              endDate: "2022-10-01",
+              terms: 1,
+              appropriateBody: {
+                name: "Induction body"
+              }
+            }
+          ]
+        },
         initialTeacherTraining: [
           {
             ageRange: {

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -28,7 +28,12 @@ RSpec.feature "User views their qualifications", type: :system do
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
     expect(page).to have_content("Pass")
-    expect(page).to have_content("1 November 2015")
+    expect(page).to have_content("1 October 2022")
+    expect(page).to have_link("Download Induction certificate")
+    find("span", text: "Induction history").click
+    expect(page).to have_content("Induction body")
+    expect(page).to have_content("1 September 2022")
+    expect(page).to have_content("Number of terms\t1")
   end
 
   def then_i_see_my_qts_details


### PR DESCRIPTION
The DQT API now supplies data on the teacher's induction qualification.

This data differs from the other qualifications and due to the way the
GOVUK view components are built, we need to create a custom version of
the summary list component. Allowing us to accommodate the induction
history entries.

### Link to Trello card

https://trello.com/c/EiGFxMOL/824-display-induction-data-from-the-api

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

![capybara-202303221009108915176521](https://user-images.githubusercontent.com/3126/226873214-b18c0675-7936-4450-9104-0fed3db397bb.png)
