### PR TITLE
Revert "Set worker count to zero"

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165p01-aytq",
-  "worker_count": 0,
+  "worker_count": 3,
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
   "enable_postgres_high_availability": true,
   "statuscake_ssl_contact_group": 249142,


### PR DESCRIPTION
This reverts commit e310cdd015c4ff3302d82a8e33f4cbd6e270fc7e.

Currently, something in our server setup prevents workers with a count of 0.