### PR TITLE
Add missing full-stop

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -51,7 +51,7 @@
             You’ll get a response within 3 working days.
           </p>
 
-          <p class="govuk-!-font-size-16">Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except public holidays)</p>
+          <p class="govuk-!-font-size-16">Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except public holidays).</p>
           <hr class="govuk-section-break govuk-section-break--l">
 
           <h2 class="govuk-visually-hidden">Footer links</h2>


### PR DESCRIPTION
The sentence detailing the availability of the helpdesk is missing a
full-stop.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
