### PR TITLE
[146] Add feedback form for Check service

### DIFF
--- a/app/controllers/check_records/feedbacks_controller.rb
+++ b/app/controllers/check_records/feedbacks_controller.rb
@@ -1,0 +1,31 @@
+module CheckRecords
+  class FeedbacksController < CheckRecordsController
+    skip_before_action :authenticate_dsi_user!
+    skip_before_action :handle_expired_session!
+
+    def new
+      @feedback = Feedback.new
+    end
+
+    def create
+      @feedback = Feedback.new(feedback_params)
+
+      if @feedback.save
+        redirect_to check_records_success_path
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def feedback_params
+      params.require(:feedback).permit(
+        :satisfaction_rating,
+        :improvement_suggestion,
+        :contact_permission_given,
+        :email
+      )
+    end
+  end
+end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,5 @@
+module FeedbackHelper
+  def satisfaction_rating_options(ratings)
+    ratings.map { |rating| OpenStruct.new(label: rating.humanize, value: rating) }
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,14 @@
+class Feedback < ApplicationRecord
+  SATISFACTION_RATINGS = %w[
+    very_satisfied
+    satisfied
+    neither_satisfied_nor_dissatisfied
+    dissatisfied
+    very_dissatisfied
+  ].freeze
+
+  validates :satisfaction_rating, inclusion: { in: SATISFACTION_RATINGS }
+  validates :improvement_suggestion, presence: true
+  validates :contact_permission_given, inclusion: { in: [true, false] }
+  validates :email, presence: true, if: :contact_permission_given?
+end

--- a/app/views/check_records/feedbacks/new.html.erb
+++ b/app/views/check_records/feedbacks/new.html.erb
@@ -6,7 +6,7 @@
       Give feedback about checking the record of a teacher
     </h1>
 
-    <%= form_with model: @feedback, url: [:check_records, :feedbacks] do |f| %>
+    <%= form_with model: [:check_records, @feedback] do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
           :satisfaction_rating,

--- a/app/views/check_records/feedbacks/new.html.erb
+++ b/app/views/check_records/feedbacks/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "Give feedback about checking the record of a teacher" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Give feedback about checking the record of a teacher
+    </h1>
+
+    <%= form_with model: @feedback, url: [:check_records, :feedbacks] do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+          :satisfaction_rating,
+          satisfaction_rating_options(Feedback::SATISFACTION_RATINGS),
+          :value,
+          :label,
+          legend: { text: "How satisfied are you with the service?", size: "m" },
+        ) %>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_area :improvement_suggestion, label: { text: "How can we improve the service?", size: "m" } %>
+      </div>
+
+      <%= f.govuk_radio_buttons_fieldset :contact_permission_given, legend: { size: "m", text: "Can we contact you about your feedback?" } do %>
+        <%= f.govuk_radio_button :contact_permission_given, 'true', label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+        <% end %>
+        <%= f.govuk_radio_button :contact_permission_given, 'false', label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Send feedback" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/check_records/feedbacks/success.html.erb
+++ b/app/views/check_records/feedbacks/success.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Feedback sent" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_panel(title_text: "Feedback sent") %>
+
+    <h2 class="govuk-heading-m">What you can do next</h2>
+
+    <p class="govuk_body">
+      Return to <%= govuk_link_to("check the record of a teacher", check_records_search_path) %>.
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -31,7 +31,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
-        This is a new service – <%= govuk_link_to("your feedback will help us to improve it.", t('service.feedback_form')) %>
+        This is a new service – your <%= govuk_link_to("feedback", main_app.check_records_feedbacks_path) %> will help us to improve it.
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -101,3 +101,11 @@ shared:
     - auditor_id
     - created_at
     - updated_at
+  :feedbacks:
+    - id
+    - satisfaction_rating
+    - improvement_suggestion
+    - contact_permission_given
+    - email
+    - created_at
+    - updated_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -17,3 +17,6 @@
     - trn
   :staff:
     - email
+  :feedbacks:
+    - email
+    - improvement_suggestion

--- a/config/initializers/govuk_formbuilder.rb
+++ b/config/initializers/govuk_formbuilder.rb
@@ -11,7 +11,7 @@ GOVUKDesignSystemFormBuilder.configure do |config|
   # config.default_submit_button_text: 'Continue'
   # config.default_radio_divider_text: 'or'
   # config.default_check_box_divider_text: 'or'
-  # config.default_error_summary_title: 'There is a problem'
+  config.default_error_summary_title = "There’s a problem"
   # config.default_error_summary_presenter: Presenters::ErrorSummaryPresenter
   # config.default_error_summary_error_order_method: nil
   # config.default_error_summary_turbo_prefix: 'turbo'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,3 +27,16 @@ en:
               in_the_future: Date of birth must be in the past
             last_name:
               blank: Enter a last name
+  activerecord:
+    errors:
+      models:
+        feedback:
+          attributes:
+            satisfaction_rating:
+              inclusion: Select how satisfied you are with the service
+            improvement_suggestion:
+              blank: Enter how we can improve the service
+            contact_permission_given:
+              inclusion: Select yes if we can contact you about your feedback
+            email:
+              blank: Enter an email address

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -15,6 +15,12 @@ namespace :check_records, path: "check-records" do
   get "/result", to: "search#show"
 
   resources :teachers, only: %i[show]
+
+  scope "/feedback" do
+    get "/", to: "feedbacks#new", as: :feedbacks
+    post "/", to: "feedbacks#create"
+    get "/success", to: "feedbacks#success"
+  end
 end
 
 root to: redirect("/check-records/search"), as: :check_records_root

--- a/db/migrate/20230829122729_create_feedbacks.rb
+++ b/db/migrate/20230829122729_create_feedbacks.rb
@@ -1,0 +1,12 @@
+class CreateFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :feedbacks do |t|
+      t.string :satisfaction_rating, null: false
+      t.text :improvement_suggestion, null: false
+      t.boolean :contact_permission_given, null: false
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_26_093546) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_29_122729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_26_093546) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.string "satisfaction_rating", null: false
+    t.text "improvement_suggestion", null: false
+    t.boolean "contact_permission_given", null: false
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "staff", force: :cascade do |t|

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Feedback, type: :model do
+  subject(:form) { described_class.new }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:improvement_suggestion) }
+    it { is_expected.not_to validate_presence_of(:email) }
+
+    specify do
+      expect(form).to validate_inclusion_of(:satisfaction_rating).in_array(
+        %w[
+          very_satisfied
+          satisfied
+          neither_satisfied_nor_dissatisfied
+          dissatisfied
+          very_dissatisfied
+        ]
+      )
+    end
+
+    context "when contact permission is given" do
+      subject(:form) { described_class.new(contact_permission_given: true) }
+
+      it { is_expected.to validate_presence_of(:email) }
+    end
+  end
+end

--- a/spec/system/check_records/user_gives_feedback_spec.rb
+++ b/spec/system/check_records/user_gives_feedback_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Feedback", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User gives feedback", test: :with_stubbed_auth do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi
+    and_i_click_on_feedback
+    then_i_see_the_feedback_form
+    when_i_press_send_feedback
+    then_i_see_validation_errors
+    when_i_choose_satisfied
+    then_i_see_validation_errors
+    when_i_fill_in_how_we_can_improve
+    then_i_see_validation_errors
+    when_i_choose_yes
+    then_i_see_validation_errors
+    when_i_enter_an_email
+    when_i_press_send_feedback
+    then_i_see_the_feedback_sent_page
+  end
+
+  private
+
+  def and_i_visit_the_search_page
+    visit search_path
+  end
+
+  def and_i_click_on_feedback
+    click_on "feedback"
+  end
+
+  def then_i_see_the_feedback_form
+    expect(page).to have_current_path("/check-records/feedback")
+    expect(page).to have_title("Give feedback about checking the record of a teacher")
+    expect(page).to have_content("How satisfied are you with the service?")
+  end
+
+  def when_i_press_send_feedback
+    click_on "Send feedback"
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content("There’s a problem")
+  end
+
+  def when_i_choose_satisfied
+    choose "Satisfied", visible: false
+  end
+
+  def when_i_fill_in_how_we_can_improve
+    fill_in "How can we improve the service?", with: "Make it better"
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_enter_an_email
+    fill_in "Email address", with: "my_email@example.com"
+  end
+
+  def then_i_see_the_feedback_sent_page
+    expect(page).to have_current_path("/check-records/feedback/success")
+    expect(page).to have_title("Feedback sent")
+    expect(page).to have_content("What you can do next")
+  end
+end


### PR DESCRIPTION
### Context

We want to collect feedback for the Check service and send to bigquery.

### Changes proposed in this pull request

- Create new MVC for feedbacks:
  - feedback form lives on `/check-records/feedback` and is linked from the banner
  - once feedback is submitted, you are redirected to a success page on `/check-records/feedback/success`
- Add presence validations for fields
  - All fields are required, except for email which is only required if consent is given
- Send feedback details to bigquery by adding to analytics.yml
- Update formbuilder initializer to render different error title ("There's a problem")

### Guidance to review

- Click on the feedback link in the banner
- Fill in the form, checking for presence validations
- Submit the feedback and check the success page


<img width="953" alt="Screenshot 2023-08-29 at 16 02 23" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/68aca41a-0f51-462e-872f-2ea9aa8f0937">

<img width="953" alt="Screenshot 2023-08-29 at 16 02 28" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/c82d5219-ea8c-4df2-9e78-71e81e9f6bb3">

<img width="573" alt="Screenshot 2023-08-29 at 16 02 37" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/5f7ed714-446b-43fa-8fff-479a42372a97">

<img width="912" alt="Screenshot 2023-08-29 at 16 02 53" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/55d8422f-6d40-453c-aa3c-04038e851a32">

### Link to Trello card

https://trello.com/c/r8fe5a5e/146-add-feedback-form

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally