### PR TITLE
Add page titles to match h1s

### DIFF
--- a/app/views/check_records/search/new.html.erb
+++ b/app/views/check_records/search/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Find teacher record" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Find teacher record</h1>

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, "Search results (#{@total})" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
 
 <div class="govuk-grid-row">

--- a/app/views/check_records/sign_in/new.html.erb
+++ b/app/views/check_records/sign_in/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Sign in" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/check_records/teachers/not_found.html.erb
+++ b/app/views/check_records/teachers/not_found.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, "Teacher not found" %>
 <% content_for :back_link_url, check_records_search_path %>
 
 <div class="govuk-grid-row">

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @teacher.name %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
 
 <div class="govuk-grid-row">

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Teacher search with restrictions",
   end
 
   def then_i_see_the_restriction_on_the_result
+    expect(page).to have_title("Search results (1) - Check the record of a teacher in England")
     expect(page).to have_content("RESTRICTIONS")
   end
 
@@ -39,5 +40,6 @@ RSpec.describe "Teacher search with restrictions",
     expect(page).to have_content("RESTRICTIONS")
     expect(page).to have_content("Failed induction")
     expect(page).to have_content("25 October 2020")
+    expect(page).to have_title("Terry Walsh - Check the record of a teacher in England")
   end
 end

--- a/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
+++ b/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
@@ -22,5 +22,6 @@ RSpec.describe "TRN search", host: :check_records, type: :system do
 
   def then_i_see_a_not_found_page
     expect(page).to have_content "Teacher not found"
+    expect(page).to have_title "Teacher not found - Check the record of a teacher in England"
   end
 end


### PR DESCRIPTION
### Context

Page titles should explain what the page it about.

### Changes proposed in this pull request

Add page titles to match the prototype.

### Link to Trello card

https://trello.com/c/wcVN2Xxz/186-add-correct-page-titles

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
