### PR TITLE
Remove support for unencrypted data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,6 @@ module AccessYourTeachingQualifications
 
     config.active_job.queue_adapter = :sidekiq
 
-    config.active_record.encryption.support_unencrypted_data = true
     config.audits1984 = {
       auditor_class: "Staff",
       base_controller_class: "SupportInterface::SupportInterfaceController"


### PR DESCRIPTION
Now that all pre-existing data has been encrypted it is safe to drop
support for unencrypted data.

This was always intended to be a temporary measure to aid with
migration.

### Link to Trello card

https://trello.com/c/goRspcE7/853-add-db-encryption

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
