### PR TITLE
Remove 'test' from the deployment matrix

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -82,7 +82,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             DEPLOYMENT_MATRIX="{ 'environment': ['${{ github.event.inputs.environment }}'] }"
           else
-            DEPLOYMENT_MATRIX="{ 'environment': ['dev', 'test', 'preprod'] }"
+            DEPLOYMENT_MATRIX="{ 'environment': ['dev', 'preprod'] }"
           fi
           echo "deployment_matrix=$DEPLOYMENT_MATRIX" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Context

We're going to use 'test' for a pentest next week so don't want to deploy to it. This can be reverted once the test is complete.
