### PR TITLE
Display any mandatory qualifications

### DIFF
--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -12,9 +12,10 @@ class QualificationSummaryComponent < ViewComponent::Base
   def rows
     return itt_rows if itt?
 
-    [
-      { key: { text: "Awarded" }, value: { text: awarded_at.to_fs(:long_uk) } },
-      {
+    @rows = [{ key: { text: "Awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }]
+
+    if qualification.certificate_url
+      @rows << {
         key: {
           text: "Certificate"
         },
@@ -27,7 +28,13 @@ class QualificationSummaryComponent < ViewComponent::Base
             )
         }
       }
-    ]
+    end
+
+    if details.specialism
+      @rows << { key: { text: "Specialism" }, value: { text: details.specialism } }
+    end
+
+    @rows
   end
 
   def itt_rows

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -60,6 +60,15 @@ module QualificationsApi
         )
       end
 
+      @qualifications << api_data.mandatory_qualifications.map do |mq|
+        Qualification.new(
+          awarded_at: mq.awarded.to_date,
+          details: mq,
+          name: "Mandatory qualification (MQ): specialist teacher",
+          type: :mandatory
+        )
+      end
+
       @qualifications.flatten!.sort_by!(&:awarded_at).reverse!
     end
   end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,13 +1,17 @@
 class Qualification
   include ActiveModel::Model
 
-  attr_accessor :awarded_at, :details, :name, :type
-  attr_writer :certificate_url
+  attr_accessor :awarded_at, :certificate_url, :name, :type
+  attr_writer :details
 
   def certificate_type
     return :npq if type.downcase.starts_with?("npq")
 
     type
+  end
+
+  def details
+    @details ||= Hashie::Mash.new({})
   end
 
   def id

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
           "awarded" => "2015-11-02",
           "certificateUrl" => "https://example.com/certificate.pdf"
         },
+        "mandatoryQualifications" => [
+          { "awarded" => "2013-06-01", "specialism" => "Visual Impairment" }
+        ],
         "npqQualifications" => [
           {
             "type" => {
@@ -71,7 +74,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     let(:teacher) { described_class.new(api_data) }
 
     it "sorts the qualifications in reverse chronological order by date of award" do
-      expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts induction itt])
+      expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts induction mandatory itt])
     end
   end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -13,7 +13,8 @@ class FakeQualificationsApi < Sinatra::Base
           certificateUrl: "http://example.com/v3/certificates/eyts"
         },
         qts: {
-          awarded: "2023-02-27"
+          awarded: "2023-02-27",
+          certificateUrl: "http://example.com/v3/certificates/qts"
         },
         induction: {
           startDate: "2022-09-01",
@@ -50,6 +51,7 @@ class FakeQualificationsApi < Sinatra::Base
             subjects: [{ code: "100079", name: "business studies" }]
           }
         ],
+        mandatoryQualifications: [{ awarded: "2023-02-28", specialism: "Visual impairment" }],
         npqQualifications: [
           {
             awarded: "2023-02-27",

--- a/spec/system/user_views_their_qualifications_spec.rb
+++ b/spec/system/user_views_their_qualifications_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "User views their qualifications", type: :system do
     and_my_eyts_certificate_is_downloadable
     then_i_see_my_npq_details
     and_my_npq_certificate_is_downloadable
+    then_i_see_my_mq_details
   end
 
   private
@@ -85,5 +86,11 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
     expect(page.response_headers["Content-Disposition"]).to eq("attachment")
+  end
+
+  def then_i_see_my_mq_details
+    expect(page).to have_content("Mandatory qualification (MQ): specialist teacher")
+    expect(page).to have_content("Awarded\t28 February 2023")
+    expect(page).to have_content("Specialism\tVisual impairment")
   end
 end


### PR DESCRIPTION
The DQT API is now providing details of the mandatory qualifications.

We can display these and the one difference is that they don't have an
associated certificate.

I opted to simply extend the existing QualificationSummaryComponent to
handle this edge case. We don't expect any more additions to the API
that we would need to handle.

If this changes in the future, we would consider making separate view
components for different qualifications.

### Link to Trello card

https://trello.com/c/Im1XdrLC/836-display-mq-data-from-the-api

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

![capybara-202303221010155913834314](https://user-images.githubusercontent.com/3126/226872386-b2089230-868f-41d4-92e9-6f2eb6ad23dd.png)
