### PR TITLE
Fix the change password flow

### DIFF
--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -25,12 +25,16 @@ class Staff::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(_resource)
+    support_interface_path
+  end
 
   # The path used after sending reset password instructions
   # def after_sending_reset_password_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
+
+  def resource_params
+    params.require(:staff).permit(:email, :password, :password_confirmation, :reset_password_token)
+  end
 end

--- a/app/views/staff/passwords/edit.html.erb
+++ b/app/views/staff/passwords/edit.html.erb
@@ -3,10 +3,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.hidden_field :reset_password_token %>
 
-      <%= f.govuk_password_field :password, autocomplete: "new-password", label: { text: "Password" } %>
-      <%= f.govuk_password_field :password_confirmation, autocomplete: "new-password", label: { text: "Password confirmation" } %>
+      <%= f.govuk_password_field :password, autocomplete: "new-password", label: { text: "Password" }, link_errors: true %>
+      <%= f.govuk_password_field :password_confirmation, autocomplete: "new-password", label: { text: "Password confirmation" }, link_errors: true %>
 
       <%= f.govuk_submit "Change my password" %>
     <% end %>

--- a/spec/system/support/staff_change_password_spec.rb
+++ b/spec/system/support/staff_change_password_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.feature "Staff support", type: :system do
+  include CommonSteps
+
+  scenario "Staff changes password" do
+    given_the_service_is_open
+    and_a_staff_user_exists
+
+    when_i_visit_the_staff_page
+    then_i_see_the_staff_sign_in_page
+
+    when_i_click_on_forgot_password
+    then_i_see_the_forgot_password_page
+
+    when_i_fill_email_address
+    and_i_submit_the_form
+    then_i_see_a_password_change_email
+    when_i_click_the_change_password_link
+    and_i_fill_password
+    and_i_set_password
+    then_i_see_the_support_interface
+  end
+
+  private
+
+  def and_a_staff_user_exists
+    create(:staff, :confirmed)
+  end
+
+  def when_i_visit_the_staff_page
+    visit new_staff_session_path
+  end
+
+  def when_i_click_the_change_password_link
+    message = ActionMailer::Base.deliveries.first
+    uri = URI.parse(URI.extract(message.body.to_s).first)
+    expect(uri.path).to eq("/staff/password/edit")
+    expect(uri.query).to include("reset_password_token=")
+    visit "#{uri.path}?#{uri.query}"
+  end
+
+  def when_i_click_on_forgot_password
+    click_link "Forgot your password?"
+  end
+
+  def when_i_fill_email_address
+    fill_in "Email", with: "staff@example.com"
+  end
+
+  def and_i_submit_the_form
+    click_button "Send me reset password instructions", visible: false
+  end
+
+  def then_i_see_the_forgot_password_page
+    expect(page).to have_current_path("/staff/password/new")
+  end
+
+  def then_i_see_the_staff_sign_in_page
+    expect(page).to have_current_path("/staff/sign_in")
+    expect(page).to have_content("Log in")
+  end
+
+  def then_i_see_a_password_change_email
+    perform_enqueued_jobs
+    message = ActionMailer::Base.deliveries.first
+    expect(message).to_not be_nil
+
+    expect(message.subject).to eq("Reset password instructions")
+    expect(message.to).to include("staff@example.com")
+  end
+
+  def and_i_fill_password
+    fill_in "staff-password-field", with: "password"
+    fill_in "staff-password-confirmation-field", with: "password"
+  end
+
+  def and_i_set_password
+    click_button "Change my password", visible: false
+  end
+  
+  def then_i_see_the_support_interface
+    expect(page).to have_current_path("/support")
+    expect(page).to have_content("Support Interface")
+  end
+end
+


### PR DESCRIPTION
There is an error in the change password flow where the reset token
doesn't get correctly passed to the model.

It seems that the controller expects a non-nested location in the params
for the reset token. Our version nests it inside a staff namespace.

While making this change, I added better support for displaying errors
on the change password page.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
