### PR TITLE
Add worker instances to non-prod envs

### DIFF
--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -7,5 +7,6 @@
   "storage_log_categories": [],
   "resource_prefix": "s165d01-aytq",
   "domain": "dev.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "dev.check-the-record-of-a-teacher.education.gov.uk"
+  "check_domain": "dev.check-the-record-of-a-teacher.education.gov.uk",
+  "worker_count": 1
 }

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -7,5 +7,6 @@
   "app_service_plan_sku": "S1",
   "storage_log_categories": [],
   "resource_prefix": "s165d01-aytq",
-  "create_env_resource_group": true
+  "create_env_resource_group": true,
+  "worker_count": 1
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -7,5 +7,6 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
   "domain": "test.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "test.check-the-record-of-a-teacher.education.gov.uk"
+  "check_domain": "test.check-the-record-of-a-teacher.education.gov.uk",
+  "worker_count": 1
 }


### PR DESCRIPTION
### Context

We are using BigQuery for analytics which queues up sidekiq jobs. We need to be able to test this in non-production environments.

### Changes proposed in this pull request

Add 1 worker instance to dev, test and review.

### Guidance to review

The variables.tf file defines `worker_count` with a description of 'multiple of av zone'. Do we need more than one here?
