### PR TITLE
Update template IDs in mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = "d5bddb2d-e560-4de1-a851-5e470bf06c76"
+  GENERIC_NOTIFY_TEMPLATE = "5e1842e6-d806-49ce-ba19-0483a056e367"
 
   def notify_email(headers)
     headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,5 +1,5 @@
 class DeviseMailer < Devise::Mailer
-  DEVISE_NOTIFY_TEMPLATE = "f92c39f3-ec99-4607-a16b-5a0eeb4ef7a3".freeze
+  DEVISE_NOTIFY_TEMPLATE = "5e1842e6-d806-49ce-ba19-0483a056e367".freeze
 
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)


### PR DESCRIPTION
This matches the template set up in the AYTQ service in Notify. https://www.notifications.service.gov.uk/services/de4ceefe-1abe-460f-9936-1991b7d26b13

The previous values are from templates labelled as AYTQ under the TRA service https://www.notifications.service.gov.uk/services/539aec1c-26ed-4f89-83c6-fb83737f3db1. We should probably use the actual AYTQ service given it's set up, as:

- this lets us generate test keys for a specific service rather than everything under TRA
- new templates don't need manually prefixing with the service name

I'll write up a card to clean up the AYTQ stuff that currently sits under the TRA service.