### PR TITLE
Add standard govuk error summary to form

### DIFF
--- a/app/views/check_records/search/new.html.erb
+++ b/app/views/check_records/search/new.html.erb
@@ -2,9 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Find teacher record</h1>
-
     <%= form_with model: @search, url: check_records_result_path, method: :get do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Find teacher record</h1>
+
       <%= f.govuk_text_field :last_name, class: "govuk-input--width-20", label: { class: "govuk-label--s", text: "Last name" }, required: true %>
 
       <%= f.govuk_date_field(

--- a/spec/system/check_records/user_searches_with_invalid_values_spec.rb
+++ b/spec/system/check_records/user_searches_with_invalid_values_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     given_the_service_is_open
     when_i_sign_in_via_dsi
     and_press_find_record
+    then_i_see_the_error_summary
     then_i_see_the_missing_name_error
     then_i_see_the_missing_dob_error
 
@@ -37,6 +38,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def and_press_find_record
     click_button "Find record"
+  end
+
+  def then_i_see_the_error_summary
+    expect(page).to have_content "There’s a problem"
   end
 
   def then_i_see_the_missing_dob_error


### PR DESCRIPTION
### Context

We're missing the error summary at the top of the search form.

### Changes proposed in this pull request

<img width="935" alt="Screenshot 2023-09-12 at 21 22 13" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/18436946/f7917014-3001-4e52-9937-a1525daec41a">

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally