### PR TITLE
Add 'No teachers found' content and link back to search page

### DIFF
--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -3,32 +3,38 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Search results (<%= @total %>)</h1>
+    <% if @total.zero? %>
+      <p class="govuk-body">
+        No teachers found.
+        <%= govuk_link_to("Try another search", check_records_search_path) %>.
+      </p>
+    <% else %>
+      <div class="search-results">
+        <% @teachers.each do |teacher| %>
+          <div class="search-results__item">
+            <h2 class="govuk-heading-s">
+              <%= link_to teacher.name, check_records_teacher_path(teacher.trn), class: "govuk-link--no-visited-state" %>
+            </h2>
+            <strong class="govuk-tag govuk-tag--<%= teacher.sanctions.any? ? "red" : "green" %>"%>
+              <%= teacher.sanctions.any? ? "Restrictions" : "No restrictions" %>
+            </strong>
 
-    <div class="search-results">
-      <% @teachers.each do |teacher| %>
-        <div class="search-results__item">
-          <h2 class="govuk-heading-s">
-            <%= link_to teacher.name, check_records_teacher_path(teacher.trn), class: "govuk-link--no-visited-state" %>
-          </h2>
-          <strong class="govuk-tag govuk-tag--<%= teacher.sanctions.any? ? "red" : "green" %>"%>
-            <%= teacher.sanctions.any? ? "Restrictions" : "No restrictions" %>
-          </strong>
-
-          <% 
-            rows = [
-              {
-                key: { text: "TRN" },
-                value: { text: teacher.trn }
-              },
-              {
-                key: { text: "Date of birth" },
-                value: { text: Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
-              }
-            ] 
-          %>
-          <%= render GovukComponent::SummaryListComponent.new(rows:, borders: false, classes: ['app-summary-list--compact']) %>
-        </div>
-      <% end %>
-    </div>
+            <%
+              rows = [
+                {
+                  key: { text: "TRN" },
+                  value: { text: teacher.trn }
+                },
+                {
+                  key: { text: "Date of birth" },
+                  value: { text: Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
+                }
+              ]
+            %>
+            <%= render GovukComponent::SummaryListComponent.new(rows:, borders: false, classes: ['app-summary-list--compact']) %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -17,6 +17,8 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
+      return { total: 0, results: [] }.to_json if params["lastName"] == "No match"
+
       {
         total: 1,
         results: [teacher_data(sanctions: params["lastName"] == "Restricted")]

--- a/spec/system/check_records/user_searches_with_no_matches_spec.rb
+++ b/spec/system/check_records/user_searches_with_no_matches_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "No matches", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include CheckRecords::AuthenticationSteps
+
+  scenario "User searches with a last name and date of birth and finds no matches",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi
+    and_search_returns_no_records
+    then_i_see_no_records
+  end
+
+  private
+
+  def and_search_returns_no_records
+    fill_in "Last name", with: "No match"
+    fill_in "Day", with: "1"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "1990"
+    click_button "Find record"
+  end
+
+  def then_i_see_no_records
+    expect(page).to have_content("No teachers found")
+    expect(page).to have_link("Try another search")
+  end
+end


### PR DESCRIPTION
### Context

Give users a link back to the search page if no records are found.

### Changes proposed in this pull request

<img width="903" alt="Screenshot 2023-09-11 at 13 17 35" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/e932d604-6987-4c70-ade7-541b8b668e53">

### Guidance to review

Make a search that returns no records.
Check the content and the link to return to the search page.

### Link to Trello card

https://trello.com/c/d0S2KO9z/187-update-content-for-no-teachers-found

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally