### PR TITLE
Fix identity account link

### DIFF
--- a/app/views/identity_users/show.html.erb
+++ b/app/views/identity_users/show.html.erb
@@ -6,9 +6,13 @@
       You can change sign in and personal details in your DfE Identity account.
     </p>
     <p>
-      You use your DfE Identity account to sign in to <b>'Access your teaching qualifications'</b>.
+      You use your DfE Identity account to sign in to <b>'<%= t('service.name') %>'</b>.
     </p>
 
-    <%= govuk_button_to "Access your DfE Identity account", "#{ENV.fetch('IDENTITY_API_DOMAIN')}/account?client_id=access-your-teaching-qualifications&redirect_uri=#{root_url}", class: "app-button--inverse govuk-!-margin-bottom-0", method: :get %>
+      <%= govuk_link_to(
+        "Access your DfE Identity account", 
+        "#{ENV.fetch('IDENTITY_API_DOMAIN')}account?client_id=#{ENV.fetch("IDENTITY_CLIENT_ID")}&redirect_uri=#{CGI::escape(root_url)}&sign_out_uri=#{CGI::escape(sign_out_url)}",
+        class: "govuk-button app-button--inverse govuk-!-margin-bottom-0"
+      ) %>
   </div>
 <% end %>

--- a/spec/system/user_views_and_updates_their_details_spec.rb
+++ b/spec/system/user_views_and_updates_their_details_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature "User views and updates their details" do
 
   def then_i_see_the_landing_page
     expect(page).to have_text("DfE Identity account")
-    expect(page).to have_button("Access your DfE Identity account")
+    expect(page).to have_link("Access your DfE Identity account")
   end
 end


### PR DESCRIPTION
The account link doesn't work due to using a form instead of a link.

This resulted in the URL params not being passed correctly.

Switching to a link that is styled as per the designs fixes this.

While making this change, I also added the sign out URI value to enable
the sign out flow.

### Link to Trello card

https://trello.com/c/Emobc386/912-id-account-sign-out-integration

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
