### PR TITLE
Display ITT status rather than result

### DIFF
--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -59,7 +59,7 @@ class QualificationSummaryComponent < ViewComponent::Base
         }
       },
       { key: { text: "End date" }, value: { text: details.end_date&.to_date&.to_fs(:long_uk) } },
-      { key: { text: "Result" }, value: { text: details.result&.to_s&.humanize } },
+      { key: { text: "Status" }, value: { text: details.result&.to_s&.humanize } },
       { key: { text: "Age range" }, value: { text: details.age_range&.description } }
     ]
   end

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Business Studies")
     expect(page).to have_content("28 February 2022")
     expect(page).to have_content("28 January 2023")
-    expect(page).to have_content("Pass")
+    expect(page).to have_content("Status\tPass")
     expect(page).to have_content("10 to 16 years")
   end
 


### PR DESCRIPTION
The title for the ITT result needs to be re-worded.

The snagging session highlighed that rather than label the ITT result as
'Result', it is preferable to call it 'Status'.

The underlying API attribute isn't changing, this is simply a UI tweak.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
