### PR TITLE
Display the teacher details

### DIFF
--- a/app/components/check_records/npq_summary_component.html.erb
+++ b/app/components/check_records/npq_summary_component.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-!-margin-bottom-9">
+  <h2 class="govuk-heading-m">National professional qualifications (NPQ)</h2>
+  <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+</div>

--- a/app/components/check_records/npq_summary_component.rb
+++ b/app/components/check_records/npq_summary_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CheckRecords::NpqSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :npqs
+
+  def rows
+    npqs.map do |npq|
+      {
+        key: {
+          text: ["Date", npq.name, "awarded"].join(" ")
+        },
+        value: {
+          text: npq.awarded_at.to_fs(:long_uk)
+        }
+      }
+    end
+  end
+end

--- a/app/components/check_records/qualification_summary_component.html.erb
+++ b/app/components/check_records/qualification_summary_component.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-!-margin-bottom-9">
+  <h2 class="govuk-heading-m"><%= title %></h2>
+  <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+</div>

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :qualification
+
+  delegate :awarded_at,
+           :certificate_type,
+           :details,
+           :id,
+           :induction?,
+           :itt?,
+           :mq?,
+           :name,
+           :type,
+           to: :qualification
+
+  alias_method :title, :name
+
+  def rows
+    return itt_rows if itt?
+    return mq_rows if mq?
+    return induction_rows if induction?
+
+    [{ key: { text: "Date awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }]
+  end
+
+  def induction_rows
+    [
+      { key: { text: "Induction status" }, value: { text: details.status&.to_s&.humanize } },
+      { key: { text: "Date completed" }, value: { text: awarded_at.to_fs(:long_uk) } }
+    ]
+  end
+
+  def itt_rows
+    [
+      { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
+      { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },
+      { key: { text: "Programme type" }, value: { text: details.programme_type } },
+      {
+        key: {
+          text: "Subject"
+        },
+        value: {
+          text: details.subjects.map { |subject| subject.name.titleize }.join(", ")
+        }
+      },
+      { key: { text: "Age range" }, value: { text: details.age_range&.description } },
+      {
+        key: {
+          text: "Course end date"
+        },
+        value: {
+          text: details.end_date&.to_date&.to_fs(:long_uk)
+        }
+      },
+      { key: { text: "Course result" }, value: { text: details.result&.to_s&.humanize } }
+    ]
+  end
+
+  def mq_rows
+    [
+      { key: { text: "Specialism" }, value: { text: details.specialism } },
+      { key: { text: "Date awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }
+    ]
+  end
+end

--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -11,6 +11,9 @@ module CheckRecords
       begin
         client = QualificationsApi::Client.new(token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"])
         @teacher = client.teacher(trn: params[:trn])
+        @npqs = @teacher.qualifications.filter(&:npq?)
+        @other_qualifications =
+          @teacher.qualifications.filter { |qualification| !qualification.npq? }
       rescue QualificationsApi::TeacherNotFoundError
         render "not_found"
       end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -91,7 +91,7 @@ module QualificationsApi
         Qualification.new(
           awarded_at: mq.awarded.to_date,
           details: mq,
-          name: "Mandatory qualification (MQ): specialist teacher",
+          name: "Mandatory qualification (MQ)",
           type: :mandatory
         )
       end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -5,7 +5,7 @@ class Qualification
   attr_writer :details
 
   def certificate_type
-    return :npq if type.downcase.starts_with?("npq")
+    return :npq if type&.downcase&.starts_with?("npq")
 
     type
   end
@@ -24,5 +24,13 @@ class Qualification
 
   def itt?
     type == :itt
+  end
+
+  def mq?
+    type == :mandatory
+  end
+
+  def npq?
+    type&.downcase&.starts_with?("npq")
   end
 end

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -4,22 +4,22 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= @teacher.name %></h1>
 
-    <h2 class="govuk-heading-m">Personal Details</h2>
-    <%= govuk_summary_list(
-      rows: [
-        { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
-        { key: { text: "Email address" }, value: { text: "TODO" } }
-      ])
-    %>
+    <div class="govuk-!-margin-bottom-9">
+      <h2 class="govuk-heading-m">Personal Details</h2>
+      <%= govuk_summary_list(
+        rows: [
+          { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
+          { key: { text: "Email address" }, value: { text: "TODO" } }
+        ])
+      %>
+    </div>
 
-    <h2 class="govuk-heading-m">Organisation Details</h2>
-    <p>TODO</p>
+    <% @other_qualifications.each do |qualification| %>
+      <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
+    <% end %>
 
-    <h2 class="govuk-heading-m">Qualified teacher status (QTS)</h2>
-    <h2 class="govuk-heading-m">Early years teacher status (EYTS)</h2>
-    <h2 class="govuk-heading-m">Induction</h2>
-    <h2 class="govuk-heading-m">Initial teacher training (ITT)</h2>
-    <h2 class="govuk-heading-m">Mandatory qualifications (MQ)</h2>
-    <h2 class="govuk-heading-m">National professional qualifications (NPQ)</h2>
+    <% if @npqs %>
+      <%= render CheckRecords::NpqSummaryComponent.new(npqs: @npqs) %>
+    <% end %>
   </div>
 </div>

--- a/spec/system/check_records/user_searches_with_a_valid_trn_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_trn_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe "TRN search", host: :check_records, type: :system do
     when_i_sign_in_via_dsi
     and_search_with_a_valid_trn
     then_i_see_a_teacher_record
+
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    then_i_see_my_itt_details
+    then_i_see_my_eyts_details
+    then_i_see_my_npq_details
+    then_i_see_my_mq_details
   end
 
   private
@@ -23,5 +30,45 @@ RSpec.describe "TRN search", host: :check_records, type: :system do
 
   def then_i_see_a_teacher_record
     expect(page).to have_content "Terry Walsh"
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Pass")
+    expect(page).to have_content("1 October 2022")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Date awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_my_eyts_details
+    expect(page).to have_content("Early years teacher status (EYTS)")
+    expect(page).to have_content("Date awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_my_itt_details
+    expect(page).to have_content("Initial teacher training (ITT)")
+    expect(page).to have_content("BA")
+    expect(page).to have_content("Earl Spencer Primary School")
+    expect(page).to have_content("HEI")
+    expect(page).to have_content("Business Studies")
+    expect(page).to have_content("28 January 2023")
+    expect(page).to have_content("Pass")
+    expect(page).to have_content("10 to 16 years")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("Date NPQ headteacher awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_my_mq_details
+    expect(page).to have_content("Mandatory qualification (MQ)")
+    expect(page).to have_content("Date awarded\t28 February 2023")
+    expect(page).to have_content("Specialism\tVisual impairment")
   end
 end

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def then_i_see_my_mq_details
-    expect(page).to have_content("Mandatory qualification (MQ): specialist teacher")
+    expect(page).to have_content("Mandatory qualification (MQ)")
     expect(page).to have_content("Awarded\t28 February 2023")
     expect(page).to have_content("Specialism\tVisual impairment")
   end


### PR DESCRIPTION
When a search returns a matching teacher record, we want to display the qualifications.

The display of qualifications is different to the way we show in Access so requires new components.

### Link to Trello card

https://trello.com/c/0B5ca4f7/25-add-qualification-sections-to-results-page

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
