### PR TITLE
Configure sign out of DSI via Omniauth strategy

### DIFF
--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   govuk_header(service_name: t("check_records_service.name"), service_url: check_records_root_path) do |header|
     if current_dsi_user
-      header.with_navigation_item(href: check_records_sign_out_path, text: "Sign out")
+      header.with_navigation_item(href: check_records_dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
     else
       header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
     end

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -17,6 +17,7 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
 
     @dsi_user = DsiUser.create_or_update_from_dsi(auth, role)
     session[:dsi_user_id] = @dsi_user.id
+    session[:id_token] = auth.credentials.id_token
     session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
 
     redirect_to check_records_root_path

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 require "check_records/dfe_sign_in"
+require "omniauth/strategies/dfe_openid_connect"
 
+OmniAuth.config.add_camelization('dfe_openid_connect', 'DfEOpenIDConnect')
 OmniAuth.config.logger = Rails.logger
 OmniAuth.config.on_failure =
   proc { |env| AuthFailuresController.action(:failure).call(env) }
@@ -15,9 +17,11 @@ else
   dfe_sign_in_issuer_uri = URI(ENV.fetch("DFE_SIGN_IN_ISSUER", "example"))
 
   Rails.application.config.middleware.use OmniAuth::Builder do
-    provider :openid_connect,
+    provider :dfe_openid_connect,
              name: :dfe,
              callback_path: "/check-records/auth/dfe/callback",
+             logout_path: "/sign-out",
+             post_logout_redirect_uri: "#{ENV['CHECK_RECORDS_DOMAIN']}/check-records/sign-out",
              client_options: {
                host: dfe_sign_in_issuer_uri&.host,
                identifier: ENV["DFE_SIGN_IN_CLIENT_ID"],

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -9,6 +9,8 @@ namespace :check_records, path: "check-records" do
   get "/not-authorised", to: "sign_in#not_authorised"
   get "/sign-out", to: "sign_out#new"
 
+  get "/auth/dfe/sign-out", to: "sign_out#new", as: :dsi_sign_out
+
   get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 

--- a/lib/omniauth/strategies/dfe_openid_connect.rb
+++ b/lib/omniauth/strategies/dfe_openid_connect.rb
@@ -1,0 +1,27 @@
+# This strategy ensures that the id_token_hint param is included in the post_logout_redirect_uri.
+# The node-oidc-provider library requires this param to be present in order for the redirect to work.
+# See: https://github.com/panva/node-oidc-provider/blob/03c9bc513860e68ee7be84f99bfc9dc930b224e8/lib/actions/end_session.js#L27
+# See: https://github.com/omniauth/omniauth_openid_connect/blob/34370d655d39fe7980f89f55715888e0ebd7270e/lib/omniauth/strategies/openid_connect.rb#L423
+#
+module OmniAuth
+  module Strategies
+    class DfEOpenIDConnect < OmniAuth::Strategies::OpenIDConnect
+      TOKEN_KEY = "id_token_hint".freeze
+
+      def encoded_post_logout_redirect_uri
+        return unless options.post_logout_redirect_uri
+
+        logout_uri_params = {
+          "post_logout_redirect_uri" => options.post_logout_redirect_uri
+        }
+
+        if query_string.present?
+          query_params = CGI.parse(query_string[1..])
+          logout_uri_params[TOKEN_KEY] = query_params[TOKEN_KEY].first if query_params.key?(TOKEN_KEY)
+        end
+
+        URI.encode_www_form(logout_uri_params)
+      end
+    end
+  end
+end

--- a/spec/support/system/check_records/authentication_steps.rb
+++ b/spec/support/system/check_records/authentication_steps.rb
@@ -12,6 +12,9 @@ module CheckRecords
         {
           provider: "dfe",
           uid: "123456",
+          credentials: {
+            id_token: "abc123",
+          },
           info: {
             email: "test@example.com",
             first_name: "Test",


### PR DESCRIPTION
### Context

Currently our ‘Sign out' link only ends the users session in our service.
We also need to sign out of DfE Signin too otherwise the user is unable to easily sign back in as a different organisation.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds an OmniAuth strategy which includes the `id_token_hint` param in the `end_session_redirect_uri`. 
Necessary for the [node-oidc-provider](https://github.com/panva/node-oidc-provider/blob/main/lib/actions/end_session.js) library to end the session and redirect successfully.
    
The `id_token_hint` value is the `auth.credentials.id_token` returned on successful sign in. 
This value is stored in the user session and passed as a param in the DfE signout path.
    
Configures omniauth to use this strategy.
    
Adding the redirect route `/check-records/auth/dfe/sign-out` is also necessary to make the redirect work as the underlying `omniauth_openid_connect` gem [pattern matches on the `request_path`](https://github.com/omniauth/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb#L437) as part of the redirect validation.


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/D916iWr3/195-sign-out-via-dfe-signin
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
