### PR TITLE
Redirect on missing certificate

### DIFF
--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -1,7 +1,8 @@
 module Qualifications
   class CertificatesController < QualificationsInterfaceController
     def show
-      client = QualificationsApi::Client.new(token: session[:identity_user_token])
+      client =
+        QualificationsApi::Client.new(token: session[:identity_user_token])
       certificate =
         client.certificate(
           name: current_user.name,
@@ -9,9 +10,14 @@ module Qualifications
           id: params[:certificate_id]
         )
 
-      send_data certificate.file_data,
-                filename: certificate.file_name,
-                content_type: "application/pdf"
+      if certificate
+        send_data certificate.file_data,
+                  filename: certificate.file_name,
+                  content_type: "application/pdf"
+      else
+        redirect_to qualifications_dashboard_path,
+                    alert: "Certificate not found"
+      end
     end
 
     private

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -69,7 +69,11 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
-      "pdf data"
+      if params[:id] == "missing"
+        halt 404
+      else
+        "pdf data"
+      end
     when "invalid-token"
       halt 401
     end
@@ -78,7 +82,13 @@ class FakeQualificationsApi < Sinatra::Base
   private
 
   def teacher_data(trn: "1234567")
-    { dateOfBirth: "2000-01-01", firstName: "Terry", lastName: "Walsh", middleName: "John", trn: }
+    {
+      dateOfBirth: "2000-01-01",
+      firstName: "Terry",
+      lastName: "Walsh",
+      middleName: "John",
+      trn:
+    }
   end
 
   def quals_data(trn: nil, itt: true)
@@ -88,11 +98,11 @@ class FakeQualificationsApi < Sinatra::Base
       lastName: "Walsh",
       eyts: {
         awarded: "2022-04-01",
-        certificateUrl: trn ? nil : "http://example.com/v3/certificates/eyts"
+        certificateUrl: trn ? nil : "/v3/certificates/eyts"
       },
       qts: {
         awarded: "2023-02-27",
-        certificateUrl: trn ? nil : "http://example.com/v3/certificates/qts"
+        certificateUrl: trn ? nil : "/v3/certificates/qts"
       },
       induction: {
         startDate: "2022-09-01",
@@ -137,7 +147,9 @@ class FakeQualificationsApi < Sinatra::Base
             ]
           end
         ),
-      mandatoryQualifications: [{ awarded: "2023-02-28", specialism: "Visual impairment" }],
+      mandatoryQualifications: [
+        { awarded: "2023-02-28", specialism: "Visual impairment" }
+      ],
       npqQualifications: [
         {
           awarded: "2023-02-27",
@@ -145,6 +157,14 @@ class FakeQualificationsApi < Sinatra::Base
           type: {
             code: "NPQH",
             name: "NPQ headteacher"
+          }
+        },
+        {
+          awarded: "2023-01-27",
+          certificateUrl: "/v3/certificates/npq/missing",
+          type: {
+            code: "NPQSL",
+            name: "NPQ senior leadership"
           }
         }
       ]

--- a/spec/system/qualifications/user_views_a_missing_certificate_spec.rb
+++ b/spec/system/qualifications/user_views_a_missing_certificate_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "User views their certificates", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario "when a certificate is missing",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    and_my_npqsl_certificate_is_missing
+    then_i_see_the_dashboard_with_a_missing_certificate_alert
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def and_my_npqsl_certificate_is_missing
+    click_on "Download NPQSL certificate"
+  end
+
+  def then_i_see_the_dashboard_with_a_missing_certificate_alert
+    expect(page).to have_content("Certificate not found")
+  end
+end


### PR DESCRIPTION
When the certificate is missing, we currently show a 404 page.

This is a bad experience for users and instead we can catch this and
display an alert describing the problem.

<img width="1031" alt="Screenshot 2023-08-01 at 11 34 08 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/6e24fc83-62ac-413c-abd1-ef911fa9f077">
