### PR TITLE
Add organisation to the scope list in DSI omniauth config

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -13,7 +13,7 @@ options = {
   name: :dfe,
   discovery: true,
   response_type: :code,
-  scope: %i[email profile],
+  scope: %i[email profile organisation],
   path_prefix: "/check-records/auth",
   callback_path: "/check-records/auth/dfe/callback",
   client_options: {


### PR DESCRIPTION

### Context
We need to restrict access to the Check service so that only DfE staff and agencies have access. The plan is to do this by checking against a list we manage in the service, using data sent by DSI.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Adding organisation to the scope array will return data related to the organisation claim in the response from DSI after successful authentication. Specifically, in "extra"."raw_info"."organisation". The "companyRegistrationNumber" in there is what we'll use to check a hardcoded list of agencies.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/I2Wjvki4/71-update-dfe-signin-integration-to-check-against-agency-list
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
