### PR TITLE
Add data migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,5 +94,6 @@ COPY azure/.sshd_config /etc/ssh/sshd_config
 # Open port 2222 for Azure SSH access
 EXPOSE 2222
 
-CMD bundle exec rails db:migrate && \
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
+    bundle exec rails data:migrate:ignore_concurrent_migration_exceptions && \
     bundle exec rails server -b 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.2.1"
 
 gem "bootsnap", require: false
 gem "cssbundling-rails"
+gem "data_migrate"
 gem "devise"
 gem "devise_invitable"
 gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
     cuprite (0.14.3)
       capybara (~> 3.0)
       ferrum (~> 0.13.0)
+    data_migrate (9.0.0)
+      activerecord (>= 6.0)
+      railties (>= 6.0)
     date (3.3.3)
     devise (4.9.0)
       bcrypt (~> 3.0)
@@ -433,6 +436,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   cuprite
+  data_migrate
   devise
   devise_invitable
   dotenv-rails

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define()

--- a/lib/tasks/ignore_concurrent_migration_exceptions.rake
+++ b/lib/tasks/ignore_concurrent_migration_exceptions.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+namespace :db do
+  namespace :migrate do
+    desc "db:migrate but ignores ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end
+
+namespace :data do
+  namespace :migrate do
+    desc "data:migrate but ignores ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["data:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
There are times when we want to migrate data across all environments but
don't want to place these operations in a schema migration.

The `data_migrate` gem provides this functionality.

To use it, run the generator `rails g data_migration name_of_migration`.

This creates a file in `db/data`.

Then run `rails data:migrate` to execute the migration.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
