### PR TITLE
Display sanction details for a specific teacher

### DIFF
--- a/app/assets/stylesheets/check_records.scss
+++ b/app/assets/stylesheets/check_records.scss
@@ -110,3 +110,12 @@ $govuk-assets-path: "/";
     margin-left: 10px;
   }
 }
+
+.app__restrictions {
+  margin-bottom: govuk-spacing(9);
+  margin-top: govuk-spacing(9);
+
+  .govuk-inset-text {
+    border-left-color: red;
+  }
+}

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -23,13 +23,13 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
     return mq_rows if mq?
     return induction_rows if induction?
 
-    [{ key: { text: "Date awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }]
+    [{ key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }]
   end
 
   def induction_rows
     [
       { key: { text: "Induction status" }, value: { text: details.status&.to_s&.humanize } },
-      { key: { text: "Date completed" }, value: { text: awarded_at.to_fs(:long_uk) } }
+      { key: { text: "Date completed" }, value: { text: awarded_at&.to_fs(:long_uk) } }
     ]
   end
 

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -35,6 +35,10 @@ module QualificationsApi
         .reverse!
     end
 
+    def sanctions
+      api_data.sanctions.map { |sanction| Sanction.new(type: sanction) }
+    end
+
     private
 
     def add_qts

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -1,0 +1,43 @@
+class Sanction
+  include ActiveModel::Model
+
+  attr_accessor :type
+
+  SANCTIONS = {
+    "A13" => { title: "Suspension order - with conditions" },
+    "A14" => { title: "Suspension order - with conditions" },
+    "A18" => { title: "Conditional registration order - conviction of a relevant offence" },
+    "A19" => { title: "Suspension order" },
+    "A1A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A1B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A2" => { title: "Suspension order" },
+    "A20" => { title: "Suspension order - with conditions" },
+    "A21A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A21B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A23" => { title: "Suspension order" },
+    "A24" => { title: "Suspension order - with conditions" },
+    "A25A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A25B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A3" => { title: "Conditional registration order - unacceptable professional conduct" },
+    "A5A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A5B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
+    "A6" => { title: "Suspension order" },
+    "A7" => { title: "Conditional registration order  - serious professional incompetence" },
+    "B3" => { title: "Prohibition by the Secretary of State or an Independent Schools Tribunal" },
+    "C1" => { title: "Prohibition by the Secretary of State" },
+    "C2" => { title: "Failed induction" },
+    "C3" => { title: "Restriction by the Secretary of State" },
+    "G1" => { title: "Record found" },
+    "T1" => { title: "Prohibition by the Secretary of State" },
+    "T2" => { title: "Interim prohibition by the Secretary of State" },
+    "T3" => { title: "Prohibition by the Secretary of State - deregistered by GTC Scotland" },
+    "T4" => { title: "Prohibition by the Secretary of State  - refer to the Education Workforce Council, Wales" },
+    "T5" => { title: "Prohibition by the Secretary of State - refer to GTC Northern Ireland" },
+    "T6" => { title: "Secretary of State decision - no prohibition" },
+    "T7" => { title: "Section 128 barring direction" }
+  }.freeze
+
+  def title  
+    SANCTIONS[type][:title] if SANCTIONS[type]
+  end
+end

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -9,6 +9,19 @@
       </strong>
     </div>
 
+    <% if @teacher.sanctions.any? %>
+      <div class="app__restrictions">
+        <h2 class="govuk-heading-m">Restrictions</h2>
+        <%= govuk_inset_text do %>
+          <% @teacher.sanctions.each do |sanction| %>
+            <h3 class="govuk-heading-s">
+              <%= sanction.title %>
+            </h3>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
     <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-m">Personal Details</h2>
       <%= govuk_summary_list(

--- a/spec/models/sanction_spec.rb
+++ b/spec/models/sanction_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Sanction, type: :model do
+  describe '#title' do
+    subject { sanction.title }
+
+    context 'when type exists in SANCTIONS' do
+      let(:sanction) { described_class.new(type: 'A13') }
+
+      it { is_expected.to eq('Suspension order - with conditions') }
+    end
+
+    context 'when type does not exist in SANCTIONS' do
+      let(:sanction) { described_class.new(type: 'Z99') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -19,7 +19,7 @@ class FakeQualificationsApi < Sinatra::Base
     when "token"
       {
         total: 1,
-        results: [teacher_data(sanctions: params[:last_name] == "Restricted")]
+        results: [teacher_data(sanctions: params["lastName"] == "Restricted")]
       }.to_json
     when "invalid-token"
       halt 401
@@ -34,6 +34,8 @@ class FakeQualificationsApi < Sinatra::Base
     when "token"
       if trn == "1234567"
         quals_data(trn: "1234567")
+      elsif trn == "987654321"
+        quals_data(trn:)
       else
         halt 404
       end
@@ -73,13 +75,28 @@ class FakeQualificationsApi < Sinatra::Base
   private
 
   def teacher_data(sanctions: false, trn: "1234567")
+    sanctions ? sanctions_data : no_sanctions_data(trn:)
+  end
+
+  def no_sanctions_data(trn:)
     {
       dateOfBirth: "2000-01-01",
       firstName: "Terry",
       lastName: "Walsh",
       middleName: "John",
-      sanctions: sanctions ? [{ type: "Restricted" }] : [],
+      sanctions: [],
       trn:
+    }
+  end
+
+  def sanctions_data
+    {
+      dateOfBirth: "2000-01-01",
+      firstName: "Teacher",
+      lastName: "Restricted",
+      middleName: "",
+      sanctions: ["C2"],
+      trn: "987654321"
     }
   end
 
@@ -160,7 +177,7 @@ class FakeQualificationsApi < Sinatra::Base
           }
         }
       ],
-      sanctions: []
+      sanctions: trn == "987654321" ? ["C2"] : []
     }.to_json
   end
 

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "Teacher search with restrictions",
     when_i_sign_in_via_dsi
     and_search_returns_a_restricted_record
     then_i_see_the_restriction_on_the_result
+
+    when_i_click_on_the_result
+    then_i_see_the_details_of_the_restriction
   end
 
   private
@@ -26,5 +29,14 @@ RSpec.describe "Teacher search with restrictions",
 
   def then_i_see_the_restriction_on_the_result
     expect(page).to have_content("RESTRICTIONS")
+  end
+
+  def when_i_click_on_the_result
+    click_link "Teacher Restricted"
+  end
+
+  def then_i_see_the_details_of_the_restriction
+    expect(page).to have_content("RESTRICTIONS")
+    expect(page).to have_content("Failed induction")
   end
 end


### PR DESCRIPTION
When a teacher has sanctions in the API response, we want to display
them as per the designs.

There is on-going work to update the wording used currently to describe each
sanction. See https://educationgovuk.sharepoint.com/:x:/s/TeacherServices/EZsyllhdkb9Giji9pHvGG1UBKseSEplO-KUUH-vseaRM7w
for details.

We don't have a full description or date attached to any of the
sanctions at the moment, so this is where the implementation diverges
from the designs.

Assumptions:
- the sanctions list won't change much so storing them as key-values in
  code will be the most efficient way of representing them
- we won't be getting any more details from the API about the sanctions
- we can ship a version of the sanctions without the descriptions and
  revisit this once they have been written

### Link to Trello card

https://trello.com/c/w4Xv9m5m/104-add-sanctions-to-the-show-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="993" alt="Screenshot 2023-08-23 at 1 16 21 pm" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/fb7ac78a-631f-4637-846a-bb4c33fe8479">
