### PR TITLE
Allow qualifications without an awarded at value

### DIFF
--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -20,7 +20,7 @@ class QualificationSummaryComponent < ViewComponent::Base
     return itt_rows if itt?
 
     @rows = [
-      { key: { text: "Awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }
+      { key: { text: "Awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }
     ]
 
     if qualification.certificate_url


### PR DESCRIPTION
We're seeing a handful of errors related to rendering qualifications
with a missing awarded at value.

We don't control the values returned by the API but it is possible that
there are edge cases where an awarded at date is missing but we still
want to display the qualification.

I opted for a defensive approach, where we simply guard against the nil
but a future iteration of this may include displaying a default when the
value is missing.

https://dfe-teacher-services.sentry.io/issues/4388735309/?project=4505227155996672&query=is:unresolved&stream_index=1

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
