### PR TITLE
Use the certificate URL from the API for induction

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -51,7 +51,7 @@ class InductionSummaryComponent < ViewComponent::Base
   end
 
   def rows
-    [
+    @rows = [
       {
         key: {
           text: "Status"
@@ -67,8 +67,11 @@ class InductionSummaryComponent < ViewComponent::Base
         value: {
           text: awarded_at&.to_fs(:long_uk)
         }
-      },
-      {
+      }
+    ]
+
+    if details.certificate_url.present?
+      @rows << {
         key: {
           text: "Certificate"
         },
@@ -76,12 +79,13 @@ class InductionSummaryComponent < ViewComponent::Base
           text:
             link_to(
               "Download Induction certificate",
-              qualifications_certificate_path(:induction),
+              details.certificate_url,
               class: "govuk-link"
             )
         }
       }
-    ]
+    end
+    @rows
   end
 
   def title

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -10,7 +10,12 @@ module QualificationsApi
       ::NameOfPerson::PersonName.full("#{first_name} #{last_name}")
     end
 
-    delegate :date_of_birth, :first_name, :last_name, :middle_name, :trn, to: :api_data
+    delegate :date_of_birth,
+             :first_name,
+             :last_name,
+             :middle_name,
+             :trn,
+             to: :api_data
 
     def qualifications
       @qualifications = []
@@ -83,6 +88,7 @@ module QualificationsApi
 
       @qualifications << Qualification.new(
         awarded_at: api_data.induction.end_date&.to_date,
+        certificate_url: api_data.induction&.certificate_url,
         details: api_data.induction,
         name: "Induction",
         type: :induction


### PR DESCRIPTION
The induction record currently builds a certificate URL based on the
type.

This means that we're never sure if the certificate is actually present
or not until we hit that URL.

We can retrieve a certificate URL from the API response and rely on its
presence to indicate whether the link should be displayed in the UI.