### PR TITLE
Add missing input declaration in smoke-test action

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -10,6 +10,9 @@ inputs:
   url:
     description: Sets the HOSTING_DOMAIN environment variable
     required: true
+  check_url:
+    description: Sets the CHECK_RECORDS_DOMAIN environment variable
+    required: true
 
 runs:
   using: composite


### PR DESCRIPTION
Patching the smoke tests to get them running.