### PR TITLE
Temporarily skip smoke tests for preprod deploys

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -119,6 +119,7 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           url: ${{ steps.deploy.outputs.environment_url }}
           check_url: ${{ steps.deploy.outputs.check_service_url }}
+        if: matrix.environment != 'preprod'
 
   deploy_prod:
     name: Deploy to production environment


### PR DESCRIPTION
The Check service on preprod still needs DNS to be set up so that it can be accessed by its expected domain name.

Until that happens, skip smoke tests on preprod.
