### PR TITLE
Add Sentry for error tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "propshaft"
 gem "puma", "~> 6.2"
 gem "rails", "~> 7.0.4"
 gem "rails_semantic_logger"
+gem "sentry-rails", "~> 5.9"
 gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,11 @@ GEM
       tilt
     semantic_logger (4.13.0)
       concurrent-ruby (~> 1.0)
+    sentry-rails (5.9.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.9.0)
+    sentry-ruby (5.9.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (7.1.0)
@@ -620,6 +625,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  sentry-rails (~> 5.9)
   shoulda-matchers
   sidekiq
   sinatra

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/parameter_filter"
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+
+  config.environment = HostingEnvironment.name
+
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda { |event, _hint| filter.filter(event.to_hash) }
+
+  config.inspect_exception_causes_for_exclusion = true
+  config.excluded_exceptions += [
+    # The following exceptions are user-errors that aren't actionable, and can
+    # be safely ignored.
+    "ActionController::BadRequest",
+    "ActionController::UnknownFormat",
+    "ActionController::UnknownHttpMethod",
+    "ActionDispatch::Http::Parameters::ParseError",
+    "Mime::Type::InvalidMimeType"
+  ]
+end


### PR DESCRIPTION
We want a way to manage app errors.

Sentry is the standard service we use across multiple projects for this.

The `SENTRY_DSN` value that the library requires needs to be set via an
ENV variable.

This change assumes that this will be provided from the Azure keyvault
and no further setup needs to happen here.

### Link to Trello card

https://trello.com/c/RRkqsxuK/35-setup-sentry-in-aytq-check

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
