### PR TITLE
Updates to ensure a real DSI auth journey works correctly 

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 BYPASS_DSI=true
-CHECK_RECORDS_DOMAIN=localhost
+CHECK_RECORDS_DOMAIN=check.localhost
 DFE_SIGN_IN_CLIENT_ID=tbd
 DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/check-records/auth/dfe/callback
 DFE_SIGN_IN_SECRET=override-locally

--- a/.env.development
+++ b/.env.development
@@ -1,9 +1,9 @@
 BYPASS_DSI=true
 CHECK_RECORDS_DOMAIN=check.localhost
-DFE_SIGN_IN_CLIENT_ID=tbd
-DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/check-records/auth/dfe/callback
+DFE_SIGN_IN_CLIENT_ID=checkrecordteacher
+DFE_SIGN_IN_REDIRECT_URL=http://check.localhost:3000/check-records/auth/dfe/callback
 DFE_SIGN_IN_SECRET=override-locally
-DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk
+DFE_SIGN_IN_ISSUER=https://dev-oidc.signin.education.gov.uk
 GOVUK_NOTIFY_API_KEY=override-locally
 HOSTING_DOMAIN=localhost
 HOSTING_ENVIRONMENT=local

--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  govuk_header(service_name: t("check_records_service.name"), service_url: "/check-records") do |header|
+  govuk_header(service_name: t("check_records_service.name"), service_url: check_records_root_path) do |header|
     if current_dsi_user
       header.with_navigation_item(href: check_records_sign_out_path, text: "Sign out")
     else

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -8,7 +8,7 @@ class DsiUser < ApplicationRecord
     dsi_user.update!(
       first_name: dsi_payload.info.first_name,
       last_name: dsi_payload.info.last_name,
-      uid: dsi_payload.info.uid
+      uid: dsi_payload.uid
     )
 
     dsi_user

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe DsiUser, type: :model do
   describe ".create_or_update_from_dsi" do
     let(:dsi_payload) do
-      OmniAuth::AuthHash.new(info: { email:, first_name: "John", last_name: "Doe", uid: "123456" })
+      OmniAuth::AuthHash.new(uid: "123456", info: { email:, first_name: "John", last_name: "Doe" })
     end
     let(:email) { "test@example.com" }
 
@@ -12,11 +12,11 @@ RSpec.describe DsiUser, type: :model do
 
       it "finds the existing user and updates the attributes" do
         result = described_class.create_or_update_from_dsi(dsi_payload)
+
         expect(result).to eq(existing_user)
-        updated_fields = %w[first_name last_name uid]
-        expect(result.attributes.slice(*updated_fields)).to eq(
-          dsi_payload.info.slice(*updated_fields)
-        )
+        expect(result.uid).to eq dsi_payload.uid
+        expect(result.first_name).to eq dsi_payload.info.first_name
+        expect(result.last_name).to eq dsi_payload.info.last_name
       end
     end
 
@@ -25,10 +25,11 @@ RSpec.describe DsiUser, type: :model do
         expect { described_class.create_or_update_from_dsi(dsi_payload) }.to change {
           DsiUser.count
         }.from(0).to(1)
-        updated_fields = %w[first_name last_name uid]
-        expect(DsiUser.first.attributes.slice(*updated_fields)).to eq(
-          dsi_payload.info.slice(*updated_fields)
-        )
+        dsi_user = DsiUser.first
+
+        expect(dsi_user.uid).to eq dsi_payload.uid
+        expect(dsi_user.first_name).to eq dsi_payload.info.first_name
+        expect(dsi_user.last_name).to eq dsi_payload.info.last_name
       end
     end
   end

--- a/spec/support/system/check_records/authentication_steps.rb
+++ b/spec/support/system/check_records/authentication_steps.rb
@@ -11,11 +11,11 @@ module CheckRecords
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
         {
           provider: "dfe",
+          uid: "123456",
           info: {
             email: "test@example.com",
             first_name: "Test",
-            last_name: "User",
-            uid: "123456"
+            last_name: "User"
           }
         }
       )


### PR DESCRIPTION
### Context

We now have dev/test environments set up for DSI. We should configure these and use them to test an actual authentication flow with DSI (rather than the fake developer flow that currently exists in Check).
<!-- Why are you making this change? -->

### Changes proposed in this pull request
See commit messages for a detailed summary.

The main changes going in relate to local development config so that we can test DSI auth from the local environment.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

To test a DSI auth flow:

- Get the secret from Check's DSI manage console in the DSI dev environment
- Add it to your  .env.development.local
- Set BYPASS_DSI to false
- Restart server and go to http://check.localhost:3000/check-records/sign-in
- Click the button and go through the auth flow
- You should be signed in and redirected to the Check search page
- Report any issues here

Both @felixclack and @gpeng have been added to the service in dev DSI Manage so should be able to sign in.

The test DSI environment will be used by the deployed Check environments (dev to preprod). I'm testing it currently.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/RwU8smrW
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
