### PR TITLE
Add a subject to the mail_to link

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -46,7 +46,7 @@
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="govuk-heading-m">Get help</h2>
           <p class="govuk-!-font-size-16">
-            Email: <%= govuk_mail_to t('service.email'), t('service.email'), class: "govuk-footer__link" %>
+            Email: <%= govuk_mail_to t('service.email'), t('service.email'), class: "govuk-footer__link", subject: t('service.name') %>
             <br>
             You’ll get a response within 3 working days.
           </p>


### PR DESCRIPTION
We want a way to define the default subject for the help email address.

The service name is an appropriate default.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
