### PR TITLE
Add a migration to encrypt existing User data

### DIFF
--- a/db/data/20230329102114_encrypt_users.rb
+++ b/db/data/20230329102114_encrypt_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EncryptUsers < ActiveRecord::Migration[7.0]
+  def up
+    User.find_each(&:encrypt)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define()
+DataMigrate::Data.define(version: 20_230_329_102_114)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_27_101401) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_29_090435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_101401) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "feature_flags_features", force: :cascade do |t|


### PR DESCRIPTION
We have enabled DB encryption for User PII fields.

All data that pre-dates this change won't be encrypted.

The data migration will ensure that all existing records are encrypted
moving forward. In a following change we will be able to drop support
for unencrypted data.

### Link to Trello card

https://trello.com/c/goRspcE7/853-add-db-encryption

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
