### PR TITLE
Revert "Pause the analytics queue"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "rails", "~> 7.0.6"
 gem "rails_semantic_logger"
 gem "sentry-rails", "~> 5.10"
 gem "sidekiq"
-gem "sidekiq-queue-pause"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,8 @@ GEM
     rake (13.0.6)
     rbs (2.8.4)
     redcarpet (3.6.0)
-    redis (4.8.1)
+    redis-client (0.14.1)
+      connection_pool
     regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -470,12 +471,11 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.9)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
-    sidekiq-queue-pause (0.1.1)
-      sidekiq (>= 6.0, < 7.0)
+    sidekiq (7.1.2)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -618,7 +618,6 @@ DEPENDENCIES
   sentry-rails (~> 5.10)
   shoulda-matchers
   sidekiq
-  sidekiq-queue-pause
   sinatra
   solargraph
   solargraph-rails

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,13 +2,8 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
-  Sidekiq.options[:fetch] = Sidekiq::QueuePause::PausingFetch.new(
-    Sidekiq.options
-  )
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
 end
-
-Sidekiq::QueuePause.pause(DfE::Analytics.config.queue) unless Rails.env.test?


### PR DESCRIPTION
This reverts commit 74ef79e12fd9a2bb3ea9a71e59701ad820dfce97.

We no longer need this as the worker count is currently being used to
provide the same functionality.