### PR TITLE
Redirect user to sign in page on sign out

### DIFF
--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -4,6 +4,7 @@ module CheckRecords
 
     def new
       session[:dsi_user_id] = nil if dsi_user_signed_in?
+      redirect_to check_records_sign_in_path
     end
   end
 end

--- a/app/views/check_records/sign_out/new.html.erb
+++ b/app/views/check_records/sign_out/new.html.erb
@@ -1,7 +1,0 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You are now signed out</h1>
-
-    <%= govuk_button_link_to "Continue", check_records_root_path  %>
-  </div>
-</div>

--- a/spec/system/check_records/user_signs_out_spec.rb
+++ b/spec/system/check_records/user_signs_out_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication", host: :check_records do
+  include AuthorizationSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User signs out", test: :with_stubbed_auth do
+    when_i_am_authorized_with_basic_auth
+    and_i_am_signed_in_via_dsi
+    when_i_sign_out
+    then_i_am_redirected_to_the_sign_in_page
+  end
+
+  private
+
+  def when_i_sign_out
+    click_on "Sign out"
+  end
+
+  def then_i_am_redirected_to_the_sign_in_page
+    expect(page).to have_current_path(check_records_sign_in_path)
+  end
+end


### PR DESCRIPTION
### Context

Currently the user is taken to a _You are signed out_ page when signing out.
They should be redirected to the sign in page.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Redirect users to sign in page on sign out.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/GsNFWOpx/178-signed-out-page
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
