### PR TITLE
Add DSI dev bypass

### DIFF
--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -1,5 +1,23 @@
 module CheckRecords
   class CheckRecordsController < ApplicationController
+    before_action :authenticate_dsi_user!
+
     layout "check_records_layout"
+
+    def current_dsi_user
+      @current_dsi_user ||= DsiUser.find(session[:dsi_user_id]) if session[:dsi_user_id]
+    end
+    helper_method :current_dsi_user
+
+    def authenticate_dsi_user!
+      if current_dsi_user.blank?
+        flash[:warning] = "You need to sign in to continue."
+        redirect_to check_records_sign_in_path
+      end
+    end
+
+    def dsi_user_signed_in?
+      !!current_dsi_user
+    end
   end
 end

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -4,6 +4,7 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
   protect_from_forgery except: :dfe_bypass
 
   def dfe_bypass
+    redirect_to check_records_root_path unless CheckRecords::DfESignIn.bypass?
     @dsi_user = DsiUser.create_or_update_from_dsi(request.env["omniauth.auth"])
     @dsi_user.begin_session!(session)
 

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CheckRecords::OmniauthCallbacksController < ApplicationController
+  protect_from_forgery except: :dfe_bypass
+
+  def dfe_bypass
+    @dsi_user = DsiUser.create_or_update_from_dsi(request.env["omniauth.auth"])
+    @dsi_user.begin_session!(session)
+
+    redirect_to check_records_root_path
+  end
+end

--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -1,5 +1,7 @@
 module CheckRecords
   class SignInController < CheckRecordsController
+    skip_before_action :authenticate_dsi_user!
+
     def new
     end
   end

--- a/app/controllers/identity_users_controller.rb
+++ b/app/controllers/identity_users_controller.rb
@@ -1,6 +1,4 @@
 class IdentityUsersController < QualificationsInterfaceController
-  before_action :authenticate_user!
-
   def show
   end
 end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -1,0 +1,2 @@
+class DsiUser < ApplicationRecord
+end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -1,2 +1,17 @@
 class DsiUser < ApplicationRecord
+  def self.create_or_update_from_dsi(dsi_payload)
+    dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
+
+    dsi_user.update!(
+      first_name: dsi_payload.info.first_name,
+      last_name: dsi_payload.info.last_name,
+      uid: dsi_payload.info.uid
+    )
+
+    dsi_user
+  end
+
+  def begin_session!(session)
+    session[:dsi_user_id] = id
+  end
 end

--- a/app/views/check_records/sign_in/new.html.erb
+++ b/app/views/check_records/sign_in/new.html.erb
@@ -1,0 +1,7 @@
+<%=
+  govuk_button_to(
+    "Sign in with DSI bypass",
+    "/check-records/auth/developer",
+    method: :post
+  )
+%>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -37,7 +37,9 @@
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
-        <%= yield :content %>
+
+        <%= yield %>
+
       </main>
     </div>
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -21,6 +21,14 @@ shared:
     - record_id
     - blob_id
     - created_at
+  :dsi_users:
+    - id
+    - email
+    - first_name
+    - last_name
+    - uid
+    - created_at
+    - updated_at
   :feature_flags_features:
     - id
     - name

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -4,6 +4,10 @@
     - filename
   :active_storage_attachments:
     - name
+  :dsi_users:
+    - email
+    - first_name
+    - last_name
   :users:
     - date_of_birth
     - email

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -27,7 +27,10 @@ options = {
 
 if CheckRecords::DfESignIn.bypass?
   Rails.application.config.middleware.use OmniAuth::Builder do
-    provider :developer, fields: %i[uid email first_name last_name], uid_field: :uid, path_prefix: "/check-records/auth"
+    provider :developer,
+             fields: %i[uid email first_name last_name],
+             uid_field: :uid,
+             path_prefix: "/check-records/auth"
   end
 else
   Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -27,7 +27,7 @@ options = {
 
 if CheckRecords::DfESignIn.bypass?
   Rails.application.config.middleware.use OmniAuth::Builder do
-    provider :developer, fields: %i[uid email first_name last_name], uid_field: :uid
+    provider :developer, fields: %i[uid email first_name last_name], uid_field: :uid, path_prefix: "/check-records/auth"
   end
 else
   Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -2,4 +2,6 @@
 
 namespace :check_records, path: "check-records" do
   root to: "sign_in#new"
+
+  post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 end

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -3,5 +3,7 @@
 namespace :check_records, path: "check-records" do
   root to: "sign_in#new"
 
+  get "/sign-in", to: "sign_in#new"
+
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 end

--- a/db/migrate/20230418103600_create_dsi_users.rb
+++ b/db/migrate/20230418103600_create_dsi_users.rb
@@ -1,0 +1,14 @@
+class CreateDsiUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dsi_users do |t|
+      t.string :email, null: false
+      t.string :first_name
+      t.string :last_name
+      t.string :uid, null: false
+
+      t.timestamps
+    end
+
+    add_index :dsi_users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_29_090435) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_103600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_090435) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "dsi_users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_dsi_users_on_email", unique: true
   end
 
   create_table "feature_flags_features", force: :cascade do |t|

--- a/spec/factories/dsi_users.rb
+++ b/spec/factories/dsi_users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :dsi_user do
+    
+  end
+end

--- a/spec/factories/dsi_users.rb
+++ b/spec/factories/dsi_users.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :dsi_user do
-    
+    sequence :email do |n|
+      "dsi-user-#{n}@example.com"
+    end
+
+    first_name { "Steven" }
+    last_name { "Toast" }
+    uid { "123" }
   end
 end

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -1,4 +1,46 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DsiUser, type: :model do
+  describe ".create_or_update_from_dsi" do
+    let(:dsi_payload) do
+      OmniAuth::AuthHash.new(info: { email:, first_name: "John", last_name: "Doe", uid: "123456" })
+    end
+    let(:email) { "test@example.com" }
+
+    context "when the user with the email exists" do
+      let!(:existing_user) { create(:dsi_user, email:) }
+
+      it "finds the existing user and updates the attributes" do
+        result = described_class.create_or_update_from_dsi(dsi_payload)
+        expect(result).to eq(existing_user)
+        updated_fields = %w[first_name last_name uid]
+        expect(result.attributes.slice(*updated_fields)).to eq(
+          dsi_payload.info.slice(*updated_fields)
+        )
+      end
+    end
+
+    context "when the user with the email does not exist" do
+      it "creates a new user" do
+        expect { described_class.create_or_update_from_dsi(dsi_payload) }.to change {
+          DsiUser.count
+        }.from(0).to(1)
+        updated_fields = %w[first_name last_name uid]
+        expect(DsiUser.first.attributes.slice(*updated_fields)).to eq(
+          dsi_payload.info.slice(*updated_fields)
+        )
+      end
+    end
+  end
+
+  describe "#begin_session!" do
+    let(:session) { {} }
+    let(:dsi_user) { create(:dsi_user) }
+
+    it "sets the dsi_user_id in the session" do
+      expect { dsi_user.begin_session!(session) }.to change { session[:dsi_user_id] }.from(nil).to(
+        dsi_user.id
+      )
+    end
+  end
 end

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe DsiUser, type: :model do
+end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
It would be useful to have a way to easily sign in during development to manually
test the Check records service. Doing this work also sets up the basic plumbing for creating a DSI user session, which will be used when we have a functioning DSI service set up and ready to integrate with this app.
### Changes proposed in this pull request

- Add a DsiUser model to hold data sent in the callback request (which for the bypass is a POST from a form that the developer manually fills out as part of the `developer` Omniauth strategy)
- Add basic UI to start the sign in process 
- Create or update the DsiUser based on the email provided and then write their ID to the session
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

- UI in the nav for signing in and out will follow in a separate PR
- The proper DSI auth flow will follow, once the service has been set up and we have a test environment we can use

To manually test:
- Go to `http://localhost:3000/check-records/sign-in`
- Click through and fill in the form with arbitrary details
- You should be redirected back to the sign in page with a session cookie written

State change will be more obvious once the nav has been updated.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/5kOuHCu8
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
