### PR TITLE
Update oauth failure handling

### DIFF
--- a/app/controllers/auth_failures_controller.rb
+++ b/app/controllers/auth_failures_controller.rb
@@ -1,12 +1,28 @@
 class AuthFailuresController < ApplicationController
+  class OpenIdConnectProtocolError < StandardError; end
+
   def failure
     strategy = request.env["omniauth.error.strategy"].name
 
     case strategy
     when :identity
-      redirect_to qualifications_dashboard_path
+      handle_failure_then_redirect_to qualifications_sign_in_path
     when :dfe
-      redirect_to check_records_root_path
+      handle_failure_then_redirect_to check_records_sign_in_path
     end
+  end
+
+  private
+
+  def handle_failure_then_redirect_to(path)
+    error_message = request.env["omniauth.error"]&.message
+    oidc_error = OpenIdConnectProtocolError.new(error_message)
+    unless Rails.env.development?
+      Sentry.capture_exception(oidc_error)
+      flash[:warning] = I18n.t("validation_errors.generic_oauth_failure")
+      redirect_to(path) and return
+    end
+
+    raise oidc_error
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com
+    generic_oauth_failure: There was a problem signing you in. Please try again.
 
   activemodel:
     errors:

--- a/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication", host: :check_records, type: :system do
+  include AuthorizationSteps
+  include CheckRecords::AuthenticationSteps
+
+  before do
+    when_i_am_authorized_with_basic_auth
+    allow(Sentry).to receive(:capture_exception)
+  end
+
+  scenario "User has oauth error when signing in", test: :with_stubbed_auth do
+    given_dsi_auth_is_mocked_with_a_failure
+    when_i_visit_the_sign_in_page
+    and_click_the_dsi_sign_in_button
+    then_i_see_a_sign_in_error
+  end
+
+  private
+
+  def given_dsi_auth_is_mocked_with_a_failure
+    OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
+  end
+
+  def then_i_see_a_sign_in_error
+    expect(page).to have_content "There was a problem signing you in. Please try again."
+  end
+end


### PR DESCRIPTION


### Context
When there's an error during the oauth flow, currently we suppress the error and simply redirect the user to a root path in either AYTQ or Check.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Instead, do the following:

- Capture some detail about what the error was and wrap this in a custom exception
- In non-development environments:
  * Send the exception to Sentry
  * Set a flash message
  * Redirect to an appropriate path
- In development, simply raise the error so its easily inspected when making changes to the authentication flow

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested locally. To simulate an error, sign in to either Check/AYTQ. After being returned to the service, click back and try and resubmit the request on the auth provider site (eg—press continue, or resubmit the POST when prompted by your browser).

You should still see an exception in dev. Flipping the conditional check on the environment and trying  again should result in a flash message instead.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/UXNNKM6y
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
