### PR TITLE
Add smoke tests for AYTQ and Check

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,11 +1,11 @@
 BYPASS_DSI=true
-CHECK_RECORDS_DOMAIN=check.localhost
+CHECK_RECORDS_DOMAIN=http://check.localhost:3000
 DFE_SIGN_IN_CLIENT_ID=checkrecordteacher
 DFE_SIGN_IN_REDIRECT_URL=http://check.localhost:3000/check-records/auth/dfe/callback
 DFE_SIGN_IN_SECRET=override-locally
 DFE_SIGN_IN_ISSUER=https://dev-oidc.signin.education.gov.uk
 GOVUK_NOTIFY_API_KEY=override-locally
-HOSTING_DOMAIN=http://localhost
+HOSTING_DOMAIN=http://localhost:3000
 HOSTING_ENVIRONMENT=local
 IDENTITY_API_DOMAIN=override-locally
 IDENTITY_CLIENT_ID=access-your-teaching-certificates

--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -22,6 +22,9 @@ outputs:
   environment_url:
     description: The base URL for the deployed environment
     value: ${{ steps.terraform.outputs.app_fqdn }}
+  check_service_url:
+    description: The base URL for the Check service in the deployed environment
+    value: ${{ steps.terraform.outputs.app_check_service_fqdn }}
 
 runs:
   using: composite
@@ -124,6 +127,7 @@ runs:
           echo ${o}=$(jq -r .${o}.value <<< "$TFOUTPUTS") >> $GITHUB_ENV
         done
         echo "app_fqdn=$(terraform output -raw app_fqdn)" >>$GITHUB_OUTPUT
+        echo "app_check_service_fqdn=$(terraform output -raw app_check_service_fqdn)" >>$GITHUB_OUTPUT
       env:
         ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,51 @@
+name: Run smoke test
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  azure_credentials:
+    description: JSON object containing a service principal that can read from Azure Key Vault
+    required: true
+  url:
+    description: Sets the HOSTING_DOMAIN environment variable
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ inputs.azure_credentials }}
+
+    - uses: ./.github/actions/prepare-app-env
+
+    # Set environment variables
+    - run: |
+        tf_vars_file=terraform/workspace_variables/${{ inputs.environment }}.tfvars.json
+        echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+      shell: bash
+
+    - uses: DfE-Digital/keyvault-yaml-secret@v1
+      id: keyvault-yaml-secret
+      with:
+        keyvault: ${{ env.KEY_VAULT_NAME }}
+        secret: INFRASTRUCTURE
+        key: GOVUK_NOTIFY_API_KEY,SUPPORT_USERNAME,SUPPORT_PASSWORD
+
+    # Run deployment smoke test
+    - uses: nick-fields/retry@v2.8.3
+      with:
+        max_attempts: 5
+        timeout_minutes: 3
+        command: bin/smoke
+        shell: bash
+      env:
+        HOSTING_DOMAIN: ${{ inputs.url }}
+        CHECK_RECORDS_DOMAIN: ${{ inputs.check_url }}
+        HOSTING_ENVIRONMENT_NAME: ${{ inputs.environment }}
+        # GOVUK_NOTIFY_API_KEY: ${{ steps.keyvault-yaml-secret.outputs.GOVUK_NOTIFY_API_KEY }}
+        SUPPORT_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_USERNAME }}
+        SUPPORT_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_PASSWORD }}
+        CUPRITE_TIMEOUT: 60

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -112,6 +112,14 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           site_up_retries: 120
 
+      - uses: ./.github/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: ${{ matrix.environment }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          url: ${{ steps.deploy.outputs.environment_url }}
+          check_url: ${{ steps.deploy.outputs.check_service_url }}
+
   deploy_prod:
     name: Deploy to production environment
     runs-on: ubuntu-latest

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--tag ~smoke_test

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,5 @@ azure-cli 2.48.1
 nodejs 19.6.0
 postgres 13.5
 ruby 3.2.1
+terraform 1.5.4
 yarn 1.22.19

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec rspec spec/system/smoke_spec.rb --tag smoke_test

--- a/spec/system/check_records/user_searches_with_invalid_values_spec.rb
+++ b/spec/system/check_records/user_searches_with_invalid_values_spec.rb
@@ -40,13 +40,17 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_the_missing_dob_error
-    expect(
-      page
-    ).to have_content "Date of birth\nError: \nEnter a valid date of birth"
+    within "#search-date-of-birth-error" do
+      expect(page).to have_content "Error:"
+      expect(page).to have_content "Enter a valid date of birth"
+    end
   end
 
   def then_i_see_the_missing_name_error
-    expect(page).to have_content "Last name\nError: \nEnter a last name"
+    within "#search-last-name-error" do
+      expect(page).to have_content "Error:"
+      expect(page).to have_content "Enter a last name"
+    end
   end
 
   def then_the_search_is_successful

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "capybara/rspec"
+require "capybara/cuprite"
+require "pry-nav"
+
+Capybara.javascript_driver = :cuprite
+
+TEST_ENVIRONMENTS = "local dev test preprod review"
+
+# If developing these tests locally, run them by:
+# - sourcing the env vars in .env.development
+# - running bin/smoke
+
+RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
+  describe "Access your teaching qualifications" do
+    before do
+      Capybara.app_host = ENV["HOSTING_DOMAIN"]
+    end
+
+    it "AYTQ works as expected" do
+      when_i_visit_the_aytq_service
+      then_i_see_the_aytq_service
+    end
+
+    it "/health/all returns 200" do
+      when_i_visit_the_aytq_service(endpoint: "/health/all")
+      puts "HEALTHCHECK:"
+      puts page.text
+      expect(page.status_code).to eq(200)
+    end
+  end
+
+  describe "Check the record of a teacher in England" do
+    before do
+      Capybara.app_host = ENV["CHECK_RECORDS_DOMAIN"]
+    end
+
+    it "Check works as expected" do
+      when_i_visit_the_check_service
+      then_i_see_the_check_service
+    end
+  end
+
+  private
+
+  def when_i_visit_the_aytq_service(endpoint: "")
+    username = ENV["SUPPORT_USERNAME"]
+    password = ENV["SUPPORT_PASSWORD"]
+    page.driver.basic_authorize(username, password)
+    page.visit(ENV["HOSTING_DOMAIN"] + endpoint)
+  end
+
+  def when_i_visit_the_check_service
+    username = ENV["SUPPORT_USERNAME"]
+    password = ENV["SUPPORT_PASSWORD"]
+    page.driver.basic_authorize(username, password)
+    page.visit(ENV["CHECK_RECORDS_DOMAIN"])
+  end
+
+  def then_i_see_the_check_service
+    expect(page).to have_content "Check the record of a teacher in England"
+    expect(page).to have_content "Sign in"
+  end
+
+  def then_i_see_the_aytq_service
+    expect(page).to have_content "Access your teaching qualifications"
+    expect(page).to have_content "Start now"
+  end
+end

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -2,6 +2,10 @@ output "app_fqdn" {
   value = "https://${var.domain != null ? var.domain : azurerm_linux_web_app.aytq-app.default_hostname}"
 }
 
+output "app_check_service_fqdn" {
+  value = "https://${var.check_domain != null ? var.check_domain : azurerm_linux_web_app.aytq-app.default_hostname}"
+}
+
 output "app_resource_group_name" {
   value = data.azurerm_resource_group.group.name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,6 +123,12 @@ variable "statuscake_alerts" {
 
 variable "domain" {
   default = null
+  description = "The domain at which the AYTQ service can be accessed"
+}
+
+variable "check_domain" {
+  default = null
+  description = "The domain at which the Check service can be accessed"
 }
 
 variable "region_name" {

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -6,5 +6,6 @@
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-aytq",
-  "domain": "dev.access-your-teaching-qualifications.education.gov.uk"
+  "domain": "dev.access-your-teaching-qualifications.education.gov.uk",
+  "check_domain": "dev.check-the-record-of-a-teacher.education.gov.uk"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -7,5 +7,7 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165t01-aytq"
+  "resource_prefix": "s165t01-aytq",
+  "domain": "preprod.access-your-teaching-qualifications.education.gov.uk",
+  "check_domain": "preprod.check-the-record-of-a-teacher.education.gov.uk"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -6,5 +6,6 @@
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
-  "domain": "test.access-your-teaching-qualifications.education.gov.uk"
+  "domain": "test.access-your-teaching-qualifications.education.gov.uk",
+  "check_domain": "test.check-the-record-of-a-teacher.education.gov.uk"
 }


### PR DESCRIPTION
### Context
We don’t currently have smoke tests for these services. We should add some using the ones in Refer serious misconduct as a reference.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

- First two commits are tangential changes to make it easier to run the smoke spec locally when editing it
- Add smoke test spec file
- Add terraform/github action changes to run the smoke test after deploys 


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
A once-over of the changes to double-check if I've missed anything is probably sufficient. Will be testing this "live" once merged and iterating on any failures. Failures will (I think, with the current setup) stop prod deploys. This doesn't matter for Check, but if we need anything to go out for AYTQ urgently, we can deploy manually.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/PMm6UKoG/87-add-smoke-tests-for-aytq-check
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
