### PR TITLE
Update Notify template IDs

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = "5e1842e6-d806-49ce-ba19-0483a056e367"
+  GENERIC_NOTIFY_TEMPLATE = "d5bddb2d-e560-4de1-a851-5e470bf06c76"
 
   def notify_email(headers)
     headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,6 +1,8 @@
 class DeviseMailer < Devise::Mailer
+  DEVISE_NOTIFY_TEMPLATE = "f92c39f3-ec99-4607-a16b-5a0eeb4ef7a3".freeze
+
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)
-    view_mail(ApplicationMailer::GENERIC_NOTIFY_TEMPLATE, headers_for(action, opts))
+    view_mail(DEVISE_NOTIFY_TEMPLATE, headers_for(action, opts))
   end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -10,4 +10,8 @@ class Staff < ApplicationRecord
     :trackable,
     :validatable
   )
+
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end


### PR DESCRIPTION
### Context

We need devise to send staff invitations for access to the support pages. The templates and keys are now set up on Notify.

### Changes proposed in this pull request

* Update the template IDs
* Add mailer method override to Staff.

### Guidance to review

### Link to Trello card

https://trello.com/c/GvxLZt4s/142-set-up-and-configure-notify-for-check-aytq-staff-invites

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
