### PR TITLE
Add restrictions indicator to search results

### DIFF
--- a/app/assets/stylesheets/check_records.scss
+++ b/app/assets/stylesheets/check_records.scss
@@ -95,3 +95,18 @@ $govuk-assets-path: "/";
 .govuk-summary-list__row:not(.govuk-summary-list__row--no-actions) > :last-child {
   padding-right: 0;
 }
+
+.app__search-detail-heading {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 20px;
+
+  .govuk-heading-l {
+    margin-bottom: 0;
+  }
+
+  .govuk-tag {
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -12,12 +12,15 @@ module CheckRecords
         params["search"]["date_of_birth(2i)"],
         params["search"]["date_of_birth(3i)"]
       ]
-      @search = Search.new(date_of_birth:, last_name: params[:search][:last_name])
+      @search =
+        Search.new(date_of_birth:, last_name: params[:search][:last_name])
       if @search.invalid?
         render :new
       else
         @total, @teachers =
-          QualificationsApi::Client.new(token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"]).teachers(
+          QualificationsApi::Client.new(
+            token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"]
+          ).teachers(
             date_of_birth: @search.date_of_birth,
             last_name: @search.last_name
           )

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -44,6 +44,7 @@ module QualificationsApi
               InitialTeacherTraining
               NpqQualifications
               MandatoryQualifications
+              Sanctions
             ].join(",")
           }
         )

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -69,7 +69,7 @@ module QualificationsApi
           }
         )
 
-      raise(QualificationApi::InvalidTokenError) if response.status == 401
+      raise(QualificationsApi::InvalidTokenError) if response.status == 401
 
       results =
         response.body["results"].map do |teacher|

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -14,6 +14,7 @@ module QualificationsApi
              :first_name,
              :last_name,
              :middle_name,
+             :sanctions,
              :trn,
              to: :api_data
 

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -8,8 +8,8 @@
           <h2 class="govuk-heading-s">
             <%= link_to teacher.name, check_records_teacher_path(teacher.trn), class: "govuk-link--no-visited-state" %>
           </h2>
-          <strong class="govuk-tag govuk-tag--green">
-            No restrictions
+          <strong class="govuk-tag govuk-tag--<%= teacher.sanctions.any? ? "red" : "green" %>"%>
+            <%= teacher.sanctions.any? ? "Restrictions" : "No restrictions" %>
           </strong>
 
           <% 

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -2,7 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= @teacher.name %></h1>
+    <div class="app__search-detail-heading">
+      <h1 class="govuk-heading-l"><%= @teacher.name %></h1>
+      <strong class="govuk-tag govuk-tag--<%= @teacher.sanctions.any? ? "red" : "green" %>"%>
+        <%= @teacher.sanctions.any? ? "Restrictions" : "No restrictions" %>
+      </strong>
+    </div>
 
     <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-m">Personal Details</h2>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -17,7 +17,10 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
-      { total: 1, results: [teacher_data] }.to_json
+      {
+        total: 1,
+        results: [teacher_data(sanctions: params[:last_name] == "Restricted")]
+      }.to_json
     when "invalid-token"
       halt 401
     end
@@ -69,12 +72,13 @@ class FakeQualificationsApi < Sinatra::Base
 
   private
 
-  def teacher_data(trn: "1234567")
+  def teacher_data(sanctions: false, trn: "1234567")
     {
       dateOfBirth: "2000-01-01",
       firstName: "Terry",
       lastName: "Walsh",
       middleName: "John",
+      sanctions: sanctions ? [{ type: "Restricted" }] : [],
       trn:
     }
   end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -159,7 +159,8 @@ class FakeQualificationsApi < Sinatra::Base
             name: "NPQ senior leadership"
           }
         }
-      ]
+      ],
+      sanctions: []
     }.to_json
   end
 

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Teacher search with restrictions",
+               host: :check_records,
+               type: :system do
+  include ActivateFeaturesSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User searches with a last name and date of birth and finds a restricted record",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi
+    and_search_returns_a_restricted_record
+    then_i_see_the_restriction_on_the_result
+  end
+
+  private
+
+  def and_search_returns_a_restricted_record
+    fill_in "Last name", with: "Restricted"
+    fill_in "Day", with: "1"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "1990"
+    click_button "Find record"
+  end
+
+  def then_i_see_the_restriction_on_the_result
+    expect(page).to have_content("RESTRICTIONS")
+  end
+end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     when_i_sign_in_via_dsi
     and_search_with_a_valid_name_and_dob
     then_i_see_a_teacher_record_in_the_results
+    and_they_have_no_restrictions
 
     when_i_click_on_the_teacher_record
     then_i_see_induction_details
@@ -34,6 +35,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_a_teacher_record_in_the_results
     expect(page).to have_content "Terry Walsh"
+  end
+
+  def and_they_have_no_restrictions
+    expect(page).to have_content "NO RESTRICTIONS"
   end
 
   def when_i_click_on_the_teacher_record


### PR DESCRIPTION
When a result returned via search contains any sanctions, we want to
flag that record as having restrictions.

The designs have extra information that isn't currently available via
the API. I've left those out for this round of changes.

Once the API provides the extra information, we can revisit this and
display them too.

### Link to Trello card

https://trello.com/c/UESb1X0r/103-add-sanctions-to-index-as-per-prototype

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="984" alt="Screenshot 2023-08-15 at 10 34 44 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/32bb267d-be03-48cd-a898-f4869c2ee540">
<img width="985" alt="Screenshot 2023-08-15 at 10 54 35 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/fed855ab-473b-4d8c-91c2-9034e417bf86">
<img width="993" alt="Screenshot 2023-08-15 at 10 55 47 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/2435de5a-a668-443d-85de-ba1077c74803">
<img width="987" alt="Screenshot 2023-08-15 at 10 56 17 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/27de9616-3d7c-4cae-99a3-2c61ffb1022c">
