### PR TITLE
Pause the analytics queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "rails", "~> 7.0.6"
 gem "rails_semantic_logger"
 gem "sentry-rails", "~> 5.10"
 gem "sidekiq"
+gem "sidekiq-queue-pause"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,8 +387,7 @@ GEM
     rake (13.0.6)
     rbs (2.8.4)
     redcarpet (3.6.0)
-    redis-client (0.14.1)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -471,11 +470,12 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.1.2)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
+    sidekiq-queue-pause (0.1.1)
+      sidekiq (>= 6.0, < 7.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -618,6 +618,7 @@ DEPENDENCIES
   sentry-rails (~> 5.10)
   shoulda-matchers
   sidekiq
+  sidekiq-queue-pause
   sinatra
   solargraph
   solargraph-rails

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,13 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+  Sidekiq.options[:fetch] = Sidekiq::QueuePause::PausingFetch.new(
+    Sidekiq.options
+  )
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
 end
+
+Sidekiq::QueuePause.pause(DfE::Analytics.config.queue) unless Rails.env.test?


### PR DESCRIPTION
We don't have a paid BigQuery account at the moment and this causes the
analytics events to fail.

Rather than lose these events, we want to let them accumulate in the
analytics queue and pause processing the queue until we have the paid
account ready.

<img width="1235" alt="Screenshot 2023-07-21 at 10 04 14 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/7742de1a-837c-4d70-a66a-2872a7091b7e">
