### PR TITLE
Fetch the higher education qualifications from the API

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -39,6 +39,7 @@ module QualificationsApi
           endpoint,
           {
             include: %w[
+              HigherEducationQualifications
               Induction
               InitialTeacherTraining
               NpqQualifications

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -26,6 +26,7 @@ module QualificationsApi
       add_mandatory_qualifications
       add_npq
       add_qts
+      add_higher_education_qualifications
 
       @qualifications
         .flatten!
@@ -104,6 +105,19 @@ module QualificationsApi
           details: mq,
           name: "Mandatory qualification (MQ)",
           type: :mandatory
+        )
+      end
+    end
+
+    def add_higher_education_qualifications
+      return if api_data.higher_education_qualifications.blank?
+
+      @qualifications << api_data.higher_education_qualifications.map do |heq|
+        Qualification.new(
+          awarded_at: heq.awarded&.to_date,
+          details: heq,
+          name: heq.name,
+          type: :higher_education
         )
       end
     end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     let(:teacher) { described_class.new(api_data) }
 
     it "sorts the qualifications in reverse chronological order by date of award" do
-      expect(qualifications.map(&:type)).to eq(%i[NPQSL NPQML eyts qts induction mandatory itt])
+      expect(qualifications.map(&:type)).to eq(
+        %i[NPQSL NPQML eyts qts induction mandatory itt]
+      )
     end
 
     context "when a qualification has no awarded date" do
@@ -98,7 +100,9 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
                 "name" => "Earl Spencer Primary School",
                 "ukprn" => nil
               },
-              "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+              "subjects" => [
+                { "code" => "100079", "name" => "business studies" }
+              ]
             }
           ],
           "npqQualifications" => [
@@ -147,7 +151,9 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
                 "name" => "Earl Spencer Primary School",
                 "ukprn" => nil
               },
-              "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+              "subjects" => [
+                { "code" => "100079", "name" => "business studies" }
+              ]
             }
           ],
           "qts" => {
@@ -158,6 +164,30 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
       it "the QTS gets priority in the sort order" do
         expect(qualifications.map(&:type)).to eq(%i[qts itt])
+      end
+    end
+
+    context "when a Higher Education qualification is returned" do
+      let(:api_data) do
+        {
+          "higherEducationQualifications" => [
+            {
+              "name" => "Some Qualification",
+              "awarded" => "2022-2-22",
+              "subjects" => [
+                { "code" => "100079", "name" => "Business Studies" }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "creates a qualification with the correct attributes" do
+        expect(qualifications.first).to have_attributes(
+          type: :higher_education,
+          name: "Some Qualification",
+          awarded_at: Date.parse("2022-2-22")
+        )
       end
     end
   end


### PR DESCRIPTION
The API can provide details on a user's higher education qualifications.

This change adds support for fetching these qualifications. It doesn't
add the UI for displaying them.

### Link to Trello card



### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
