### PR TITLE
Add default_url_options[:host] for mail

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
+require "./app/models/hosting_environment"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :notify
+  config.action_mailer.default_url_options = { host: HostingEnvironment.aytq_domain }
 end


### PR DESCRIPTION


### Context

Notify emails are failing due to this not being set.

### Changes proposed in this pull request

Set default host. 

### Guidance to review

Trying this again. The previous effort failed when merged as `HostingDomain` was unrecognised, probably not loaded at the time the asset compilation started. I've included it in application.rb now.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
