### PR TITLE
Reenable smoke tests on preprod

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -119,7 +119,6 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           url: ${{ steps.deploy.outputs.environment_url }}
           check_url: ${{ steps.deploy.outputs.check_service_url }}
-        if: matrix.environment != 'preprod'
 
   deploy_prod:
     name: Deploy to production environment


### PR DESCRIPTION
DNS changes have been made so that Check is available at https://preprod.check-the-record-of-a-teacher.education.gov.uk 

We can now run smoke tests against this environment.