### PR TITLE
Set a default issuer value

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -12,7 +12,7 @@ if CheckRecords::DfESignIn.bypass?
              path_prefix: "/check-records/auth"
   end
 else
-  dfe_sign_in_issuer_uri = URI(ENV["DFE_SIGN_IN_ISSUER"])
+  dfe_sign_in_issuer_uri = URI(ENV.fetch("DFE_SIGN_IN_ISSUER", "example"))
 
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider :openid_connect,


### PR DESCRIPTION
We're seeing scenarios where the dev-ops processes trigger an error due
to ENV variables not being available at the time we run certain rake
tasks.

Rather than adding the value everywhere, we can set a default to allow
those rake tasks to run without an exception.