### PR TITLE
Add search logs

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -17,6 +17,11 @@ module CheckRecords
       if @search.invalid?
         render :new
       else
+        SearchLog.create!(
+          dsi_user: current_dsi_user,
+          last_name: @search.last_name,
+          date_of_birth: @search.date_of_birth.to_s
+        )
         @total, @teachers =
           QualificationsApi::Client.new(
             token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"]

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -2,6 +2,8 @@ class DsiUser < ApplicationRecord
   encrypts :email, deterministic: true
   encrypts :first_name, :last_name
 
+  has_many :search_logs
+
   def self.create_or_update_from_dsi(dsi_payload)
     dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
 

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,0 +1,3 @@
+class SearchLog < ApplicationRecord
+  belongs_to :dsi_user
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -45,6 +45,13 @@ shared:
     - family_name
     - trn
     - date_of_birth
+  :search_logs:
+    - id
+    - dsi_user_id
+    - last_name
+    - date_of_birth
+    - created_at
+    - updated_at
   :staff:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -15,6 +15,9 @@
     - given_name
     - name
     - trn
+  :search_logs:
+    - last_name
+    - date_of_birth
   :staff:
     - email
   :feedbacks:

--- a/db/migrate/20230907120219_create_search_logs.rb
+++ b/db/migrate/20230907120219_create_search_logs.rb
@@ -1,0 +1,10 @@
+class CreateSearchLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :search_logs do |t|
+      t.references :dsi_user, foreign_key: true
+      t.string :last_name
+      t.date :date_of_birth
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_29_122729) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_120219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -117,6 +117,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_122729) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "search_logs", force: :cascade do |t|
+    t.bigint "dsi_user_id"
+    t.string "last_name"
+    t.date "date_of_birth"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dsi_user_id"], name: "index_search_logs_on_dsi_user_id"
+  end
+
   create_table "staff", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -168,4 +177,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_122729) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "search_logs", "dsi_users"
 end

--- a/spec/factories/search_logs.rb
+++ b/spec/factories/search_logs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :search_log do
+  end
+end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   include ActivateFeaturesSteps
   include CheckRecords::AuthenticationSteps
 
-  scenario "User searches with a last name and date of birth and finds a records",
+  scenario "User searches with a last name and date of birth and finds a record",
            test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_service_is_open
     when_i_sign_in_via_dsi
     and_search_with_a_valid_name_and_dob
     then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
     and_they_have_no_restrictions
 
     when_i_click_on_the_teacher_record
@@ -27,14 +28,19 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def and_search_with_a_valid_name_and_dob
     fill_in "Last name", with: "Walsh"
-    fill_in "Day", with: "1"
-    fill_in "Month", with: "January"
-    fill_in "Year", with: "1990"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
     click_button "Find record"
   end
 
   def then_i_see_a_teacher_record_in_the_results
     expect(page).to have_content "Terry Walsh"
+  end
+
+  def and_my_search_is_logged
+    expect(SearchLog.last.last_name).to eq "Walsh"
+    expect(SearchLog.last.date_of_birth.to_s).to eq "1992-04-05"
   end
 
   def and_they_have_no_restrictions


### PR DESCRIPTION

### Context
To monitor usage against T&Cs we need to log searches against the user record.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Introduce a SearchLog model with corresponding database table
- Persist last name and date of birth when a valid search is submitted
- Add last name and date of birth to analytics_pii list
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/9YnVCO4Z/183-log-searches
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
