### PR TITLE
Add safe operator for displaying the induction

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -39,7 +39,7 @@ class InductionSummaryComponent < ViewComponent::Base
   def rows
     [
       { key: { text: "Status" }, value: { text: details.status.to_s.humanize } },
-      { key: { text: "Completed" }, value: { text: awarded_at.to_fs(:long_uk) } },
+      { key: { text: "Completed" }, value: { text: awarded_at&.to_fs(:long_uk) } },
       {
         key: {
           text: "Certificate"


### PR DESCRIPTION
There are scenarios where an induction qualification record has no
awarded_at value.

Currently, this is throwing an exception. We should be more lenient with
this and allow the page to render with a missing value.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
