### PR TITLE
Add separate view layout for Check records service

### DIFF
--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,0 +1,4 @@
+<%=
+  govuk_header(service_name: t("check_records_service.name"), service_url: "/check-records") do |header|
+  end
+%>

--- a/app/components/check_records/navigation_component.rb
+++ b/app/components/check_records/navigation_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class CheckRecords::NavigationComponent < ViewComponent::Base
+end

--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -1,4 +1,5 @@
 module CheckRecords
   class CheckRecordsController < ApplicationController
+    layout "check_records_layout"
   end
 end

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <title><%= [yield(:page_title).presence, t('check_records_service.name')].compact.join(' - ') %></title>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= favicon_link_tag asset_path('images/favicon.ico') %>
+    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+
+    <%= stylesheet_link_tag :main %>
+    <%= javascript_include_tag :application, defer: true %>
+  </head>
+
+  <body class="govuk-template__body">
+    <%= javascript_tag nonce: true do %>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    <% end %>
+
+    <%= govuk_skip_link %>
+
+    <%= render(CheckRecords::NavigationComponent.new) %>
+
+    <div class="govuk-width-container">
+      <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
+        This is a new service – <%= govuk_link_to("your feedback will help us to improve it.", t('service.feedback_form')) %>
+      <% end %>
+      <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
+      <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= render(FlashMessageComponent.new(flash: flash)) %>
+        <%= yield :content %>
+      </main>
+    </div>
+
+    <%= render GovukComponent::FooterComponent.new do |footer| %>
+      <% footer.with_meta do %>
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <h2 class="govuk-heading-m">Get help</h2>
+          <p class="govuk-!-font-size-16">Email: <%= govuk_link_to(t('service.email'), t('service.email'), class: "govuk-footer__link") %><br>You’ll get a response within 3 working days.</p>
+
+          <p class="govuk-!-font-size-16">Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except public holidays)</p>
+          <hr class="govuk-section-break govuk-section-break--l">
+
+          <h2 class="govuk-visually-hidden">Footer links</h2>
+
+          <ul class="govuk-footer__inline-list">
+            <li class="govuk-footer__inline-list-item">
+              <%= govuk_link_to("Accessibility", "/accessibility", class: "govuk-footer__link") %>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <%= govuk_link_to("Cookies", "/cookies", class: "govuk-footer__link") %>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <%= govuk_link_to("Privacy notice", "/privacy", class: "govuk-footer__link") %>
+            </li>
+          </ul>
+
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+          </svg>
+
+          <span class="govuk-footer__licence-description">All content is available under the <%= govuk_link_to("Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", class: "govuk-footer__link") %>, except where otherwise stated</span>
+        </div>
+
+        <div class="govuk-footer__meta-item">
+          <%= footer.copyright %>
+        </div>
+      <% end %>
+    <% end %>
+  </body>
+</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
     email: my-service@email
     feedback_form: https://forms.gle/mroZH7aVYGPrB37G6
     url: https://access-your-teaching-qualifications.digital.education.gov.uk
+  check_records_service:
+    name: Check the record of a teacher in England
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/spec/system/check_records/user_view_check_records_homepage_spec.rb
+++ b/spec/system/check_records/user_view_check_records_homepage_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Check records homepage" do
+  include CommonSteps
+
+  scenario "User views Check records homepage" do
+    given_the_service_is_open
+    when_i_visit_the_check_records_homepage
+    then_i_see_the_check_records_nav
+  end
+
+  private
+
+  def when_i_visit_the_check_records_homepage
+    visit check_records_root_path
+  end
+
+  def then_i_see_the_check_records_nav
+    within("header") { expect(page).to have_content("Check the record of a teacher in England") }
+  end
+end


### PR DESCRIPTION

### Context
We're implementing the Check records service in this repo. We need to make various decisions about how to co-locate views, models, controllers, etc.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Use a separate layout file for the Check records service so that its UI can be iterated on separately from Access your teaching qualifications
- Use this layout in all controllers inheriting from CheckRecords::CheckRecordsController
- Add a component for the Check records navigation

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Navigating between `/` (or any Quals service route) and `/check-records` should demonstrate the distinct headers. 
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/pMVFuDQp
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
