### PR TITLE
Add DSI test helpers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 BYPASS_DSI=true
 CHECK_RECORDS_DOMAIN=localhost
 DFE_SIGN_IN_CLIENT_ID=tbd
-DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/auth/dfe/callback
+DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/check-records/auth/dfe/callback
 DFE_SIGN_IN_SECRET=override-locally
 DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk
 GOVUK_NOTIFY_API_KEY=override-locally

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -3,11 +3,11 @@
 class CheckRecords::OmniauthCallbacksController < ApplicationController
   protect_from_forgery except: :dfe_bypass
 
-  def dfe_bypass
-    redirect_to check_records_root_path unless CheckRecords::DfESignIn.bypass?
+  def dfe
     @dsi_user = DsiUser.create_or_update_from_dsi(request.env["omniauth.auth"])
     @dsi_user.begin_session!(session)
 
     redirect_to check_records_root_path
   end
+  alias_method :dfe_bypass, :dfe
 end

--- a/app/views/check_records/sign_in/new.html.erb
+++ b/app/views/check_records/sign_in/new.html.erb
@@ -1,7 +1,17 @@
-<%=
-  govuk_button_to(
-    "Sign in with DSI bypass",
-    "/check-records/auth/developer",
-    method: :post
-  )
-%>
+<% if CheckRecords::DfESignIn.bypass? %>
+  <%=
+    govuk_button_to(
+      "Sign in with DSI bypass",
+      "/check-records/auth/developer",
+      method: :post
+    )
+  %>
+<% else %>
+  <%=
+    govuk_button_to(
+      "Sign in with DSI",
+      "/check-records/auth/dfe",
+      method: :post
+    )
+  %>
+<% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -36,6 +36,7 @@ else
   Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
 end
 
+# Identity setup
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :identity,
            ENV.fetch("IDENTITY_CLIENT_ID"),

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,18 +3,18 @@ require "omniauth/strategies/identity"
 
 OmniAuth.config.logger = Rails.logger
 
+# DSI setup
 dfe_sign_in_identifier = ENV.fetch("DFE_SIGN_IN_CLIENT_ID", "example")
 dfe_sign_in_secret = ENV.fetch("DFE_SIGN_IN_SECRET", "example")
 dfe_sign_in_redirect_uri = ENV.fetch("DFE_SIGN_IN_REDIRECT_URL", "example")
 dfe_sign_in_issuer_uri = ENV["DFE_SIGN_IN_ISSUER"].present? ? URI(ENV["DFE_SIGN_IN_ISSUER"]) : nil
-
 options = {
   name: :dfe,
   discovery: true,
   response_type: :code,
   scope: %i[email profile],
-  path_prefix: "/auth",
-  callback_path: "/auth/dfe/callback",
+  path_prefix: "/check-records/auth",
+  callback_path: "/check-records/auth/dfe/callback",
   client_options: {
     port: dfe_sign_in_issuer_uri&.port,
     scheme: dfe_sign_in_issuer_uri&.scheme,
@@ -24,7 +24,6 @@ options = {
     redirect_uri: dfe_sign_in_redirect_uri&.to_s
   }
 }
-
 if CheckRecords::DfESignIn.bypass?
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider :developer,

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -6,5 +6,6 @@ namespace :check_records, path: "check-records" do
   get "/sign-in", to: "sign_in#new"
   get "/sign-out", to: "sign_out#new"
 
+  get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,7 +84,9 @@ RSpec.configure do |config|
     OmniAuth.config.test_mode = true
     example.run
     OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth[:identity] = nil
+
+    OmniAuth.config.mock_auth.delete(:identity)
+    OmniAuth.config.mock_auth.delete(:dfe)
   end
 
   config.include ActiveJob::TestHelper

--- a/spec/support/system/check_records/authentication_steps.rb
+++ b/spec/support/system/check_records/authentication_steps.rb
@@ -1,0 +1,31 @@
+module CheckRecords
+  module AuthenticationSteps
+    def when_i_sign_in_via_dsi
+      given_dsi_auth_is_mocked
+      when_i_visit_the_sign_in_page
+      and_click_the_dsi_sign_in_button
+    end
+
+    def given_dsi_auth_is_mocked
+      OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+        {
+          provider: "dfe",
+          info: {
+            email: "test@example.com",
+            first_name: "Test",
+            last_name: "User",
+            uid: "123456"
+          }
+        }
+      )
+    end
+
+    def when_i_visit_the_sign_in_page
+      visit check_records_sign_in_path
+    end
+
+    def and_click_the_dsi_sign_in_button
+      click_button "Sign in with DSI"
+    end
+  end
+end

--- a/spec/system/check_records/user_signs_in_spec.rb
+++ b/spec/system/check_records/user_signs_in_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication" do
+  include AuthorizationSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User signs in via DfE Sign In", test: :with_stubbed_auth do
+    when_i_am_authorized_with_basic_auth
+    when_i_sign_in_via_dsi
+    then_i_am_signed_in
+  end
+
+  private
+
+  def then_i_am_signed_in
+    within("header") { expect(page).to have_content "Sign out" }
+    expect(DsiUser.count).to eq 1
+  end
+end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
We need to be able to mock the DSI auth strategy and return an auth hash in our system specs, similarly to how we do for Identity auth in the AYTQ service. This will make it easier to write system specs that depend on being signed in to DSI.
### Changes proposed in this pull request
- Namespace the DSI OAuth routes under `/check-records`
- Add a sign in button to kick off the DSI auth flow (the actual `dfe` strategy, not the `developer` one)
- Add test helpers that mock out the response when signing in
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/mFEKrti8/14-add-test-helpers-for-dsi
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
