### PR TITLE
Bug fix for sending environment name to sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,7 @@ require "active_support/parameter_filter"
 Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
-  config.environment = HostingEnvironment.name
+  config.environment = HostingEnvironment.environment_name
 
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda { |event, _hint| filter.filter(event.to_hash) }


### PR DESCRIPTION
### Context

Just a lil bug fix, environment was always showing as `HostingEnvironment` in Sentry.

### Link to Trello card

https://trello.com/c/q92CrUpp/134-hostingenvironment-not-being-properly-reported-to-sentry

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally