### PR TITLE
Set namespace for analytics

### DIFF
--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -10,6 +10,11 @@ module CheckRecords
     end
     helper_method :current_dsi_user
 
+    # Differentiate web requests sent to BigQuery via dfe-analytics
+    def current_namespace
+      "check-the-record-of-a-teacher"
+    end
+
     def authenticate_dsi_user!
       if current_dsi_user.blank?
         flash[:warning] = "You need to sign in to continue."

--- a/app/controllers/concerns/support_namespaceable.rb
+++ b/app/controllers/concerns/support_namespaceable.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SupportNamespaceable
+  # Differentiate web requests sent to BigQuery via dfe-analytics
+  def current_namespace
+    "support"
+  end
+end

--- a/app/controllers/qualifications/qualifications_interface_controller.rb
+++ b/app/controllers/qualifications/qualifications_interface_controller.rb
@@ -10,6 +10,11 @@ module Qualifications
     end
     helper_method :current_user
 
+    # Differentiate web requests sent to BigQuery via dfe-analytics
+    def current_namespace
+      "access-your-teaching-qualifications"
+    end
+
     def authenticate_user!
       if current_user.blank?
         flash[:warning] = "You need to sign in to continue."

--- a/app/controllers/staff/confirmations_controller.rb
+++ b/app/controllers/staff/confirmations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Staff::ConfirmationsController < Devise::ConfirmationsController
+  include SupportNamespaceable
+
   # GET /resource/confirmation/new
   # def new
   #   super

--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Staff::InvitationsController < Devise::InvitationsController
+  include SupportNamespaceable
   protect_from_forgery prepend: true
 
   protected

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Staff::PasswordsController < Devise::PasswordsController
+  include SupportNamespaceable
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Staff::SessionsController < Devise::SessionsController
+  include SupportNamespaceable
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/staff/unlocks_controller.rb
+++ b/app/controllers/staff/unlocks_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Staff::UnlocksController < Devise::UnlocksController
+  include SupportNamespaceable
+
   # GET /resource/unlock/new
   # def new
   #   super

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,5 +1,7 @@
-class SupportInterface::StaffController < ApplicationController
-  def index
-    @staff = Staff.all
+module SupportInterface
+  class StaffController < SupportInterfaceController
+    def index
+      @staff = Staff.all
+    end
   end
 end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module SupportInterface
   class SupportInterfaceController < ApplicationController
+    include SupportNamespaceable
+
     layout "support_layout"
 
     before_action :authenticate_staff!

--- a/app/views/staff/confirmations/new.html.erb
+++ b/app/views/staff/confirmations/new.html.erb
@@ -8,7 +8,7 @@
         autofocus: true, 
         autocomplete: "email", 
         value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), 
-        label: { text: "Email" } 
+        label: { text: "Email" })
       %>
       <%= f.govuk_submit "Resend confirmation instructions" %>
     <% end %>


### PR DESCRIPTION
### Context

We want to differentiate between web requests coming from Check and those coming from AYTQ.

### Changes proposed in this pull request

Define `current_namespace` in each base controller so that it's value is attached to the `namespace` param as per the gem's instructions here:

https://github.com/DFE-Digital/dfe-analytics#web-requests

### Link to Trello card

https://trello.com/b/QHGTdbfn/tra-check-the-record-of-a-teacher

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally