### PR TITLE
Add session expiry for DSI authentication

### DIFF
--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -1,6 +1,7 @@
 module CheckRecords
   class CheckRecordsController < ApplicationController
     before_action :authenticate_dsi_user!
+    before_action :handle_expired_session!
 
     layout "check_records_layout"
 
@@ -18,6 +19,18 @@ module CheckRecords
 
     def dsi_user_signed_in?
       !!current_dsi_user
+    end
+
+    def handle_expired_session!
+      if session[:dsi_user_session_expiry].nil?
+        redirect_to check_records_sign_out_path
+        return
+      end
+
+      if Time.zone.at(session[:dsi_user_session_expiry]).past?
+        flash[:warning] = "Your session has expired. Please sign in again."
+        redirect_to check_records_sign_out_path
+      end
     end
   end
 end

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -5,7 +5,8 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
 
   def dfe
     @dsi_user = DsiUser.create_or_update_from_dsi(request.env["omniauth.auth"])
-    @dsi_user.begin_session!(session)
+    session[:dsi_user_id] = @dsi_user.id
+    session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
 
     redirect_to check_records_root_path
   end

--- a/app/controllers/check_records/pages_controller.rb
+++ b/app/controllers/check_records/pages_controller.rb
@@ -1,0 +1,6 @@
+module CheckRecords
+  class PagesController < CheckRecordsController
+    def start
+    end
+  end
+end

--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -1,6 +1,7 @@
 module CheckRecords
   class SignInController < CheckRecordsController
     skip_before_action :authenticate_dsi_user!
+    skip_before_action :handle_expired_session!
 
     def new
     end

--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -1,5 +1,7 @@
 module CheckRecords
   class SignOutController < CheckRecordsController
+    skip_before_action :handle_expired_session!
+
     def new
       session[:dsi_user_id] = nil if dsi_user_signed_in?
     end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -13,8 +13,4 @@ class DsiUser < ApplicationRecord
 
     dsi_user
   end
-
-  def begin_session!(session)
-    session[:dsi_user_id] = id
-  end
 end

--- a/app/views/check_records/pages/start.html.erb
+++ b/app/views/check_records/pages/start.html.erb
@@ -1,0 +1,1 @@
+<h1>Start Check Records</h1>

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -6,6 +6,8 @@ namespace :check_records, path: "check-records" do
 
   get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
+
+  get "/start", to: "pages#start"
 end
 
-root to: redirect("/check-records/sign-in"), as: :check_records_root
+root to: redirect("/check-records/start"), as: :check_records_root

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -32,15 +32,4 @@ RSpec.describe DsiUser, type: :model do
       end
     end
   end
-
-  describe "#begin_session!" do
-    let(:session) { {} }
-    let(:dsi_user) { create(:dsi_user) }
-
-    it "sets the dsi_user_id in the session" do
-      expect { dsi_user.begin_session!(session) }.to change { session[:dsi_user_id] }.from(nil).to(
-        dsi_user.id
-      )
-    end
-  end
 end

--- a/spec/support/system/check_records/authentication_steps.rb
+++ b/spec/support/system/check_records/authentication_steps.rb
@@ -5,6 +5,7 @@ module CheckRecords
       when_i_visit_the_sign_in_page
       and_click_the_dsi_sign_in_button
     end
+    alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
 
     def given_dsi_auth_is_mocked
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(

--- a/spec/system/check_records/user_session_expires_spec.rb
+++ b/spec/system/check_records/user_session_expires_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "DSI session expiry", host: :check_records, type: :system do
+  include CommonSteps
+  include CheckRecords::AuthenticationSteps
+
+  after { travel_back }
+
+  scenario "Session expires", test: :with_stubbed_auth do
+    given_the_service_is_open
+    and_i_am_signed_in_via_dsi
+    and_my_session_expires
+    when_i_refresh_the_page
+    then_i_am_required_to_sign_in_again
+  end
+
+  private
+
+  def and_my_session_expires
+    travel_to 121.minutes.from_now
+  end
+
+  def then_i_am_required_to_sign_in_again
+    expect(page).to have_content "Your session has expired. Please sign in again."
+  end
+
+  def when_i_refresh_the_page
+    page.refresh
+  end
+end


### PR DESCRIPTION
When authenticating in the check records service using the DSI method,
there is no token expiry.

A long-lived token like this has an increased security risk over a
short-lived one.

To resolve this, we are proposing adding an arbitrary time out on the
session, starting with a 2 hour limit.

There is nothing magic about the choice of 2 hours, so if it turns out
that you think there is a better window, then feel free to change.

The implementation sets a hard-limit of 2 hours from a successful
response from the identity auth provider. This means that if the user
has a single session longer than 2 hours, they will be required to sign
in again to continue accessing the service.

### Link to Trello card

https://trello.com/c/HbzmgxeL/12-add-dsi-session-expiry

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
