### PR TITLE
Use the provided certificate URL

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -5,7 +5,7 @@ class InductionSummaryComponent < ViewComponent::Base
 
   attr_accessor :qualification
 
-  delegate :awarded_at, :details, :name, to: :qualification
+  delegate :awarded_at, :certificate_type, :details, :name, to: :qualification
 
   def detail_classes
     "app__induction-details"
@@ -79,7 +79,10 @@ class InductionSummaryComponent < ViewComponent::Base
           text:
             link_to(
               "Download Induction certificate",
-              details.certificate_url,
+              qualifications_certificate_path(
+                certificate_type,
+                certificate_url: details.certificate_url
+              ),
               class: "govuk-link"
             )
         }

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -5,14 +5,23 @@ class QualificationSummaryComponent < ViewComponent::Base
 
   attr_accessor :qualification
 
-  delegate :awarded_at, :certificate_type, :details, :id, :itt?, :name, :type, to: :qualification
+  delegate :awarded_at,
+           :certificate_type,
+           :details,
+           :id,
+           :itt?,
+           :name,
+           :type,
+           to: :qualification
 
   alias_method :title, :name
 
   def rows
     return itt_rows if itt?
 
-    @rows = [{ key: { text: "Awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }]
+    @rows = [
+      { key: { text: "Awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }
+    ]
 
     if qualification.certificate_url
       @rows << {
@@ -23,7 +32,10 @@ class QualificationSummaryComponent < ViewComponent::Base
           text:
             link_to(
               "Download #{type.to_s.upcase} certificate",
-              qualifications_certificate_path(certificate_type, certificate_id: id),
+              qualifications_certificate_path(
+                certificate_type,
+                certificate_url: qualification.certificate_url
+              ),
               class: "govuk-link"
             )
         }
@@ -31,7 +43,14 @@ class QualificationSummaryComponent < ViewComponent::Base
     end
 
     if details.specialism
-      @rows << { key: { text: "Specialism" }, value: { text: details.specialism } }
+      @rows << {
+        key: {
+          text: "Specialism"
+        },
+        value: {
+          text: details.specialism
+        }
+      }
     end
 
     @rows
@@ -41,15 +60,37 @@ class QualificationSummaryComponent < ViewComponent::Base
     return [] if details.end_date.blank?
 
     [
-      { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
-      { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },
-      { key: { text: "Training type" }, value: { text: details.programme_type_description } },
+      {
+        key: {
+          text: "Qualification"
+        },
+        value: {
+          text: details.dig(:qualification, :name)
+        }
+      },
+      {
+        key: {
+          text: "ITT provider"
+        },
+        value: {
+          text: details.dig(:provider, :name)
+        }
+      },
+      {
+        key: {
+          text: "Training type"
+        },
+        value: {
+          text: details.programme_type_description
+        }
+      },
       {
         key: {
           text: "Subjects"
         },
         value: {
-          text: details.subjects.map { |subject| subject.name.titleize }.join(", ")
+          text:
+            details.subjects.map { |subject| subject.name.titleize }.join(", ")
         }
       },
       {
@@ -60,9 +101,30 @@ class QualificationSummaryComponent < ViewComponent::Base
           text: details.start_date&.to_date&.to_fs(:long_uk)
         }
       },
-      { key: { text: "End date" }, value: { text: details.end_date&.to_date&.to_fs(:long_uk) } },
-      { key: { text: "Status" }, value: { text: details.result&.to_s&.humanize } },
-      { key: { text: "Age range" }, value: { text: details.age_range&.description } }
+      {
+        key: {
+          text: "End date"
+        },
+        value: {
+          text: details.end_date&.to_date&.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
+          text: "Status"
+        },
+        value: {
+          text: details.result&.to_s&.humanize
+        }
+      },
+      {
+        key: {
+          text: "Age range"
+        },
+        value: {
+          text: details.age_range&.description
+        }
+      }
     ]
   end
 end

--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -7,7 +7,7 @@ module Qualifications
         client.certificate(
           name: current_user.name,
           type: certificate_type,
-          id: params[:certificate_id]
+          url: params[:certificate_url]
         )
 
       if certificate

--- a/app/lib/qualifications_api/certificate.rb
+++ b/app/lib/qualifications_api/certificate.rb
@@ -1,16 +1,12 @@
 module QualificationsApi
   class Certificate
-    VALID_TYPES = %i[eyts induction itt mq npq qts].freeze
-    attr_reader :user_name, :type, :file_data
+    include ActiveModel::Model
 
-    def initialize(user_name, type, file_data)
-      @user_name = user_name
-      @type = type
-      @file_data = file_data
-    end
+    VALID_TYPES = %i[eyts induction itt mq npq qts].freeze
+    attr_accessor :name, :type, :file_data
 
     def file_name
-      "#{user_name}_#{type}_certificate.pdf"
+      "#{name}_#{type}_certificate.pdf"
     end
   end
 end

--- a/spec/lib/qualifications_api/certificate_spec.rb
+++ b/spec/lib/qualifications_api/certificate_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe QualificationsApi::Certificate, type: :model do
+  describe "#file_name" do
+    subject { described_class.new(name:, type:, file_data:).file_name }
+
+    let(:file_data) { "pdf data" }
+    let(:name) { "Steven Toast" }
+    let(:type) { "qts" }
+
+    it { is_expected.to eq("Steven Toast_qts_certificate.pdf") }
+  end
+end

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
       it "raises an error" do
         client = described_class.new(token: "invalid-token")
 
-        expect { client.teacher }.to raise_error(QualificationsApi::InvalidTokenError)
+        expect { client.teacher }.to raise_error(
+          QualificationsApi::InvalidTokenError
+        )
       end
     end
 
@@ -39,21 +41,38 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
   end
 
   describe "#certificate" do
-    it "returns a PDF certificate" do
-      client = described_class.new(token: "token")
-      certificate = client.certificate(name: "Steven Toast", type: :qts)
+    subject(:certificate) do
+      described_class.new(token:).certificate(name:, type:, url:)
+    end
 
-      expect(certificate).to be_a(QualificationsApi::Certificate)
+    let(:name) { "Steven Toast" }
+    let(:token) { "token" }
+    let(:type) { :qts }
+    let(:url) { "/v3/certificates/qts" }
+
+    it { is_expected.to be_a(QualificationsApi::Certificate) }
+
+    it "returns a PDF certificate" do
       expect(certificate.file_data).to eq "pdf data"
       expect(certificate.file_name).to eq "Steven Toast_qts_certificate.pdf"
     end
 
     context "with an invalid token" do
-      it "raises an error" do
-        client = described_class.new(token: "invalid-token")
+      let(:token) { "invalid-token" }
 
-        expect { client.certificate(name: "Steven Toast", type: :qts) }.to raise_error(
+      it "raises an error" do
+        expect { certificate }.to raise_error(
           QualificationsApi::InvalidTokenError
+        )
+      end
+    end
+
+    context "with an invalid certificate url" do
+      let(:url) { "/some/invalid/url" }
+
+      it "raises an error" do
+        expect { certificate }.to raise_error(
+          QualificationsApi::InvalidCertificateUrlError
         )
       end
     end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -39,30 +39,6 @@ class FakeQualificationsApi < Sinatra::Base
     end
   end
 
-  get "/v3/certificates/qts" do
-    content_type "application/pdf"
-    attachment "qts_certificate.pdf"
-
-    case bearer_token
-    when "token"
-      "pdf data"
-    when "invalid-token"
-      halt 401
-    end
-  end
-
-  get "/v3/certificates/eyts" do
-    content_type "application/pdf"
-    attachment "eyts_certificate.pdf"
-
-    case bearer_token
-    when "token"
-      "pdf data"
-    when "invalid-token"
-      halt 401
-    end
-  end
-
   get "/v3/certificates/npq/:id" do
     content_type "application/pdf"
     attachment "npq_certificate.pdf"
@@ -74,6 +50,18 @@ class FakeQualificationsApi < Sinatra::Base
       else
         "pdf data"
       end
+    when "invalid-token"
+      halt 401
+    end
+  end
+
+  get "/v3/certificates/:id" do
+    content_type "application/pdf"
+    attachment "#{params[:id]}_certificate.pdf"
+
+    case bearer_token
+    when "token"
+      "pdf data"
     when "invalid-token"
       halt 401
     end
@@ -108,7 +96,7 @@ class FakeQualificationsApi < Sinatra::Base
         startDate: "2022-09-01",
         endDate: "2022-10-01",
         status: "pass",
-        certificateUrl: trn ? nil : "string",
+        certificateUrl: "/v3/certificates/induction",
         periods: [
           {
             startDate: "2022-09-01",

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -4,12 +4,14 @@ RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "when they have qualifications", test: %i[with_stubbed_auth with_fake_quals_api] do
+  scenario "when they have qualifications",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
     then_i_see_my_induction_details
+    and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
     then_i_see_my_itt_details
@@ -38,6 +40,17 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Number of terms\t1")
   end
 
+  def and_my_induction_certificate_is_downloadable
+    click_on "Download Induction certificate"
+    expect(page.response_headers["Content-Type"]).to eq("application/pdf")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "attachment"
+    )
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "filename=\"Test User_induction_certificate.pdf\""
+    )
+  end
+
   def then_i_see_my_qts_details
     expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Awarded")
@@ -55,7 +68,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "attachment"
+    )
     expect(page.response_headers["Content-Disposition"]).to include(
       "filename=\"Test User_qts_certificate.pdf\";"
     )
@@ -64,7 +79,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "attachment"
+    )
     expect(page.response_headers["Content-Disposition"]).to include(
       "filename=\"Test User_eyts_certificate.pdf\";"
     )
@@ -92,7 +109,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
     expect(page.response_headers["Content-Type"]).to eq("application/pdf")
-    expect(page.response_headers["Content-Disposition"]).to include("attachment")
+    expect(page.response_headers["Content-Disposition"]).to include(
+      "attachment"
+    )
     expect(page.response_headers["Content-Disposition"]).to include(
       "filename=\"Test User_npq_certificate.pdf\";"
     )


### PR DESCRIPTION
Currently we construct the URL for a certificate by using the
certificate type.

There are reports from users of 404 pages and the exceptions point to a
timeout when fetching a certificate.

The working theory is that we're constructing a URL that doesn't exist
and so the API call hits the timeout.

There's no reason to construct the certificate URL in this fashion as
the API returns the path if the certificate is present.

We can rely on this provided value instead.