### PR TITLE
Update Check footer to match prototype

### DIFF
--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -46,22 +46,19 @@
       <% footer.with_meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="govuk-heading-m">Get help</h2>
-          <p class="govuk-!-font-size-16">Email: <%= govuk_link_to(t('service.email'), t('service.email'), class: "govuk-footer__link") %><br>You’ll get a response within 3 working days.</p>
-
-          <p class="govuk-!-font-size-16">Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except public holidays)</p>
-          <hr class="govuk-section-break govuk-section-break--l">
+          <p class="govuk-!-font-size-16">Email: <%= govuk_link_to(t('check_records_service.email'), t('check_records_service.email'), class: "govuk-footer__link") %><br>You’ll get a response within 5 working days.</p>
 
           <h2 class="govuk-visually-hidden">Footer links</h2>
 
           <ul class="govuk-footer__inline-list">
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Accessibility", "/accessibility", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Accessibility", "", class: "govuk-footer__link") %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Cookies", "/cookies", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Cookies", "", class: "govuk-footer__link") %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Privacy notice", "/privacy", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Privacy notice", "", class: "govuk-footer__link") %>
             </li>
           </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     url: https://access-your-teaching-qualifications.digital.education.gov.uk
   check_records_service:
     name: Check the record of a teacher in England
+    email: employer.access@education.gov.uk
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com


### PR DESCRIPTION

### Context
Check's footer content should be distinct from AYTQ's but these changes haven't been made in the service yet.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Make changes so that the Check footer no longer has AYTQ-specific content, matching instead the Check prototype.

The static content for Check hasn't been done yet and will be card up to complete separately.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/Nb6kvNI8
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
