### PR TITLE
Remove flash on successful sign in

### DIFF
--- a/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,6 @@ module Qualifications
         session[:identity_user_token_expiry] = auth.credentials.expires_at
 
         log_auth_credentials_in_development(auth)
-        flash[:notice] = "Signed in successfully."
         redirect_to qualifications_dashboard_path
       end
 

--- a/spec/system/qualifications/user_signs_in_via_identity_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_identity_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature "Identity auth", type: :system do
   private
 
   def then_i_am_signed_in_after_successfully_authenticating_with_identity
-    expect(page).to have_content "Signed in successfully"
     expect(User.last.email).to eq "test@example.com"
   end
 end


### PR DESCRIPTION
As part of the snagging session, it was identified that the flash
message was surplus to requirements.

This removes the specific message but leaves the flash mechanism so we
can still use it elsewhere.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
