### PR TITLE
Remove auth-related flash warnings in Check

### DIFF
--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -17,7 +17,6 @@ module CheckRecords
 
     def authenticate_dsi_user!
       if current_dsi_user.blank?
-        flash[:warning] = "You need to sign in to continue."
         redirect_to check_records_sign_in_path
       end
     end
@@ -33,7 +32,6 @@ module CheckRecords
       end
 
       if Time.zone.at(session[:dsi_user_session_expiry]).past?
-        flash[:warning] = "Your session has expired. Please sign in again."
         redirect_to check_records_sign_out_path
       end
     end

--- a/spec/system/check_records/user_session_expires_spec.rb
+++ b/spec/system/check_records/user_session_expires_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "DSI session expiry", host: :check_records, type: :system do
   end
 
   def then_i_am_required_to_sign_in_again
-    expect(page).to have_content "Your session has expired. Please sign in again."
+    expect(page).to have_content "Sign in to check a teacher’s record"
   end
 
   def when_i_refresh_the_page


### PR DESCRIPTION
We don't want to display these. Being redirected to the sign in page provides sufficient context.
