### PR TITLE
Add support for new field, programmeTypeDescription

### DIFF
--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -37,7 +37,7 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
     [
       { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
       { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },
-      { key: { text: "Programme type" }, value: { text: details.programme_type } },
+      { key: { text: "Programme type" }, value: { text: details.programme_type_description } },
       {
         key: {
           text: "Subject"

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -43,7 +43,7 @@ class QualificationSummaryComponent < ViewComponent::Base
     [
       { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
       { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },
-      { key: { text: "Training type" }, value: { text: details.programme_type } },
+      { key: { text: "Training type" }, value: { text: details.programme_type_description } },
       {
         key: {
           text: "Subjects"

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "startDate" => "2012-02-28",
             "endDate" => "2013-01-28",
             "programmeType" => "HEI",
+            "programmeTypeDescription" => "Higher Education Institution",
             "result" => "Pass",
             "ageRange" => {
               "description" => "10 to 16 years"
@@ -88,6 +89,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
               "startDate" => "2012-02-28",
               "endDate" => "2013-01-28",
               "programmeType" => "HEI",
+              "programmeTypeDescription" => "Higher Education Institution",
               "result" => "Pass",
               "ageRange" => {
                 "description" => "10 to 16 years"
@@ -136,6 +138,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
               "startDate" => "2012-02-28",
               "endDate" => "2013-01-28",
               "programmeType" => "HEI",
+              "programmeTypeDescription" => "Higher Education Institution",
               "result" => "Pass",
               "ageRange" => {
                 "description" => "10 to 16 years"

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -122,6 +122,7 @@ class FakeQualificationsApi < Sinatra::Base
                 },
                 endDate: "2023-01-28",
                 programmeType: "HEI",
+                programmeTypeDescription: "Higher education institution",
                 provider: {
                   name: "Earl Spencer Primary School",
                   ukprn: nil

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     expect(page).to have_content("Initial teacher training (ITT)")
     expect(page).to have_content("BA")
     expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("HEI")
+    expect(page).to have_content("Higher education institution")
     expect(page).to have_content("Business Studies")
     expect(page).to have_content("28 January 2023")
     expect(page).to have_content("Pass")

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Initial teacher training (ITT)")
     expect(page).to have_content("BA")
     expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("HEI")
+    expect(page).to have_content("Higher education institution")
     expect(page).to have_content("Business Studies")
     expect(page).to have_content("28 February 2022")
     expect(page).to have_content("28 January 2023")


### PR DESCRIPTION
We want to display a human-friendly string for the programme type of an
ITT record.

The API now provides this as `programmeTypeDescription`.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
