### PR TITLE
Add default_url_options[:host] for mail

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :notify
+  config.action_mailer.default_url_options = { host: HostingEnvironment.aytq_domain }
 end


### PR DESCRIPTION
### Context

Set the default host

### Changes proposed in this pull request

Notify emails are failing due to this not being set.

### Guidance to review

This relates to -> https://dfe-teacher-services.sentry.io/issues/4399021638/?project=4505227155996672&query=is%3Aunresolved&referrer=issue-stream&stream_index=2

We're passing the domain into the devise mail and it's failing when we try to send invite mails.

