### PR TITLE
Ensure the trn_token gets passed to Identity

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -37,6 +37,7 @@ end
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :openid_connect,
            name: :identity,
+           allow_authorize_params: %i[session_id trn_token],
            callback_path: "/qualifications/users/auth/identity/callback",
            client_options: {
              host: URI(ENV["IDENTITY_API_DOMAIN"]).host,


### PR DESCRIPTION
We switched OmniAuth strategies to use the OIDC one and didn't enable
the functionality to pass through the TRN token from the magic links.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
