### PR TITLE
Encrypt sensitive DSI User fields

### DIFF
--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -1,4 +1,7 @@
 class DsiUser < ApplicationRecord
+  encrypts :email, deterministic: true
+  encrypts :first_name, :last_name
+
   def self.create_or_update_from_dsi(dsi_payload)
     dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
 

--- a/db/migrate/20230426093546_change_length_of_sensitive_fields_dsi_user.rb
+++ b/db/migrate/20230426093546_change_length_of_sensitive_fields_dsi_user.rb
@@ -1,0 +1,17 @@
+class ChangeLengthOfSensitiveFieldsDsiUser < ActiveRecord::Migration[7.0]
+  def up
+    change_table :dsi_users, bulk: true do |t|
+      t.change :email, :string, limit: 510
+      t.change :first_name, :string, limit: 510
+      t.change :last_name, :string, limit: 510
+    end
+  end
+
+  def down
+    change_table :dsi_users, bulk: true do |t|
+      t.change :email, :string, limit: 255
+      t.change :first_name, :string, limit: 255
+      t.change :last_name, :string, limit: 255
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_103600) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_093546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,9 +91,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_103600) do
   end
 
   create_table "dsi_users", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "first_name"
-    t.string "last_name"
+    t.string "email", limit: 510, null: false
+    t.string "first_name", limit: 510
+    t.string "last_name", limit: 510
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Whenever we store sensitive data on an individual, we want to encrypt
it.

This change adds encryption to the DSI User record for PII. Currently,
the only affected fields are email, first name and last name.

The encrypted version of the fields are longer and don't reliably fit
within the default 255 character limit, so we increase the length of the
column to accommodate this.


### Link to Trello card

https://trello.com/c/SKDNWe4i/16-add-db-encryption-for-dsi-user-records

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
