### PR TITLE
Pass a session ID to Identity

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,22 @@ class ApplicationController < ActionController::Base
     password: ENV.fetch("SUPPORT_PASSWORD", nil),
     unless: -> { FeatureFlags::FeatureFlag.active?("service_open") }
   )
+
+  def trigger_request_event
+    return unless DfE::Analytics.enabled?
+
+    request_event =
+      DfE::Analytics::Event
+        .new
+        .with_type("web_request")
+        .with_request_details(request)
+        .with_response_details(response)
+        .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id))
+        .with_data(session_id: session[:session_id])
+
+    request_event.with_user(current_user) if respond_to?(:current_user, true)
+    request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
+
+    DfE::Analytics::SendEvents.do([request_event.as_json])
+  end
 end

--- a/app/views/users/sign_in/new.html.erb
+++ b/app/views/users/sign_in/new.html.erb
@@ -5,4 +5,3 @@
     method: :post
   )
 %>
-

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -5,6 +5,7 @@ module OmniAuth
 
       option :client_options,
              {
+               authorize_params: lambda { |request| { session_id: request.session.id } },
                authorize_url: "/connect/authorize",
                site: ENV.fetch("IDENTITY_API_DOMAIN"),
                token_url: "/connect/token"


### PR DESCRIPTION
We want to be able to track a session across apps in order to better
deliver a good authentication experience.

The identity provider will add a provided `session_id` to every tracking
event it sends to BigQuery.

This will allow us to better connect sessions across different BigQuery
tables.

The `dfe-analytics` library doesn't have support for custom data in the
web request event type.

Rather than extend that library, as it appears this is not something
required across other apps yet. I opted to monkey-patch the method that
triggers the web request event to add custom data.

We're using the Rails session ID as the identifier to be used across
apps as it is the most unique thing we can use across services.

### Link to Trello card

https://trello.com/c/h9MfVpN1/914-pass-sessionid-to-authorize-endpoint-for-cross-service-analytics

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
