### PR TITLE
Set worker count to zero

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165p01-aytq",
-  "worker_count": 3,
+  "worker_count": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
   "enable_postgres_high_availability": true,
   "statuscake_ssl_contact_group": 249142,


### PR DESCRIPTION
### Context

We only use the workers to send analytics data to BigQuery. BQ isn't fully configured yet. This will allow the jobs to queue up but not be sent until we re-enable the workers. We may need to rethink this if it takes much longer to set BigQuery up.

### Changes proposed in this pull request

Temporarily deploy the service without workers

