### PR TITLE
Use long_uk date format for consistency

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -19,7 +19,7 @@
               <%= sanction.title %>
             </h3>
             <p class="govuk-!-margin-bottom-l">
-              <%= sanction.start_date.strftime("%d %B %Y") if sanction.start_date %>
+              <%= sanction.start_date.to_fs(:long_uk) if sanction.start_date %>
             </p>
           <% end %>
         <% end %>


### PR DESCRIPTION
### Context

Sanction start date is incorrectly formatted, rendering a leading `0` on the date.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Use the `:long_uk` date format for consistency.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
