### PR TITLE
Downgrade data_migrate to fix CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     cuprite (0.14.3)
       capybara (~> 3.0)
       ferrum (~> 0.13.0)
-    data_migrate (10.0.2)
+    data_migrate (9.0.0)
       activerecord (>= 6.0)
       railties (>= 6.0)
     date (3.3.3)


### PR DESCRIPTION
Gem was yanked https://github.com/ilyakatz/data-migrate/issues/267

Downgrade to 9.0.0 to get builds working again.
