### PR TITLE
Support the teachers search returning a 500 response

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -72,11 +72,13 @@ module QualificationsApi
       raise(QualificationApi::InvalidTokenError) if response.status == 401
 
       results =
-        response.body["results"].map do |teacher|
+        response.body["results"]&.map do |teacher|
           QualificationsApi::Teacher.new(teacher)
         end
 
-      [response.body["total"], results]
+      results ||= []
+      total = response.body["total"] || 0
+      [total, results]
     end
 
     def client

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -77,4 +77,36 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
       end
     end
   end
+
+  describe "#teachers" do
+    subject do
+      described_class.new(token: "token").teachers(date_of_birth:, last_name:)
+    end
+
+    let(:date_of_birth) { "1990-01-01" }
+    let(:last_name) { "Walsh" }
+
+    it "returns a list of teachers" do
+      expect(subject.first).to eq 1
+      expect(subject.last).to all(be_a(QualificationsApi::Teacher))
+    end
+
+    context "when there are no matches" do
+      let(:last_name) { "NotAMatch" }
+
+      it "returns an empty list" do
+        expect(subject.first).to eq 0
+        expect(subject.last).to eq []
+      end
+    end
+
+    context "when the API returns a 500 error" do
+      before { stub_request(:get, /teachers/).to_return(status: 500) }
+
+      it "returns an empty list" do
+        expect(subject.first).to eq 0
+        expect(subject.last).to eq []
+      end
+    end
+  end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -17,7 +17,11 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
-      { total: 1, results: [teacher_data] }.to_json
+      if params[:lastName] == "NotAMatch"
+        { total: 0, results: [] }.to_json
+      else
+        { total: 1, results: [teacher_data] }.to_json
+      end
     when "invalid-token"
       halt 401
     end


### PR DESCRIPTION
There is a scenario where when searching for teacher records the API can
return a 500 response.

We don't currently handle this and present an unhelpful error page.

I opted to treat this as a no match scenario for the user, as it is
effectively the same thing to them.

### Link to Trello card

https://trello.com/c/XNwY3qMX/137-fix-missing-search-results

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
