### PR TITLE
Fix QTS certificate downloads

### DIFF
--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -2,6 +2,7 @@ module Qualifications
   class CertificatesController < QualificationsInterfaceController
     def show
       client = QualificationsApi::Client.new(token: session[:identity_user_token])
+
       send_data client.certificate(type: params[:id], id: params[:certificate_id]),
                 name: "#{params[:type]}_certificate.pdf",
                 content_type: "application/pdf"

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -15,6 +15,9 @@ class Qualification
   end
 
   def id
+    # QTS certificate URLs don't contain an id
+    return nil if qts?
+
     @certificate_url&.split("/")&.last
   end
 
@@ -32,5 +35,9 @@ class Qualification
 
   def npq?
     type&.downcase&.starts_with?("npq")
+  end
+
+  def qts?
+    type == :qts
   end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Qualification, type: :model do
     let(:type) { :qts }
 
     it { is_expected.to eq(:qts) }
+
     context "when the qualification type is npq" do
       let(:type) { "npq-leading-teaching" }
 
@@ -16,15 +17,22 @@ RSpec.describe Qualification, type: :model do
   end
 
   describe "#id" do
+    let(:type) { :npq }
     subject { qualification.id }
 
-    let(:qualification) { described_class.new(certificate_url:) }
+    let(:qualification) { described_class.new(certificate_url:, type:) }
     let(:certificate_url) { "https://example.com/1234" }
 
     it { is_expected.to eq("1234") }
 
     context "when certificate url is not present" do
       let(:certificate_url) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when certificate type is qts" do
+      let(:type) { :qts }
 
       it { is_expected.to be_nil }
     end


### PR DESCRIPTION

### Context
QTS download link is returning empty file
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Some code was introduced which handles certificate download URLs in a generalised way for all certificates, including code dealing with the certificate id.

QTS certificate URLs don't contain an id so this was resulting in a slightly incorrect URL being used when retrieving data from the API.

Add a conditional check in Qualifications#id specifically for QTS certificates, so that we use the correct API endpoint.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested locally by downloading the QTS cert
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
