### PR TITLE
Add a start page

### DIFF
--- a/app/controllers/qualifications/starts_controller.rb
+++ b/app/controllers/qualifications/starts_controller.rb
@@ -1,0 +1,9 @@
+module Qualifications
+  class StartsController < QualificationsInterfaceController
+    skip_before_action :authenticate_user!
+    skip_before_action :handle_expired_token!
+
+    def show
+    end
+  end
+end

--- a/app/views/qualifications/starts/show.html.erb
+++ b/app/views/qualifications/starts/show.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-8"><%= t('service.name') %></h1>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Qualified teachers can use this service to:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+      <li>download your teaching certificates</li>
+      <li>check your qualification status</li>
+      <li>check your early career teacher induction status</li>
+      <li>change the name on your teaching certificates</li>
+    </ul>
+    <h1 class="govuk-heading-m">Before you start</h1>
+
+    <p class="govuk-body">
+      You’ll need to create a <strong>DfE Identity account</strong> to access your teaching qualifications. You'll use the account to sign-in to this service and other DfE teaching services.
+    </p>
+
+    <%= button_to ["/users/auth/identity", "trn_token=#{params[:trn_token]}"].join('?'), class: "govuk-button govuk-button--start" do %>
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+      </svg>
+    <% end %>
+  </div>
+</div>

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -16,3 +16,7 @@ end
 get "/accessibility", to: "static#accessibility"
 get "/cookies", to: "static#cookies"
 get "/privacy", to: "static#privacy"
+
+namespace :qualifications do
+  resource :start, only: [:show]
+end

--- a/spec/system/qualifications/start_spec.rb
+++ b/spec/system/qualifications/start_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "The qualifications start page", type: :system do
+  include CommonSteps
+
+  scenario "when a user views the start page", test: :with_stubbed_auth do
+    given_the_service_is_open
+
+    when_i_visit_the_qualifications_start_page
+    then_i_see_the_start_page
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_start_page
+    visit qualifications_start_path
+  end
+
+  def then_i_see_the_start_page
+    expect(page).to have_content("Access your teaching qualifications")
+    expect(page).to have_button("Start now")
+  end
+end


### PR DESCRIPTION
We need a start page for the service. This will serve as the entrypoint
for people arriving directly at the service from a link on the web or
via magic link in an email.

### Link to Trello card

https://trello.com/c/w882EqCD/888-magic-link-landing-page

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
