### PR TITLE
Add generic OAuth failure handling

### DIFF
--- a/app/controllers/auth_failures_controller.rb
+++ b/app/controllers/auth_failures_controller.rb
@@ -1,0 +1,12 @@
+class AuthFailuresController < ApplicationController
+  def failure
+    strategy = request.env["omniauth.error.strategy"].name
+
+    case strategy
+    when :identity
+      redirect_to qualifications_dashboard_path
+    when :dfe
+      redirect_to check_records_root_path
+    end
+  end
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,6 +2,7 @@ require "check_records/dfe_sign_in"
 require "omniauth/strategies/identity"
 
 OmniAuth.config.logger = Rails.logger
+OmniAuth.config.on_failure = proc { |env| AuthFailuresController.action(:failure).call(env) }
 
 # DSI setup
 dfe_sign_in_identifier = ENV.fetch("DFE_SIGN_IN_CLIENT_ID", "example")


### PR DESCRIPTION
We need some basic error handling in the event of a failure during the OAuth flow, in both Identity and DSI auth strategies.

This commit adds a failure controller which simply redirects the user to the correct root path, depending on which auth strategy they're using.

The primary error scenario this handles is when users navigate back in their browser to a stale page on the auth provider site. These cases don't provide particularly helpful error messages, so I've elected not to display an error message to the user.


### Link to Trello card
https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
