### PR TITLE
[182] Add breadcrumbs

### DIFF
--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Search results (<%= @total %>)</h1>

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link_url, check_records_search_path %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Context

Users should be able to navigate back from a teacher show page, back to their search results, and back to home (the search page)

### Changes proposed in this pull request

Add breadcrumbs to search results page and show page.

### Link to Trello card

https://trello.com/c/EGLbfKQy/182-breadcrumbs

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally