### PR TITLE
Adjust prettier lineWidth check from 80 char to 100

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+printWidth: 100

--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -33,9 +33,7 @@ class FlashMessageComponent < ViewComponent::Base
   end
 
   def body
-    if messages.is_a?(Array) && messages.count >= 2
-      tag.p(messages[1], class: "govuk-body")
-    end
+    tag.p(messages[1], class: "govuk-body") if messages.is_a?(Array) && messages.count >= 2
   end
 
   def render?

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -15,52 +15,17 @@ class InductionSummaryComponent < ViewComponent::Base
 
   def history
     [
-      {
-        key: {
-          text: "Appropriate body"
-        },
-        value: {
-          text: "Westminster School"
-        }
-      },
-      {
-        key: {
-          text: "Start date"
-        },
-        value: {
-          text: Date.new(2014, 1, 14).to_fs(:long_uk)
-        }
-      },
-      {
-        key: {
-          text: "End date"
-        },
-        value: {
-          text: Date.new(2015, 10, 1).to_fs(:long_uk)
-        }
-      },
+      { key: { text: "Appropriate body" }, value: { text: "Westminster School" } },
+      { key: { text: "Start date" }, value: { text: Date.new(2014, 1, 14).to_fs(:long_uk) } },
+      { key: { text: "End date" }, value: { text: Date.new(2015, 10, 1).to_fs(:long_uk) } },
       { key: { text: "Number of terms" }, value: { text: 3 } }
     ]
   end
 
   def rows
     [
-      {
-        key: {
-          text: "Status"
-        },
-        value: {
-          text: qualification.status.to_s.humanize
-        }
-      },
-      {
-        key: {
-          text: "Completed"
-        },
-        value: {
-          text: qualification.completed_at.to_fs(:long_uk)
-        }
-      }
+      { key: { text: "Status" }, value: { text: qualification.status.to_s.humanize } },
+      { key: { text: "Completed" }, value: { text: qualification.completed_at.to_fs(:long_uk) } }
     ]
   end
 

--- a/app/components/npq_summary_component.rb
+++ b/app/components/npq_summary_component.rb
@@ -7,14 +7,7 @@ class NpqSummaryComponent < ViewComponent::Base
 
   def rows
     [
-      {
-        key: {
-          text: "Awarded"
-        },
-        value: {
-          text: qualification.awarded_at.to_fs(:long_uk)
-        }
-      },
+      { key: { text: "Awarded" }, value: { text: qualification.awarded_at.to_fs(:long_uk) } },
       {
         key: {
           text: "Certificate"

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -5,14 +5,7 @@ class QualificationSummaryComponent < ViewComponent::Base
 
   attr_accessor :qualification
 
-  delegate :awarded_at,
-           :certificate_type,
-           :details,
-           :id,
-           :itt?,
-           :name,
-           :type,
-           to: :qualification
+  delegate :awarded_at, :certificate_type, :details, :id, :itt?, :name, :type, to: :qualification
 
   alias_method :title, :name
 
@@ -39,64 +32,21 @@ class QualificationSummaryComponent < ViewComponent::Base
 
   def itt_rows
     [
-      {
-        key: {
-          text: "Qualification"
-        },
-        value: {
-          text: details.qualification.name
-        }
-      },
+      { key: { text: "Qualification" }, value: { text: details.qualification.name } },
       { key: { text: "ITT provider" }, value: { text: details.provider.name } },
-      {
-        key: {
-          text: "Training type"
-        },
-        value: {
-          text: details.programme_type
-        }
-      },
+      { key: { text: "Training type" }, value: { text: details.programme_type } },
       {
         key: {
           text: "Subjects"
         },
         value: {
-          text:
-            details.subjects.map { |subject| subject.name.titleize }.join(", ")
+          text: details.subjects.map { |subject| subject.name.titleize }.join(", ")
         }
       },
-      {
-        key: {
-          text: "Start date"
-        },
-        value: {
-          text: details.start_date.to_date.to_fs(:long_uk)
-        }
-      },
-      {
-        key: {
-          text: "End date"
-        },
-        value: {
-          text: details.end_date.to_date.to_fs(:long_uk)
-        }
-      },
-      {
-        key: {
-          text: "Result"
-        },
-        value: {
-          text: details.result.to_s.humanize
-        }
-      },
-      {
-        key: {
-          text: "Age range"
-        },
-        value: {
-          text: details.age_range.description
-        }
-      }
+      { key: { text: "Start date" }, value: { text: details.start_date.to_date.to_fs(:long_uk) } },
+      { key: { text: "End date" }, value: { text: details.end_date.to_date.to_fs(:long_uk) } },
+      { key: { text: "Result" }, value: { text: details.result.to_s.humanize } },
+      { key: { text: "Age range" }, value: { text: details.age_range.description } }
     ]
   end
 end

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,10 +1,7 @@
 class CertificatesController < QualificationsInterfaceController
   def show
     client = QualificationsApi::Client.new(token: session[:identity_user_token])
-    send_data client.certificate(
-                type: params[:id],
-                id: params[:certificate_id]
-              ),
+    send_data client.certificate(type: params[:id], id: params[:certificate_id]),
               name: "#{params[:type]}_certificate.pdf",
               content_type: "application/pdf"
   end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -1,8 +1,7 @@
 class QualificationsController < QualificationsInterfaceController
   def show
     begin
-      client =
-        QualificationsApi::Client.new(token: session[:identity_user_token])
+      client = QualificationsApi::Client.new(token: session[:identity_user_token])
       @teacher = client.teacher
     rescue QualificationsApi::InvalidTokenError
       redirect_to sign_out_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,10 +18,7 @@ module ApplicationHelper
           href: main_app.support_interface_staff_index_path
         )
         if current_staff
-          header.with_navigation_item(
-            href: main_app.staff_sign_out_path,
-            text: "Sign out"
-          )
+          header.with_navigation_item(href: main_app.staff_sign_out_path, text: "Sign out")
         end
       else
         if current_user
@@ -30,10 +27,7 @@ module ApplicationHelper
             href: main_app.identity_user_path,
             text: "Account"
           )
-          header.with_navigation_item(
-            href: main_app.sign_out_path,
-            text: "Sign out"
-          )
+          header.with_navigation_item(href: main_app.sign_out_path, text: "Sign out")
         end
       end
     end

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -27,10 +27,8 @@ class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
 
   private
 
-  SUPPORT_USERNAME =
-    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
-  SUPPORT_PASSWORD =
-    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
+  SUPPORT_USERNAME = Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
+  SUPPORT_PASSWORD = Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
 
   ANONYMOUS_SUPPORT_USER = AnonymousSupportUser.new
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,8 +3,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   GENERIC_NOTIFY_TEMPLATE = "5e1842e6-d806-49ce-ba19-0483a056e367"
 
   def notify_email(headers)
-    headers =
-      headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
+    headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
     view_mail(GENERIC_NOTIFY_TEMPLATE, headers)
   end
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,9 +1,6 @@
 class DeviseMailer < Devise::Mailer
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)
-    view_mail(
-      ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
-      headers_for(action, opts)
-    )
+    view_mail(ApplicationMailer::GENERIC_NOTIFY_TEMPLATE, headers_for(action, opts))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,11 +15,7 @@ class User < ApplicationRecord
   end
 
   def induction
-    Struct.new(:name, :status, :completed_at).new(
-      "Induction",
-      :pass,
-      Date.new(2015, 11, 1)
-    )
+    Struct.new(:name, :status, :completed_at).new("Induction", :pass, Date.new(2015, 11, 1))
   end
 
   def name

--- a/app/validators/valid_for_notify_validator.rb
+++ b/app/validators/valid_for_notify_validator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class ValidForNotifyValidator < ActiveModel::EachValidator
-  NUMBERS_AND_LETTERS =
-    "a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ"
+  NUMBERS_AND_LETTERS = "a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ"
   CHINESE_JAPANESE_AND_KOREAN_CHARS =
     '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'
   ALPHANUMERIC = NUMBERS_AND_LETTERS + CHINESE_JAPANESE_AND_KOREAN_CHARS
@@ -16,9 +15,6 @@ class ValidForNotifyValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless value.blank? || !value.match?(EMAIL_REGEX)
 
-    record.errors.add(
-      attribute,
-      I18n.t("validation_errors.email_address_format")
-    )
+    record.errors.add(attribute, I18n.t("validation_errors.email_address_format"))
   end
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -30,9 +30,7 @@ m =
       ARGV.each_with_index do |a, i|
         bundler_version = a if update_index && update_index.succ == i &&
           a =~ Gem::Version::ANCHORED_VERSION_PATTERN
-        unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-          next
-        end
+        next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
         bundler_version = $1
         update_index = i
       end
@@ -60,8 +58,7 @@ m =
     def lockfile_version
       return unless File.file?(lockfile)
       lockfile_contents = File.read(lockfile)
-      unless lockfile_contents =~
-               /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+      unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
         return
       end
       Regexp.last_match(1)
@@ -69,8 +66,7 @@ m =
 
     def bundler_requirement
       @bundler_requirement ||=
-        env_var_version || cli_arg_version ||
-          bundler_requirement_for(lockfile_version)
+        env_var_version || cli_arg_version || bundler_requirement_for(lockfile_version)
     end
 
     def bundler_requirement_for(version)
@@ -80,9 +76,7 @@ m =
 
       requirement = bundler_gem_version.approximate_recommendation
 
-      unless Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.0")
-        return requirement
-      end
+      return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.0")
 
       requirement += ".a" if bundler_gem_version.prerelease?
 
@@ -96,8 +90,7 @@ m =
     end
 
     def activate_bundler
-      gem_error =
-        activation_error_handling { gem "bundler", bundler_requirement }
+      gem_error = activation_error_handling { gem "bundler", bundler_requirement }
       return if gem_error.nil?
       require_error = activation_error_handling { require "bundler/version" }
       if require_error.nil? &&

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,7 @@ module AccessYourTeachingQualifications
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.assets.paths << Rails.root.join(
-      "node_modules/govuk-frontend/govuk/assets"
-    )
+    config.assets.paths << Rails.root.join("node_modules/govuk-frontend/govuk/assets")
 
     config.action_mailer.notify_settings = {
       api_key:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,9 +24,7 @@ Rails.application.configure do
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
+    config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,9 +18,7 @@ Rails.application.configure do
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
-  }
+  config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.hour.to_i}" }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,9 +17,7 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap and inline scripts
-  config.content_security_policy_nonce_generator = ->(request) do
-    request.session.id.to_s
-  end
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -323,9 +323,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :identity,
-                  ENV.fetch("IDENTITY_CLIENT_ID"),
-                  ENV.fetch("IDENTITY_CLIENT_SECRET")
+  config.omniauth :identity, ENV.fetch("IDENTITY_CLIENT_ID"), ENV.fetch("IDENTITY_CLIENT_SECRET")
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,5 @@ Rails.application.routes.draw do
     mount FeatureFlags::Engine => "/features"
   end
 
-  constraints(
-    RouteConstraints::AccessYourTeachingQualificationsConstraint.new
-  ) { draw(:aytq) }
+  constraints(RouteConstraints::AccessYourTeachingQualificationsConstraint.new) { draw(:aytq) }
 end

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -2,10 +2,7 @@
 
 root to: "users/sign_in#new"
 
-devise_for :users,
-           controllers: {
-             omniauth_callbacks: "users/omniauth_callbacks"
-           }
+devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 get "/sign-in", to: "users/sign_in#new"
 get "/sign-out", to: "users/sign_out#new"
 

--- a/db/migrate/20230220091732_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230220091732_create_active_storage_tables.active_storage.rb
@@ -24,11 +24,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
     create_table :active_storage_attachments, id: primary_key_type do |t|
       t.string :name, null: false
-      t.references :record,
-                   null: false,
-                   polymorphic: true,
-                   index: false,
-                   type: foreign_key_type
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
       t.references :blob, null: false, type: foreign_key_type
 
       if connection.supports_datetime_with_precision?

--- a/lib/route_constraints/access_your_teaching_qualifications_constraint.rb
+++ b/lib/route_constraints/access_your_teaching_qualifications_constraint.rb
@@ -1,8 +1,7 @@
 module RouteConstraints
   class AccessYourTeachingQualificationsConstraint
     def matches?(request)
-      request.host.in?(HostingEnvironment.aytq_domain) ||
-        request.host.include?("aytq-review-pr")
+      request.host.in?(HostingEnvironment.aytq_domain) || request.host.include?("aytq-review-pr")
     end
   end
 end

--- a/public/404.html
+++ b/public/404.html
@@ -61,9 +61,7 @@
         <h1>The page you were looking for doesn't exist.</h1>
         <p>You may have mistyped the address or the page may have moved.</p>
       </div>
-      <p>
-        If you are the application owner check the logs for more information.
-      </p>
+      <p>If you are the application owner check the logs for more information.</p>
     </div>
   </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -61,9 +61,7 @@
         <h1>The change you wanted was rejected.</h1>
         <p>Maybe you tried to change something you didn't have access to.</p>
       </div>
-      <p>
-        If you are the application owner check the logs for more information.
-      </p>
+      <p>If you are the application owner check the logs for more information.</p>
     </div>
   </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -60,9 +60,7 @@
       <div>
         <h1>We're sorry, but something went wrong.</h1>
       </div>
-      <p>
-        If you are the application owner check the logs for more information.
-      </p>
+      <p>If you are the application owner check the logs for more information.</p>
     </div>
   </body>
 </html>

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe QualificationsApi::Client do
       it "raises an error" do
         client = described_class.new(token: "invalid-token")
 
-        expect { client.teacher }.to raise_error(
-          QualificationsApi::InvalidTokenError
-        )
+        expect { client.teacher }.to raise_error(QualificationsApi::InvalidTokenError)
       end
     end
   end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -57,9 +57,7 @@ RSpec.describe StaffHttpBasicAuthStrategy do
     end
 
     context "with valid credentials" do
-      let(:env) do
-        { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
-      end
+      let(:env) { { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" } }
 
       it "is successful" do
         expect(staff_http_basic_auth_strategy).to be_successful

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe User, type: :model do
     end
 
     context "a user exists" do
-      let!(:user) do
-        create(:user, email: "test@example.com", given_name: "Ray")
-      end
+      let!(:user) { create(:user, email: "test@example.com", given_name: "Ray") }
 
       it "updates the user's details" do
         described_class.from_identity(auth_data)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,9 +3,7 @@ require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
-if Rails.env.production?
-  abort("The Rails environment is running in production mode!")
-end
+abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -17,12 +15,7 @@ require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true)
 
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(
-    app,
-    timeout: 10,
-    process_timeout: 30,
-    window_size: [1200, 800]
-  )
+  Capybara::Cuprite::Driver.new(app, timeout: 10, process_timeout: 30, window_size: [1200, 800])
 end
 Capybara.default_driver = :cuprite
 Capybara.javascript_driver = :cuprite
@@ -83,9 +76,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) { driven_by(:cuprite) }
   config.before { Sidekiq::Worker.clear_all }
   config.before(:each) do
-    stub_request(:any, /preprod-teacher-qualifications-api/).to_rack(
-      FakeQualificationsApi
-    )
+    stub_request(:any, /preprod-teacher-qualifications-api/).to_rack(FakeQualificationsApi)
   end
   config.around(:each, test: :with_stubbed_auth) do |example|
     OmniAuth.config.test_mode = true

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe "Health check", type: :request do
 
   describe "GET /health/all" do
     before do
-      allow(Notifications::Client).to receive(:new).and_return(
-        double(:client, send_email: true)
-      )
+      allow(Notifications::Client).to receive(:new).and_return(double(:client, send_email: true))
     end
 
     it "responds successfully" do
@@ -36,9 +34,7 @@ RSpec.describe "Health check", type: :request do
   end
 
   it "checks Notify integration health" do
-    allow(Notifications::Client).to receive(:new).and_return(
-      double(:client, send_email: true)
-    )
+    allow(Notifications::Client).to receive(:new).and_return(double(:client, send_email: true))
     get "/health/notify"
     expect(response).to have_http_status(:ok)
   end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,3 +1,1 @@
-RSpec.configure do |config|
-  config.include Shoulda::Matchers::ActiveModel, type: :model
-end
+RSpec.configure { |config| config.include Shoulda::Matchers::ActiveModel, type: :model }

--- a/spec/system/user_token_expires_while_viewing_qualifications_spec.rb
+++ b/spec/system/user_token_expires_while_viewing_qualifications_spec.rb
@@ -6,8 +6,7 @@ RSpec.feature "Identity auth", type: :system do
 
   after { travel_back }
 
-  scenario "Access token expires while viewing qualifications",
-           test: :with_stubbed_auth do
+  scenario "Access token expires while viewing qualifications", test: :with_stubbed_auth do
     given_the_service_is_open
     and_i_am_signed_in_via_identity
 
@@ -32,8 +31,6 @@ RSpec.feature "Identity auth", type: :system do
   end
 
   def then_i_am_required_to_sign_in_again
-    expect(
-      page
-    ).to have_content "Your session has expired. Please sign in again."
+    expect(page).to have_content "Your session has expired. Please sign in again."
   end
 end


### PR DESCRIPTION

### Context
Opinion — 80 chars is great for commit messages but is a little restrictive in code. Occasionally the formatting enforced by prettier isn't great for readability.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Bump lineWidth to 100 in a .prettierrc.yml
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
👍🏼 / 👎🏼 ?
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
na
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
