### PR TITLE
Remove quotes from service name

### DIFF
--- a/app/views/qualifications/identity_users/show.html.erb
+++ b/app/views/qualifications/identity_users/show.html.erb
@@ -6,7 +6,7 @@
       You can change sign in and personal details in your DfE Identity account.
     </p>
     <p>
-      You use your DfE Identity account to sign in to <b>'<%= t('service.name') %>'</b>.
+      You use your DfE Identity account to sign in to <b><%= t('service.name') %></b>.
     </p>
 
       <%= govuk_link_to(


### PR DESCRIPTION
The quotes around the service name are not required.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
