### PR TITLE
Add teacher not found page

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -8,8 +8,12 @@ module CheckRecords
     def show
       redirect_to check_records_search_path if params[:trn].blank?
 
-      client = QualificationsApi::Client.new(token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"])
-      @teacher = client.teacher(trn: params[:trn])
+      begin
+        client = QualificationsApi::Client.new(token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"])
+        @teacher = client.teacher(trn: params[:trn])
+      rescue QualificationsApi::TeacherNotFoundError
+        render "not_found"
+      end
     end
   end
 end

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -39,6 +39,8 @@ module QualificationsApi
       case response.status
       when 200
         QualificationsApi::Teacher.new response.body
+      when 404
+        raise QualificationsApi::TeacherNotFoundError
       when 401
         raise QualificationsApi::InvalidTokenError
       end

--- a/app/lib/qualifications_api/teacher_not_found_error.rb
+++ b/app/lib/qualifications_api/teacher_not_found_error.rb
@@ -1,0 +1,2 @@
+class QualificationsApi::TeacherNotFoundError < StandardError
+end

--- a/app/views/check_records/search/not_found.html.erb
+++ b/app/views/check_records/search/not_found.html.erb
@@ -1,0 +1,9 @@
+<% content_for :back_link_url, check_records_search_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Teacher not found</h1>
+
+    <%= govuk_link_to "Search again", check_records_search_path %>
+  </div>
+</div>

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
         expect(response.trn).to eq "1234567"
       end
     end
+
+    context "when an invalid trn is provided" do
+      it "raises an error" do
+        client = described_class.new(token: "token")
+        expect { client.teacher(trn: "bad-trn") }.to raise_error(
+          QualificationsApi::TeacherNotFoundError
+        )
+      end
+    end
   end
 
   describe "#certificate" do

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -10,12 +10,17 @@ class FakeQualificationsApi < Sinatra::Base
     end
   end
 
-  get "/v3/teachers/1234567" do
+  get "/v3/teachers/:trn" do
     content_type :json
 
+    trn = params[:trn]
     case bearer_token
     when "token"
-      quals_data(trn: "1234567")
+      if trn == "1234567"
+        quals_data(trn: "1234567")
+      else
+        halt 404
+      end
     when "invalid-token"
       halt 401
     end

--- a/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
+++ b/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "TRN search", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User searches with invalid TRN",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi
+    and_search_with_an_invalid_trn
+    then_i_see_a_not_found_page
+  end
+
+  private
+
+  def and_search_with_an_invalid_trn
+    fill_in "trn", with: "bad-trn"
+    click_button "Search"
+  end
+
+  def then_i_see_a_not_found_page
+    expect(page).to have_content "Teacher not found"
+  end
+end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
The Check records service allows employers to look up teachers by their TRN. We need to handle the case where a TRN doesn't return a teacher record.
### Changes proposed in this pull request
![Screenshot_20230510_142853](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/942c39d9-f524-4f12-baff-ce2ba11b3fcc)


- Update the API client to handle 404s
- Add a not found page and render this when the client returns a TeacherNotFoundError
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be manually tested by putting a bad TRN into Check's search.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/xyNQQa4N
### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
