### PR TITLE
Hide ITT row if no data

### DIFF
--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -38,6 +38,8 @@ class QualificationSummaryComponent < ViewComponent::Base
   end
 
   def itt_rows
+    return [] if details.end_date.blank?
+
     [
       { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
       { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -5,6 +5,8 @@ class FakeQualificationsApi < Sinatra::Base
     case bearer_token
     when "token"
       quals_data
+    when "no-itt-token"
+      quals_data(trn: "1234567", itt: false)
     when "invalid-token"
       halt 401
     end
@@ -79,7 +81,7 @@ class FakeQualificationsApi < Sinatra::Base
     { dateOfBirth: "2000-01-01", firstName: "Terry", lastName: "Walsh", middleName: "John", trn: }
   end
 
-  def quals_data(trn: nil)
+  def quals_data(trn: nil, itt: true)
     {
       trn: trn || "3000299",
       firstName: "Terry",
@@ -108,25 +110,32 @@ class FakeQualificationsApi < Sinatra::Base
           }
         ]
       },
-      initialTeacherTraining: [
-        {
-          ageRange: {
-            description: "10 to 16 years"
-          },
-          endDate: "2023-01-28",
-          programmeType: "HEI",
-          provider: {
-            name: "Earl Spencer Primary School",
-            ukprn: nil
-          },
-          qualification: {
-            name: "BA"
-          },
-          result: "Pass",
-          startDate: "2022-02-28",
-          subjects: [{ code: "100079", name: "business studies" }]
-        }
-      ],
+      initialTeacherTraining:
+        (
+          if !itt
+            []
+          else
+            [
+              {
+                ageRange: {
+                  description: "10 to 16 years"
+                },
+                endDate: "2023-01-28",
+                programmeType: "HEI",
+                provider: {
+                  name: "Earl Spencer Primary School",
+                  ukprn: nil
+                },
+                qualification: {
+                  name: "BA"
+                },
+                result: "Pass",
+                startDate: "2022-02-28",
+                subjects: [{ code: "100079", name: "business studies" }]
+              }
+            ]
+          end
+        ),
       mandatoryQualifications: [{ awarded: "2023-02-28", specialism: "Visual impairment" }],
       npqQualifications: [
         {

--- a/spec/system/qualifications/user_views_their_qualifications_no_itt_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_no_itt_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario "when they have no ITT", test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    then_i_see_there_are_no_itt_details
+  end
+
+  private
+
+  def given_identity_auth_is_mocked
+    OmniAuth.config.mock_auth[:identity] = OmniAuth::AuthHash.new(
+      {
+        provider: "identity",
+        info: {
+          date_of_birth: "1986-01-02",
+          email: "test@example.com",
+          family_name: "Trained",
+          given_name: "Not",
+          name: "Not Trained",
+          trn: "0000000"
+        },
+        credentials: {
+          token: "no-itt-token",
+          expires_at: (Time.zone.now + 1.hour).to_i
+        }
+      }
+    )
+  end
+
+  def then_i_see_there_are_no_itt_details
+    expect(page).not_to have_content("Initial teacher training (ITT)")
+  end
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+end


### PR DESCRIPTION
The current implementation of the qualifications view assumes that there
will always be an ITT record for a teacher.

There are scenarios where this isn't true. This results in the component
displaying with empty values, which is confusing for the user.

Instead, we want to conditionally render the ITT row only if it is
present in the returned data.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
