### PR TITLE
Add console1984 & audits1984

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.1"
 
+gem "audits1984"
 gem "bootsnap", require: false
+gem "console1984"
 gem "cssbundling-rails"
 gem "data_migrate"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,12 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    audits1984 (0.1.2)
+      console1984
+      rinku
+      rouge
+      sassc-rails
+      turbo-rails
     backport (1.2.0)
     bcrypt (3.1.18)
     benchmark (0.2.1)
@@ -94,8 +100,12 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
+    colorize (0.8.1)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
+    console1984 (0.1.26)
+      colorize
+      parser
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -138,6 +148,7 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     govuk-components (4.0.0a2)
@@ -298,7 +309,9 @@ GEM
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
+    rinku (2.0.6)
     rladr (1.2.0)
+    rouge (4.1.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -351,6 +364,14 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.12.0)
     ruby2_keywords (0.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (7.0.7)
@@ -384,6 +405,13 @@ GEM
     solargraph-rails (1.1.0)
       activesupport
       solargraph
+    sprockets (4.2.0)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
     syntax_tree-haml (4.0.3)
@@ -398,6 +426,10 @@ GEM
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
+    turbo-rails (1.4.0)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -432,8 +464,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  audits1984
   bootsnap
   capybara
+  console1984
   cssbundling-rails
   cuprite
   data_migrate

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -4,5 +4,9 @@ module SupportInterface
     layout "support_layout"
 
     before_action :authenticate_staff!
+
+    def find_current_auditor
+      current_staff.presence
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,10 @@ module AccessYourTeachingQualifications
     config.active_job.queue_adapter = :sidekiq
 
     config.active_record.encryption.support_unencrypted_data = true
+    config.audits1984 = {
+      auditor_class: "Staff",
+      base_controller_class: "SupportInterface::SupportInterfaceController"
+    }
+    config.console1984 = { ask_for_username_if_empty: true }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :staff, only: %i[index]
 
     mount FeatureFlags::Engine => "/features"
+    mount Audits1984::Engine => "/console"
   end
 
   constraints(RouteConstraints::AccessYourTeachingQualificationsConstraint.new) { draw(:aytq) }

--- a/db/migrate/20230329090348_create_console1984_tables.console1984.rb
+++ b/db/migrate/20230329090348_create_console1984_tables.console1984.rb
@@ -1,0 +1,37 @@
+# This migration comes from console1984 (originally 20210517203931)
+class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :console1984_sessions do |t|
+      t.text :reason
+      t.references :user, null: false, index: false
+      t.timestamps
+
+      t.index :created_at
+      t.index %i[user_id created_at]
+    end
+
+    create_table :console1984_users do |t|
+      t.string :username, null: false
+      t.timestamps
+
+      t.index [:username]
+    end
+
+    create_table :console1984_commands do |t|
+      t.text :statements
+      t.references :sensitive_access
+      t.references :session, null: false, index: false
+      t.timestamps
+
+      t.index %i[session_id created_at sensitive_access_id],
+              name: "on_session_and_sensitive_chronologically"
+    end
+
+    create_table :console1984_sensitive_accesses do |t|
+      t.text :justification
+      t.references :session, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230329090435_create_auditing_tables.audits1984.rb
+++ b/db/migrate/20230329090435_create_auditing_tables.audits1984.rb
@@ -1,0 +1,13 @@
+# This migration comes from audits1984 (originally 20210810092639)
+class CreateAuditingTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :audits1984_audits do |t|
+      t.integer :status, default: 0, null: false
+      t.text :notes
+      t.references :session, null: false
+      t.references :auditor, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,51 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_090435) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "audits1984_audits", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.text "notes"
+    t.bigint "session_id", null: false
+    t.bigint "auditor_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["auditor_id"], name: "index_audits1984_audits_on_auditor_id"
+    t.index ["session_id"], name: "index_audits1984_audits_on_session_id"
+  end
+
+  create_table "console1984_commands", force: :cascade do |t|
+    t.text "statements"
+    t.bigint "sensitive_access_id"
+    t.bigint "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sensitive_access_id"], name: "index_console1984_commands_on_sensitive_access_id"
+    t.index ["session_id", "created_at", "sensitive_access_id"], name: "on_session_and_sensitive_chronologically"
+  end
+
+  create_table "console1984_sensitive_accesses", force: :cascade do |t|
+    t.text "justification"
+    t.bigint "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_console1984_sensitive_accesses_on_session_id"
+  end
+
+  create_table "console1984_sessions", force: :cascade do |t|
+    t.text "reason"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_console1984_sessions_on_created_at"
+    t.index ["user_id", "created_at"], name: "index_console1984_sessions_on_user_id_and_created_at"
+  end
+
+  create_table "console1984_users", force: :cascade do |t|
+    t.string "username", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["username"], name: "index_console1984_users_on_username"
+  end
+
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 


### PR DESCRIPTION
We have encrypted user PII now and want to protect access to it via the
Rails console.

There are 2 libraries that can help us with this. `console1984` provides
the ability to decrypt and encrypt the data.

`audits1984` provides auditing of these decryption actions along with an
interface to review the logs.

Something to note is that we aren't able to connect the auditing to our
authentication system.

The console asks for details about the person making the decrypt request
along with details of consent to view it. However, this is entirely
reliant on the user providing truthful details here.

This doesn't protect against bad actors.

### Link to Trello card

https://trello.com/c/goRspcE7/853-add-db-encryption

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

Example console session:

<img width="2284" alt="Screenshot 2023-03-29 at 11 08 48 am" src="https://user-images.githubusercontent.com/3126/228503673-cde862ba-b7f4-4b6c-8463-f6c8c922b756.png">
