### PR TITLE
Add support for LogStash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.1"
 
+gem "amazing_print"
 gem "audits1984"
 gem "bootsnap", require: false
 gem "console1984"
@@ -19,6 +20,7 @@ gem "govuk_feature_flags",
 gem "govuk_markdown"
 gem "hashie"
 gem "jsbundling-rails"
+gem "logstash-logger"
 gem "mail-notify"
 gem "name_of_person"
 gem "okcomputer"
@@ -29,6 +31,7 @@ gem "pg", "~> 1.4"
 gem "propshaft"
 gem "puma", "~> 6.1"
 gem "rails", "~> 7.0.4"
+gem "rails_semantic_logger"
 gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
+    amazing_print (1.4.0)
     ast (2.4.2)
     attr_required (1.0.1)
     audits1984 (0.1.2)
@@ -196,6 +197,9 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.2)
       addressable (~> 2.8)
+    logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -321,6 +325,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails_semantic_logger (4.12.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -404,6 +412,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    semantic_logger (4.13.0)
+      concurrent-ruby (~> 1.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (7.0.7)
@@ -509,6 +519,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  amazing_print
   audits1984
   bootsnap
   capybara
@@ -528,6 +539,7 @@ DEPENDENCIES
   hashie
   jsbundling-rails
   launchy
+  logstash-logger
   mail-notify
   name_of_person
   okcomputer
@@ -540,6 +552,7 @@ DEPENDENCIES
   pry-nav
   puma (~> 6.1)
   rails (~> 7.0.4)
+  rails_semantic_logger
   rladr
   rspec
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,9 +71,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
+    $stdout.sync = true
+    config.rails_semantic_logger.add_file_appender = false
+    config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: :json)
   end
 
   # Do not dump schema after migrations.

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,0 +1,8 @@
+LogStashLogger.configure do |config|
+  config.customize_event do |event|
+    event["environment"] = Rails.env
+    event["host"] = ENV["HOSTING_DOMAIN"]
+    event["hosting_environment"] = ENV["HOSTING_ENVIRONMENT_NAME"]
+    event["type"] = "rails"
+  end
+end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,0 +1,50 @@
+class LogStashFormatter < SemanticLogger::Formatters::Raw
+  def call(log, logger)
+    super(log, logger)
+
+    format_exception
+    format_stacktrace
+
+    hash.to_json
+  end
+
+  def format_exception
+    exception_message = hash.dig(:exception, :message)
+    return if exception_message.blank?
+
+    hash[:message] = "Exception occured: #{exception_message}"
+  end
+
+  def format_stacktrace
+    stack_trace = hash.dig(:exception, :stack_trace)
+    return if stack_trace.blank?
+
+    hash[:stacktrace] = stack_trace.first(3)
+    hash[:exception].delete(:stack_trace)
+  end
+end
+
+if ENV["LOGSTASH_HOST"] && ENV["LOGSTASH_PORT"]
+  warn("logstash configured, sending logs there")
+
+  # For some reason logstash / elasticsearch drops events where the payload
+  # is a hash. These are more conveniently accessed at the top level of the
+  # event, anyway, so we move it there.
+  customize_event = ->(event) do
+    if event["payload"].present?
+      event.append(event["payload"])
+      event["payload"] = nil
+    end
+  end
+
+  logger =
+    LogStashLogger.new(
+      {
+        host: ENV["LOGSTASH_HOST"],
+        port: ENV["LOGSTASH_PORT"],
+        ssl_enable: true,
+        type: :tcp
+      }.merge(customize_event:)
+    )
+  SemanticLogger.add_appender(logger:, level: :info, formatter: LogStashFormatter.new)
+end

--- a/spec/logs/formatters/log_stash_formatter_spec.rb
+++ b/spec/logs/formatters/log_stash_formatter_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe LogStashFormatter do
+  let(:formatter) { described_class.new }
+
+  let(:info_level_log) do
+    {
+      application: "AYTQ",
+      duration: 253.90900003910065,
+      duration_ms: nil,
+      environment: "development",
+      host: "example-host",
+      hosting_environment: "local",
+      level: :info,
+      level_index: 2,
+      message: "Completed #new",
+      name: "Users::SessionsController",
+      payload: {
+        action: "new",
+        allocations: 47_495,
+        controller: "Users::SessionsController",
+        db_runtime: 41.77,
+        format: "HTML",
+        method: "GET",
+        path: "/users/sign_in",
+        status: 200,
+        status_message: "OK",
+        view_runtime: 77.42
+      },
+      pid: 6092,
+      thread: "puma srv tp 002",
+      time: "2023-03-30T11:14:00.000+01:00",
+      type: "rails"
+    }
+  end
+
+  let(:fatal_level_log) do
+    {
+      application: "Semantic Logger",
+      duration: nil,
+      duration_ms: nil,
+      environment: "development",
+      exception: {
+        name: "ActionController::RoutingError",
+        message: "No route matches [GET] \"/users/unknown\"",
+        stack_trace: [
+          "stack trace line 1",
+          "stack trace line 2",
+          "stack trace line 3",
+          "stack trace line 4",
+          "stack trace line 5"
+        ]
+      },
+      host: "example-host",
+      hosting_environment: "local",
+      level: :fatal,
+      level_index: 5,
+      line: 93,
+      name: "Rails",
+      pid: 6092,
+      thread: "puma srv tp 004",
+      time: "2023-03-23T12:17:42.923+00:00",
+      type: "rails"
+    }
+  end
+
+  before { allow(formatter).to receive(:hash).and_return(log) }
+
+  describe "#format_exception" do
+    before { formatter.format_exception }
+
+    context "when there is an info log" do
+      let(:log) { info_level_log }
+
+      it "does not change the log" do
+        expect(formatter.hash).to eq(log)
+      end
+    end
+
+    context "when there is an fatal log" do
+      let(:log) { fatal_level_log }
+
+      it "adds the error message under the `message` key in the log" do
+        expect(formatter.hash[:message]).to eq(
+          'Exception occured: No route matches [GET] "/users/unknown"'
+        )
+      end
+    end
+  end
+
+  describe "#format_stacktrace" do
+    before { formatter.format_stacktrace }
+
+    let(:log) { fatal_level_log }
+
+    it "removes the stacktrace from the exception" do
+      expect(formatter.hash[:exception]).to eq(
+        {
+          name: "ActionController::RoutingError",
+          message: "No route matches [GET] \"/users/unknown\""
+        }
+      )
+    end
+
+    it "adds a stacktrace key to the log" do
+      expect(formatter.hash[:stacktrace]).to eq(
+        ["stack trace line 1", "stack trace line 2", "stack trace line 3"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
We want to make use of LogStash to access logs in production.

In order to do this, we need to ensure the logs are in a suitable
format.

Firstly, we need to convert the verbose logging default Rails format
into a more compact JSON format.

`rails_semantic_logger` helps with that.

There's a wrinkle in this process in that the way exceptions are handled
by semantic logger isn't supported by LogStash. Adding a custom format
for this is required.

Secondly, we conditionally send the newly formatted logs to LogStash
using the presence of the environment variables as the gate.

Assumptions:

* LogStash will be configured on the project shortly by the DevOps team
* Access to the logs will be managed via Azure
* The condensed format doesn't interfere with how devs currently use the
  logs

### Link to Trello card

https://trello.com/c/KeLN0adr/862-add-logit-support

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
