### PR TITLE
Add nav links for signing in and out of the Check records service

### DIFF
--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,4 +1,9 @@
 <%=
   govuk_header(service_name: t("check_records_service.name"), service_url: "/check-records") do |header|
+    if current_dsi_user
+      header.with_navigation_item(href: check_records_sign_out_path, text: "Sign out")
+    else
+      header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
+    end
   end
 %>

--- a/app/components/check_records/navigation_component.rb
+++ b/app/components/check_records/navigation_component.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class CheckRecords::NavigationComponent < ViewComponent::Base
+  attr_accessor :current_dsi_user
+
+  def initialize(current_dsi_user:)
+    super
+    @current_dsi_user = current_dsi_user
+  end
 end

--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -1,0 +1,7 @@
+module CheckRecords
+  class SignOutController < CheckRecordsController
+    def new
+      session[:dsi_user_id] = nil if dsi_user_signed_in?
+    end
+  end
+end

--- a/app/views/check_records/sign_out/new.html.erb
+++ b/app/views/check_records/sign_out/new.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You are now signed out</h1>
+
+    <%= govuk_button_link_to "Continue", check_records_root_path  %>
+  </div>
+</div>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -27,7 +27,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= render(CheckRecords::NavigationComponent.new) %>
+    <%= render(CheckRecords::NavigationComponent.new(current_dsi_user: current_dsi_user)) %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -4,6 +4,7 @@ namespace :check_records, path: "check-records" do
   root to: "sign_in#new"
 
   get "/sign-in", to: "sign_in#new"
+  get "/sign-out", to: "sign_out#new"
 
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 end


### PR DESCRIPTION
### Context
Check records needs it own nav, including sign in / sign out links for DfE Sign in.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Update the Check records nav to dynamically display Sign in / Sign out depending on auth state.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/OceHISdM/10-add-dsi-links-in-nav
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
