### PR TITLE
Use smart quotes in name

### DIFF
--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl"><%= @user.name.possessive %></span>
+    <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
     <h1 class="govuk-heading-xl">Teaching qualifications</h1>
 
     <div class="govuk-grid-row">


### PR DESCRIPTION
The name of the teacher needs to use smart quotes, inline with the
convention in other GOV.UK projects.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
