### PR TITLE
Update the Quals API call

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -20,7 +20,18 @@ module QualificationsApi
     end
 
     def teacher
-      response = client.get("v3/teacher")
+      response =
+        client.get(
+          "v3/teacher",
+          {
+            include: %w[
+              Induction
+              InitialTeacherTraining
+              NpqQualifications
+              MandatoryQualifications
+            ].join(",")
+          }
+        )
 
       case response.status
       when 200


### PR DESCRIPTION
The Qualifications API requires a new parameter, `include`, to return
the appropriate data.

Given that this is something outside our control, we don't have tests
around the calls we make to external APIs. There wasn't a test I could
write for this case.

### Link to Trello card

https://trello.com/c/GtLeWiiH/886-update-ruby-client-for-quals-api-to-opt-in-to-all-required-info

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
