### PR TITLE
Add issuer value to DSI config

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -23,7 +23,9 @@ options = {
     identifier: dfe_sign_in_identifier,
     secret: dfe_sign_in_secret,
     redirect_uri: dfe_sign_in_redirect_uri&.to_s
-  }
+  },
+  issuer:
+    ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
 }
 if CheckRecords::DfESignIn.bypass?
   Rails.application.config.middleware.use OmniAuth::Builder do


### PR DESCRIPTION
### Context
DSI is currently broken for the Check service, on both the dev and test environments.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
The issuer value will tell the omniauth gem where to find openid configuration data during the discovery phase. It will look for it at:

https://issuer-url/.well-known/openid-configuration

Without this, the default behaviour is to use a Webfinger endpoint, ie:

https://issuer-url/.well-known/webfinger (with some query params describing the resource)

The OIDC implementation in DSI no longer supports the Webfinger protocol, hence the switch.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested by trying to sign in to Check via either dev/test DSI locally.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
