### PR TITLE
Date formatting on teacher record show page

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -27,7 +27,7 @@
       <%= govuk_summary_list(
         rows: [
           { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
-          { key: { text: "Date of birth" }, value: { text: @teacher.date_of_birth } }
+          { key: { text: "Date of birth" }, value: { text: Date.parse(@teacher.date_of_birth).to_fs(:long_uk) } }
         ])
       %>
     </div>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -103,6 +103,7 @@ class FakeQualificationsApi < Sinatra::Base
   def quals_data(trn: nil, itt: true)
     {
       trn: trn || "3000299",
+      dateOfBirth: "2000-01-01",
       firstName: "Terry",
       lastName: "Walsh",
       eyts: {


### PR DESCRIPTION
### Context

Date of birth on a teacher record is not formatted consistently with other dates in the service.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/e73cc68f-1aea-4757-9e7b-8adc5580ed67)

Format date of birth like _1 January 1990_ for consistency (`:long_uk` format).
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I checked the teacher response from the preprod Qualifications API and this included `dateOfBirth`, so this has been added to the `FakeQualificationsApi` Rack app which tests rely on.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/kZGLIhMb/181-date-formatting-on-teacher-record-show-page
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
