### PR TITLE
Add static content for Check service

### DIFF
--- a/app/controllers/check_records/static_controller.rb
+++ b/app/controllers/check_records/static_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CheckRecords
+  class StaticController < CheckRecordsController
+    skip_before_action :authenticate_dsi_user!
+    skip_before_action :handle_expired_session!
+  end
+end

--- a/app/views/check_records/static/accessibility.html.md
+++ b/app/views/check_records/static/accessibility.html.md
@@ -1,0 +1,71 @@
+<% content_for :page_title, 'Accessibility statement' %>
+
+# Accessibility statement
+
+This statement applies to the <%= t('check_records_service.name') %> service.
+
+This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- navigate most of the service using just a keyboard
+- navigate most of the service using speech recognition
+  software
+- listen to most of the service using a screen reader (including the most recent
+  versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the text in the service as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device
+easier to use if you have a disability.
+
+## How accessible this service is
+
+All parts of this service are fully accessible.
+
+## Reporting accessibility problems with this service
+
+We are always looking to improve the accessibility of this service.
+
+If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:
+
+Email: <a href="mailto:<%=
+t('service.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
+t('service.email') %></a>
+
+<a class="govuk-link" href="http://www.w3.org/WAI/users/inaccessible">Read tips on contacting organisations about inaccessible websites</a>
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing
+the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+Accessibility Regulations 2018 (the ‘accessibility regulations’).
+
+If you’re not happy with how we respond to your complaint, contact [the
+Equality Advisory and Support Service
+(EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this service’s accessibility
+
+The Department for Education is committed to making this service accessible, in
+accordance with the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.
+
+### Disproportionate burden
+
+Not applicable
+
+### Content not within scope of this accessibility statement
+
+Not applicable
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 12 June 2023.

--- a/app/views/check_records/static/cookies.md
+++ b/app/views/check_records/static/cookies.md
@@ -1,0 +1,36 @@
+<% content_for :page_title, 'Cookies' %>
+
+# Cookies
+
+Cookies are small files saved on your phone, tablet or computer when you visit
+a website.
+
+We use cookies to store information about how you use <%= t('check_records_service.name') %>, such as the pages you visit.
+
+## Essential cookies
+
+Essential cookies keep your information secure while you use the service. We do not need to ask permission to use them.
+
+<table class="govuk-table">
+  <caption class="govuk-visually-hidden">Essential cookies</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Name</th>
+      <th class="govuk-table__header">Purpose</th>
+      <th class="govuk-table__header">Expires</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+      _access_your_teaching_qualifications_session
+      </td>
+      <td class="govuk-table__cell">
+        Keeps you signed in
+      </td>
+      <td class="govuk-table__cell">
+        When the session ends
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/check_records/static/privacy.md
+++ b/app/views/check_records/static/privacy.md
@@ -2,7 +2,7 @@
 
 ## Privacy notice
 
-When you use the <%= t('service.name') %> service, DfE (Department for Education) processes some of your personal data.
+When you use the <%= t('check_records_service.name') %> service, DfE (Department for Education) processes some of your personal data.
 
 DfE is the data controller for your information, as defined by data protection law.
 
@@ -10,21 +10,16 @@ DfE is referred to as ‘we’, ‘us’ and ‘our’ in this privacy policy.
 
 ### What personal data we process
 
-When you create a DfE Identity account, we collect the following information about you:
+When you create a DfE Sign-in account, we collect the following information about you:
 
 - name
 - email address
-- mobile phone number
-- date of birth
-- National Insurance number
-- initial teacher training (ITT) provider - where you gained qualified teacher status(QTS) or early years teacher status (EYTS).
-- teacher reference number (TRN)
 
 ### How we use your personal data
 
-We use your personal data collected for the DfE Identity account to give you access to your teaching qualifications and certificates in the Access your teaching qualifications service.
+We use your personal data collected for the DfE Identity account to give you access to teacher records.
 
-We also use your data in Access your teaching qualifications to:
+We also use your data in <%= t('check_records_service.name') %> to:
 
 - help us inform government policy to improve education
 - improve the service - we may ask you to participate in user research. Your participation in research or survey activity is entirely voluntary.
@@ -41,7 +36,7 @@ We use Zendesk to manage and respond to your queries.
 
 #### Hosting services
 
-We host the <%= t('service.name') %> service on Microsoft Azure. Your data is encrypted to prevent it from being accessed by unauthorised people.
+We host the <%= t('check_records_service.name') %> service on Microsoft Azure. Your data is encrypted to prevent it from being accessed by unauthorised people.
 
 ### How long we keep your personal data for
 
@@ -61,7 +56,7 @@ Under the Data Protection Act 2018, you have the right to:
 
 ### Get help
 
-<a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen">Contact the Department for Education</a> if you want to ask us to remove your data or you want access to the data we have about you.
+[Contact the Department for Education](mailto:data.protection@education.gov.uk) if you want to ask us to remove your data or you want access to the data we have about you.
 
 For further information, or to raise a concern, visit the <a href="https://ico.org.uk/">Information Commissioner’s Office</a>.
 

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -38,7 +38,11 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-        <%= yield %>
+        <% if content_for?(:two_thirds) %>
+          <%= yield(:two_thirds)%>
+        <% else %>
+          <%= yield %>
+        <% end %>
       </main>
     </div>
 

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -52,13 +52,13 @@
 
           <ul class="govuk-footer__inline-list">
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Accessibility", "", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Accessibility", check_records_accessibility_path, class: "govuk-footer__link") %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Cookies", "", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Cookies", check_records_cookies_path, class: "govuk-footer__link") %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Privacy notice", "", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Privacy notice", check_records_privacy_path, class: "govuk-footer__link") %>
             </li>
           </ul>
 

--- a/app/views/layouts/check_records_two_thirds.html.erb
+++ b/app/views/layouts/check_records_two_thirds.html.erb
@@ -1,0 +1,9 @@
+<% content_for :two_thirds do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= yield %>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/check_records_layout' %>

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,1 +1,5 @@
-<%= render template: 'layouts/application' %>
+<% content_for :content do %>
+  <%= yield %>
+<% end %>
+
+<%= render template: 'layouts/base' %>

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 namespace :check_records, path: "check-records" do
+  get "/accessibility", to: "static#accessibility"
+  get "/cookies", to: "static#cookies"
+  get "/privacy", to: "static#privacy"
+
   get "/sign-in", to: "sign_in#new"
   get "/sign-out", to: "sign_out#new"
 


### PR DESCRIPTION
### Context
The links in the footer don't point to anything currently.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Adapt the AYTQ ones to create equivalent pages for Check
- Link to these from the footer

Also includes some changes to support two thirds layout in the Check service.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/ygJB9yfN
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
