### PR TITLE
Update how qualifications are sorted

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -15,12 +15,12 @@ module QualificationsApi
     def qualifications
       @qualifications = []
 
-      add_qts
       add_eyts
-      add_npq
-      add_itt
       add_induction
+      add_itt
       add_mandatory_qualifications
+      add_npq
+      add_qts
 
       @qualifications
         .flatten!

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -22,31 +22,34 @@ module QualificationsApi
       add_induction
       add_mandatory_qualifications
 
-      @qualifications.flatten!.sort_by!(&:awarded_at).reverse!
+      @qualifications
+        .flatten!
+        .sort_by! { |qualification| qualification.awarded_at || Date.new }
+        .reverse!
     end
 
     private
 
     def add_qts
-      if api_data.qts.present?
-        @qualifications << Qualification.new(
-          awarded_at: api_data.qts.awarded&.to_date,
-          certificate_url: api_data.qts.certificate_url,
-          name: "Qualified teacher status (QTS)",
-          type: :qts
-        )
-      end
+      return if api_data.qts.blank?
+
+      @qualifications << Qualification.new(
+        awarded_at: api_data.qts.awarded&.to_date,
+        certificate_url: api_data.qts.certificate_url,
+        name: "Qualified teacher status (QTS)",
+        type: :qts
+      )
     end
 
     def add_eyts
-      if api_data.eyts.present?
-        @qualifications << Qualification.new(
-          awarded_at: api_data.eyts.awarded&.to_date,
-          certificate_url: api_data.eyts.certificate_url,
-          name: "Early years teacher status (EYTS)",
-          type: :eyts
-        )
-      end
+      return if api_data.eyts.blank?
+
+      @qualifications << Qualification.new(
+        awarded_at: api_data.eyts.awarded&.to_date,
+        certificate_url: api_data.eyts.certificate_url,
+        name: "Early years teacher status (EYTS)",
+        type: :eyts
+      )
     end
 
     def add_npq
@@ -76,17 +79,19 @@ module QualificationsApi
     end
 
     def add_induction
-      if api_data.induction.present?
-        @qualifications << Qualification.new(
-          awarded_at: api_data.induction.end_date&.to_date,
-          details: api_data.induction,
-          name: "Induction",
-          type: :induction
-        )
-      end
+      return if api_data.induction.blank?
+
+      @qualifications << Qualification.new(
+        awarded_at: api_data.induction.end_date&.to_date,
+        details: api_data.induction,
+        name: "Induction",
+        type: :induction
+      )
     end
 
     def add_mandatory_qualifications
+      return if api_data.mandatory_qualifications.blank?
+
       @qualifications << api_data.mandatory_qualifications.map do |mq|
         Qualification.new(
           awarded_at: mq.awarded&.to_date,

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -76,5 +76,53 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     it "sorts the qualifications in reverse chronological order by date of award" do
       expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts induction mandatory itt])
     end
+
+    context "when a qualification has no awarded date" do
+      let(:api_data) do
+        {
+          "initial_teacher_training" => [
+            {
+              "qualification" => {
+                "name" => "BA"
+              },
+              "startDate" => "2012-02-28",
+              "endDate" => "2013-01-28",
+              "programmeType" => "HEI",
+              "result" => "Pass",
+              "ageRange" => {
+                "description" => "10 to 16 years"
+              },
+              "provider" => {
+                "name" => "Earl Spencer Primary School",
+                "ukprn" => nil
+              },
+              "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+            }
+          ],
+          "npqQualifications" => [
+            {
+              "type" => {
+                "code" => "NPQML",
+                "name" => "NPQ for Middle Leadership"
+              },
+              "awarded" => nil,
+              "certificateUrl" => "https://example.com/v3/certificates/456"
+            }
+          ]
+        }
+      end
+
+      it "sorts the qualifications in reverse chronological order by date of award" do
+        expect(qualifications.map(&:type)).to eq(%i[itt NPQML])
+      end
+    end
+
+    context "when there are no MQs returned" do
+      let(:api_data) { {} }
+
+      it "returns an empty array" do
+        expect(qualifications).to eq([])
+      end
+    end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -124,5 +124,38 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         expect(qualifications).to eq([])
       end
     end
+
+    context "when QTS and ITT share the same date" do
+      let(:api_data) do
+        {
+          "initialTeacherTraining" => [
+            {
+              "qualification" => {
+                "name" => "BA"
+              },
+              "startDate" => "2012-02-28",
+              "endDate" => "2013-01-28",
+              "programmeType" => "HEI",
+              "result" => "Pass",
+              "ageRange" => {
+                "description" => "10 to 16 years"
+              },
+              "provider" => {
+                "name" => "Earl Spencer Primary School",
+                "ukprn" => nil
+              },
+              "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+            }
+          ],
+          "qts" => {
+            "awarded" => "2013-01-28"
+          }
+        }
+      end
+
+      it "the QTS gets priority in the sort order" do
+        expect(qualifications.map(&:type)).to eq(%i[qts itt])
+      end
+    end
   end
 end


### PR DESCRIPTION
There are scenarios where a qualification has no associated date.

Currently, this causes the app to throw an exception as we sort
qualifications by date.

I landed on using a default value for the date in the sort function.
This allows us to position the qualifications without a date at the end
of the list, so it makes sense visually.

We don't want this date to be visible though as it is used purely for
the sort order, so I didn't set the default on the qualification itself.

Also, when the QTS and ITT qualifications share the same awarded at date,
the QTS should take priority.

### Link to Trello card

https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
