### PR TITLE
[169] Add sanction date

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -36,7 +36,7 @@ module QualificationsApi
     end
 
     def sanctions
-      api_data.sanctions.map { |sanction| Sanction.new(type: sanction) }
+      api_data.sanctions.map { |sanction| Sanction.new(sanction) }
     end
 
     private

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -1,7 +1,10 @@
 class Sanction
-  include ActiveModel::Model
+  attr_accessor :code, :start_date
 
-  attr_accessor :type
+  def initialize(api_data)
+    @code = api_data[:code]
+    @start_date = api_data[:start_date].present? ? Date.parse(api_data[:start_date]) : nil
+  end
 
   SANCTIONS = {
     "A13" => { title: "Suspension order - with conditions" },
@@ -37,7 +40,7 @@ class Sanction
     "T7" => { title: "Section 128 barring direction" }
   }.freeze
 
-  def title  
-    SANCTIONS[type][:title] if SANCTIONS[type]
+  def title
+    SANCTIONS[code][:title] if SANCTIONS[code]
   end
 end

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -17,11 +17,12 @@
             <h3 class="govuk-heading-s">
               <%= sanction.title %>
             </h3>
+            <%= sanction.start_date.strftime("%d %B %Y") if sanction.start_date %>
           <% end %>
         <% end %>
       </div>
     <% end %>
-
+    
     <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-m">Personal Details</h2>
       <%= govuk_summary_list(

--- a/spec/models/sanction_spec.rb
+++ b/spec/models/sanction_spec.rb
@@ -1,19 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Sanction, type: :model do
+  let(:api_data) do
+    {
+      code:,
+      start_date:
+    }
+  end
+  let(:code) { "A13" }
+  let(:start_date) { "2020-10-25" }
+  let(:sanction) { described_class.new(api_data) }
+
   describe '#title' do
     subject { sanction.title }
 
     context 'when type exists in SANCTIONS' do
-      let(:sanction) { described_class.new(type: 'A13') }
-
       it { is_expected.to eq('Suspension order - with conditions') }
     end
 
     context 'when type does not exist in SANCTIONS' do
-      let(:sanction) { described_class.new(type: 'Z99') }
+      let(:code) { "Z99" }
 
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe "start_date" do
+    subject { sanction.start_date }
+
+    it { is_expected.to eq(Date.parse(start_date)) }
+
+    context "when startDate is not present" do
+      let(:start_date) { nil }
+
+      it { is_expected.to be nil }
     end
   end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -95,7 +95,12 @@ class FakeQualificationsApi < Sinatra::Base
       firstName: "Teacher",
       lastName: "Restricted",
       middleName: "",
-      sanctions: ["C2"],
+      sanctions: [
+        {
+          code: "C2",
+          startDate: "2019-10-25"
+        }
+      ],
       trn: "987654321"
     }
   end
@@ -177,7 +182,7 @@ class FakeQualificationsApi < Sinatra::Base
           }
         }
       ],
-      sanctions: trn == "987654321" ? ["C2"] : []
+      sanctions: trn == "987654321" ? [ { code: "C2", startDate: "2020-10-25" } ] : []
     }.to_json
   end
 

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -38,5 +38,6 @@ RSpec.describe "Teacher search with restrictions",
   def then_i_see_the_details_of_the_restriction
     expect(page).to have_content("RESTRICTIONS")
     expect(page).to have_content("Failed induction")
+    expect(page).to have_content("25 October 2020")
   end
 end


### PR DESCRIPTION
DO NOT MERGE - needs a bit more work on the API to use the new format on the `v3/teachers` endpoint. The changes are currently only live on `v3/teachers/<trn>`.

### Context

The response from the API now includes start date and is in a different format.

### Changes proposed in this pull request

* support new API response format
* render start date on the teacher record

<img width="1085" alt="Screenshot 2023-09-01 at 16 34 43" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/5216/69a20609-20d7-44c4-ab91-f0d3fd2da176">

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
