### PR TITLE
Fix oauth failure handling for AYTQ

### DIFF
--- a/app/controllers/auth_failures_controller.rb
+++ b/app/controllers/auth_failures_controller.rb
@@ -6,7 +6,7 @@ class AuthFailuresController < ApplicationController
 
     case strategy
     when :identity
-      handle_failure_then_redirect_to qualifications_sign_in_path
+      handle_failure_then_redirect_to qualifications_root_path
     when :dfe
       handle_failure_then_redirect_to check_records_sign_in_path
     end

--- a/spec/system/qualifications/user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/qualifications/user_has_oauth_error_signing_in_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication", type: :system do
+  include AuthorizationSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    when_i_am_authorized_with_basic_auth
+    allow(Sentry).to receive(:capture_exception)
+  end
+
+  scenario "User has oauth error when signing in", test: :with_stubbed_auth do
+    given_identity_auth_is_mocked_with_a_failure
+    when_i_go_to_the_sign_in_page
+    and_click_the_sign_in_button
+    then_i_see_a_sign_in_error
+  end
+
+  private
+
+  def given_identity_auth_is_mocked_with_a_failure
+    OmniAuth.config.mock_auth[:identity] = :invalid_credentials
+  end
+
+  def then_i_see_a_sign_in_error
+    expect(page).to have_content "There was a problem signing you in. Please try again."
+  end
+end


### PR DESCRIPTION
The AuthFailuresController is using an AYTQ route that no longer exists. Added a system spec to cover this.
