### PR TITLE
Modify authorize options in Identity strategy

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -5,12 +5,23 @@ module OmniAuth
 
       option :client_options,
              {
-               authorize_params: lambda { |request| { session_id: request.session.id } },
                authorize_url: "connect/authorize",
                end_session_uri: "connect/signout",
                site: ENV.fetch("IDENTITY_API_DOMAIN"),
                token_url: "connect/token"
              }
+      option :authorize_options, %i[scope state session_id trn_token]
+      option :trn_token,
+             lambda { |env|
+               request = Rack::Request.new(env)
+               request.params["trn_token"]
+             }
+      option :session_id,
+             lambda { |env|
+               request = Rack::Request.new(env)
+               request.session.id
+             }
+
       option :pkce, true
       option :scope, "dqt:read"
       option :post_logout_redirect_uri, "#{ENV.fetch("HOSTING_DOMAIN")}/qualifications/sign-out"


### PR DESCRIPTION

### Context
We need to send the trn_token to the authorize endpoint in Identity so that the magic links functionality works as expected (ie—so that it populates the email field automatically)

<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add trn_token to the default list of authorize_options so we can send it as a param when redirecting to the authorize endpoint
- Make the trn_token option a lambda so that we can dynamically set its value with each request
- Do the same for session_id, which was previously implemented but not working

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be manually tested, with Network tools open in your browser to observe the requests. Set a trn_token param manually on the start page. Should be set in the `authorize` call.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/1unAP0QQ/1024-access-quals-id-snags
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
