### PR TITLE
Update formatting of sanctions

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -13,12 +13,14 @@
     <% if @teacher.sanctions.any? %>
       <div class="app__restrictions">
         <h2 class="govuk-heading-m">Restrictions</h2>
-        <%= govuk_inset_text do %>
+        <%= govuk_inset_text classes: "govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
           <% @teacher.sanctions.each do |sanction| %>
-            <h3 class="govuk-heading-s">
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-0">
               <%= sanction.title %>
             </h3>
-            <%= sanction.start_date.strftime("%d %B %Y") if sanction.start_date %>
+            <p class="govuk-!-margin-bottom-l">
+              <%= sanction.start_date.strftime("%d %B %Y") if sanction.start_date %>
+            </p>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
When multiple sanctions are displayed they were incorrectly spaced.

Before:
<img width="861" alt="Screenshot 2023-09-14 at 10 55 13" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/5216/129735a1-1d0d-4973-a890-c382b9ad2bff">

After:
<img width="658" alt="Screenshot 2023-09-14 at 14 30 46" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/5216/74b207aa-f398-4293-bb61-08ee8dd6ea4f">


