### PR TITLE
Make analytics low priority

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,7 +7,7 @@ production:
 :max_retries: 1
 
 :queues:
-  - analytics
   - critical
   - default
   - low
+  - analytics


### PR DESCRIPTION
We want analytics to be the lowest priority queue for sidekiq so as any backlog doesn't block other jobs.

### Context

We send analytics data using sidekiq. This will back up initially until the BigQuery config is complete.

### Changes proposed in this pull request

Make the 'analytics' queue the lowest priority.

