### PR TITLE
Change filename of downloaded certificates

### DIFF
--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -2,9 +2,11 @@ module Qualifications
   class CertificatesController < QualificationsInterfaceController
     def show
       client = QualificationsApi::Client.new(token: session[:identity_user_token])
+      certificate =
+        client.certificate(name: current_user.name, type: params[:id], id: params[:certificate_id])
 
-      send_data client.certificate(type: params[:id], id: params[:certificate_id]),
-                name: "#{params[:type]}_certificate.pdf",
+      send_data certificate.file_data,
+                filename: certificate.file_name,
                 content_type: "application/pdf"
     end
   end

--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -3,11 +3,28 @@ module Qualifications
     def show
       client = QualificationsApi::Client.new(token: session[:identity_user_token])
       certificate =
-        client.certificate(name: current_user.name, type: params[:id], id: params[:certificate_id])
+        client.certificate(
+          name: current_user.name,
+          type: certificate_type,
+          id: params[:certificate_id]
+        )
 
       send_data certificate.file_data,
                 filename: certificate.file_name,
                 content_type: "application/pdf"
+    end
+
+    private
+
+    def certificate_type
+      if params[:id].to_sym.in? QualificationsApi::Certificate::VALID_TYPES
+        params[:id]
+      else
+        raise UnrecognisedCertificateTypeError
+      end
+    end
+
+    class UnrecognisedCertificateTypeError < StandardError
     end
   end
 end

--- a/app/lib/qualifications_api/certificate.rb
+++ b/app/lib/qualifications_api/certificate.rb
@@ -1,0 +1,15 @@
+module QualificationsApi
+  class Certificate
+    attr_reader :user_name, :type, :file_data
+
+    def initialize(user_name, type, file_data)
+      @user_name = user_name
+      @type = type
+      @file_data = file_data
+    end
+
+    def file_name
+      "#{user_name}_#{type}_certificate.pdf"
+    end
+  end
+end

--- a/app/lib/qualifications_api/certificate.rb
+++ b/app/lib/qualifications_api/certificate.rb
@@ -1,5 +1,6 @@
 module QualificationsApi
   class Certificate
+    VALID_TYPES = %i[eyts induction itt mq npq qts].freeze
     attr_reader :user_name, :type, :file_data
 
     def initialize(user_name, type, file_data)

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -8,12 +8,12 @@ module QualificationsApi
       @token = token
     end
 
-    def certificate(type:, id: nil)
+    def certificate(name:, type:, id: nil)
       response = client.get(["v3/certificates/#{type}", id].compact.join("/"))
 
       case response.status
       when 200
-        response.body
+        QualificationsApi::Certificate.new(name, type, response.body)
       when 401
         raise QualificationsApi::InvalidTokenError
       end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -15,9 +15,8 @@ class Qualification
   end
 
   def id
-    # QTS certificate URLs don't contain an id
-    return nil if qts?
-
+    # QTS and EYTS certificate URLs don't contain an id
+    return nil if qts? || eyts?
     @certificate_url&.split("/")&.last
   end
 
@@ -39,5 +38,9 @@ class Qualification
 
   def qts?
     type == :qts
+  end
+
+  def eyts?
+    type == :eyts
   end
 end

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -41,16 +41,18 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
   describe "#certificate" do
     it "returns a PDF certificate" do
       client = described_class.new(token: "token")
-      response = client.certificate(type: :qts)
+      certificate = client.certificate(name: "Steven Toast", type: :qts)
 
-      expect(response).to eq "pdf data"
+      expect(certificate).to be_a(QualificationsApi::Certificate)
+      expect(certificate.file_data).to eq "pdf data"
+      expect(certificate.file_name).to eq "Steven Toast_qts_certificate.pdf"
     end
 
     context "with an invalid token" do
       it "raises an error" do
         client = described_class.new(token: "invalid-token")
 
-        expect { client.certificate(type: :qts) }.to raise_error(
+        expect { client.certificate(name: "Steven Toast", type: :qts) }.to raise_error(
           QualificationsApi::InvalidTokenError
         )
       end

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -55,13 +55,19 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "filename=\"Test User_qts_certificate.pdf\";"
+    )
   end
 
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "filename=\"Test User_eyts_certificate.pdf\";"
+    )
   end
 
   def then_i_see_my_itt_details
@@ -86,7 +92,10 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "filename=\"Test User_npq_certificate.pdf\";"
+    )
   end
 
   def then_i_see_my_mq_details


### PR DESCRIPTION
### Context
An improvement identified during snagging https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add a Certificate model to QualificationsApi to hold the file data
  and to generate the file name from arguments passed to the initializer
- Have the Client return an instance of this model rather than the raw
  certificate data
- Prepare the file download in the controller by using methods on the
  returned instance
- Update system specs to confirm the file name of various downloaded
  certificate types
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
