### PR TITLE
Omit summary list rows with no values

### DIFF
--- a/app/components/check_records/npq_summary_component.html.erb
+++ b/app/components/check_records/npq_summary_component.html.erb
@@ -1,4 +1,6 @@
-<div class="govuk-!-margin-bottom-9">
-  <h2 class="govuk-heading-m">National professional qualifications (NPQ)</h2>
-  <%= render GovukComponent::SummaryListComponent.new(rows:) %>
-</div>
+<% if rows.any? %>
+  <div class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-m">National professional qualifications (NPQ)</h2>
+    <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+  </div>
+<% end %>

--- a/app/components/check_records/qualification_summary_component.html.erb
+++ b/app/components/check_records/qualification_summary_component.html.erb
@@ -1,4 +1,6 @@
-<div class="govuk-!-margin-bottom-9">
-  <h2 class="govuk-heading-m"><%= title %></h2>
-  <%= render GovukComponent::SummaryListComponent.new(rows:) %>
-</div>
+<% if rows.any? %>
+  <div class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-m"><%= title %></h2>
+    <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+  </div>
+<% end %>

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -19,11 +19,18 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
   alias_method :title, :name
 
   def rows
-    return itt_rows if itt?
-    return mq_rows if mq?
-    return induction_rows if induction?
-
-    [{ key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }]
+    @rows = (
+      if itt?
+        itt_rows
+      elsif mq?
+        mq_rows
+      elsif induction?
+        induction_rows if induction?
+      else
+        [{ key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }]
+      end
+    )
+    @rows.select { |row| row[:value][:text].present? }
   end
 
   def induction_rows

--- a/app/components/induction_summary_component.html.erb
+++ b/app/components/induction_summary_component.html.erb
@@ -3,9 +3,9 @@
     <h2 class="govuk-summary-card__title"><%= title %></h2>
   </div>
   <div class="govuk-summary-card__content">
-    <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+    <%= render GovukComponent::SummaryListComponent.new(rows:) if rows.any? %>
     <%= render GovukComponent::DetailsComponent.new(classes: detail_classes, summary_text: "Induction history") do %>
-      <%= render GovukComponent::SummaryListComponent.new(classes: list_classes, rows: history) %>
+      <%= render GovukComponent::SummaryListComponent.new(classes: list_classes, rows: history) if history.any? %>
     <% end %>
   </div>
 </div>

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -48,6 +48,7 @@ class InductionSummaryComponent < ViewComponent::Base
         ]
       end
       .flatten
+      .select { |row| row[:value][:text].present? }
   end
 
   def rows
@@ -88,7 +89,7 @@ class InductionSummaryComponent < ViewComponent::Base
         }
       }
     end
-    @rows
+    @rows.select { |row| row[:value][:text].present? }
   end
 
   def title

--- a/app/components/qualification_summary_component.html.erb
+++ b/app/components/qualification_summary_component.html.erb
@@ -1,1 +1,1 @@
-<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) %>
+<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) if rows.any? %>

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -53,7 +53,7 @@ class QualificationSummaryComponent < ViewComponent::Base
       }
     end
 
-    @rows
+    @rows.select { |row| row[:value][:text].present? }
   end
 
   def itt_rows

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_quals_data, type: :component do
+  describe "rendering" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        name: "Initial teacher training (ITT)",
+        awarded_at: fake_quals_data.end_date&.to_date,
+        type: :itt,
+        details: fake_quals_data.fetch("initial_teacher_training").first
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the qualification" do
+      expect(rows[0].text).to include(qualification.details.dig(:qualification, :name))
+    end
+
+    it "renders the qualification provider" do
+      expect(rows[1].text).to include(qualification.details.dig(:provider, :name))
+    end
+
+    it "renders the qualification programme type" do
+      expect(rows[2].text).to include(qualification.details.programme_type_description)
+    end
+
+    it "renders the qualification subject" do
+      expect(rows[3].text).to include(qualification.details.subjects.first.name.titleize)
+    end
+
+    it "renders the qualification age range" do
+      expect(rows[4].text).to include(qualification.details.age_range&.description)
+    end
+
+    it "renders the qualification course end date" do
+      expect(rows[5].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
+    end
+
+    it "renders the qualification status" do
+      expect(rows[6].text).to include(qualification.details.result)
+    end
+
+    it "omits rows with no value" do
+      qualification.details.end_date = nil
+      qualification.details.result = nil
+      expect(rows.text).not_to include("Course end date")
+      expect(rows.text).not_to include("Course result")
+    end
+  end
+end

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :component do
+  describe "rendering" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:induction) { fake_quals_data.fetch("induction") }
+    let(:qualification) do
+      Qualification.new(
+        name: "Induction summary",
+        awarded_at: induction.end_date&.to_date,
+        type: :itt,
+        details: induction
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+
+    it "renders the component title" do
+      expect(rendered.css(".govuk-summary-card__title").text).to eq("Induction summary")
+    end
+
+    it "renders the component rows" do
+      rows = rendered.css(".govuk-summary-list__row")
+      expect(rows[0].css(".govuk-summary-list__key").text).to eq("Status")
+      expect(rows[0].css(".govuk-summary-list__value").text).to eq("Pass")
+
+      expect(rows[1].css(".govuk-summary-list__key").text).to eq("Completed")
+      expect(rows[1].css(".govuk-summary-list__value").text).to eq(" 1 October 2022")
+
+      expect(rows[2].css(".govuk-summary-list__key").text).to eq("Certificate")
+      expect(rows[2].css(".govuk-summary-list__value").text).to eq("Download Induction certificate")
+
+      expect(rows[3].css(".govuk-summary-list__key").text).to eq("Appropriate body")
+      expect(rows[3].css(".govuk-summary-list__value").text).to eq("Induction body")
+
+      expect(rows[4].css(".govuk-summary-list__key").text).to eq("Start date")
+      expect(rows[4].css(".govuk-summary-list__value").text).to eq(" 1 September 2022")
+
+      expect(rows[5].css(".govuk-summary-list__key").text).to eq("End date")
+      expect(rows[5].css(".govuk-summary-list__value").text).to eq(" 1 October 2022")
+
+      expect(rows[6].css(".govuk-summary-list__key").text).to eq("Number of terms")
+      expect(rows[6].css(".govuk-summary-list__value").text).to eq("1")
+    end
+
+    it "renders does not render empty component rows" do
+      component.qualification.awarded_at = nil
+      component.qualification.details.periods.first.end_date = nil
+
+      expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("Completed")
+      expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("End date")
+    end
+  end
+end

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type: :component do
+  describe "rendering" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        name: "Initial teacher training (ITT)",
+        awarded_at: fake_quals_data.end_date&.to_date,
+        type: :itt,
+        details: fake_quals_data.fetch("initial_teacher_training").first
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the qualification" do
+      expect(rows[0].text).to include(qualification.details.dig(:qualification, :name))
+    end
+
+    it "renders the qualification provider" do
+      expect(rows[1].text).to include(qualification.details.dig(:provider, :name))
+    end
+
+    it "renders the qualification programme type" do
+      expect(rows[2].text).to include(qualification.details.programme_type_description)
+    end
+
+    it "renders the qualification subject" do
+      expect(rows[3].text).to include(qualification.details.subjects.first.name.titleize)
+    end
+
+    it "renders the qualification course start date" do
+      expect(rows[4].text).to include(Date.parse(qualification.details.start_date).to_fs(:long_uk))
+    end
+
+    it "renders the qualification course end date" do
+      expect(rows[5].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
+    end
+
+    it "renders the qualification status" do
+      expect(rows[6].text).to include(qualification.details.result)
+    end
+
+    it "renders the qualification age range" do
+      expect(rows[7].text).to include(qualification.details.age_range&.description)
+    end
+
+    it "omits rows with no value" do
+      qualification.details.end_date = nil
+      qualification.details.result = nil
+      expect(rows.text).not_to include("Course end date")
+      expect(rows.text).not_to include("Course result")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,4 +98,6 @@ RSpec.configure do |config|
 
   config.include ActiveJob::TestHelper
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include FakeQualificationsData, test: :with_fake_quals_data
+  config.include ViewComponent::TestHelpers, type: :component
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -1,12 +1,16 @@
+require_relative "fake_qualifications_data"
+
 class FakeQualificationsApi < Sinatra::Base
+  include FakeQualificationsData
+
   get "/v3/teacher" do
     content_type :json
 
     case bearer_token
     when "token"
-      quals_data
+      quals_data.to_json
     when "no-itt-token"
-      quals_data(trn: "1234567", itt: false)
+      quals_data(trn: "1234567", itt: false).to_json
     when "invalid-token"
       halt 401
     end
@@ -35,9 +39,9 @@ class FakeQualificationsApi < Sinatra::Base
     case bearer_token
     when "token"
       if trn == "1234567"
-        quals_data(trn: "1234567")
+        quals_data(trn: "1234567").to_json
       elsif trn == "987654321"
-        quals_data(trn:)
+        quals_data(trn:).to_json
       else
         halt 404
       end
@@ -105,88 +109,6 @@ class FakeQualificationsApi < Sinatra::Base
       ],
       trn: "987654321"
     }
-  end
-
-  def quals_data(trn: nil, itt: true)
-    {
-      trn: trn || "3000299",
-      dateOfBirth: "2000-01-01",
-      firstName: "Terry",
-      lastName: "Walsh",
-      eyts: {
-        awarded: "2022-04-01",
-        certificateUrl: trn ? nil : "/v3/certificates/eyts"
-      },
-      qts: {
-        awarded: "2023-02-27",
-        certificateUrl: trn ? nil : "/v3/certificates/qts"
-      },
-      induction: {
-        startDate: "2022-09-01",
-        endDate: "2022-10-01",
-        status: "pass",
-        certificateUrl: "/v3/certificates/induction",
-        periods: [
-          {
-            startDate: "2022-09-01",
-            endDate: "2022-10-01",
-            terms: 1,
-            appropriateBody: {
-              name: "Induction body"
-            }
-          }
-        ]
-      },
-      initialTeacherTraining:
-        (
-          if !itt
-            []
-          else
-            [
-              {
-                ageRange: {
-                  description: "10 to 16 years"
-                },
-                endDate: "2023-01-28",
-                programmeType: "HEI",
-                programmeTypeDescription: "Higher education institution",
-                provider: {
-                  name: "Earl Spencer Primary School",
-                  ukprn: nil
-                },
-                qualification: {
-                  name: "BA"
-                },
-                result: "Pass",
-                startDate: "2022-02-28",
-                subjects: [{ code: "100079", name: "business studies" }]
-              }
-            ]
-          end
-        ),
-      mandatoryQualifications: [
-        { awarded: "2023-02-28", specialism: "Visual impairment" }
-      ],
-      npqQualifications: [
-        {
-          awarded: "2023-02-27",
-          certificateUrl: trn ? nil : "/v3/certificates/npq/1",
-          type: {
-            code: "NPQH",
-            name: "NPQ headteacher"
-          }
-        },
-        {
-          awarded: "2023-01-27",
-          certificateUrl: "/v3/certificates/npq/missing",
-          type: {
-            code: "NPQSL",
-            name: "NPQ senior leadership"
-          }
-        }
-      ],
-      sanctions: trn == "987654321" ? [ { code: "C2", startDate: "2020-10-25" } ] : []
-    }.to_json
   end
 
   def bearer_token

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -1,0 +1,83 @@
+module FakeQualificationsData
+  def quals_data(trn: nil, itt: true)
+    {
+      trn: trn || "3000299",
+      dateOfBirth: "2000-01-01",
+      firstName: "Terry",
+      lastName: "Walsh",
+      eyts: {
+        awarded: "2022-04-01",
+        certificateUrl: trn ? nil : "/v3/certificates/eyts"
+      },
+      qts: {
+        awarded: "2023-02-27",
+        certificateUrl: trn ? nil : "/v3/certificates/qts"
+      },
+      induction: {
+        startDate: "2022-09-01",
+        endDate: "2022-10-01",
+        status: "pass",
+        certificateUrl: "/v3/certificates/induction",
+        periods: [
+          {
+            startDate: "2022-09-01",
+            endDate: "2022-10-01",
+            terms: 1,
+            appropriateBody: {
+              name: "Induction body"
+            }
+          }
+        ]
+      },
+      initialTeacherTraining:
+        (
+          if !itt
+            []
+          else
+            [
+              {
+                ageRange: {
+                  description: "10 to 16 years"
+                },
+                endDate: "2023-01-28",
+                programmeType: "HEI",
+                programmeTypeDescription: "Higher education institution",
+                provider: {
+                  name: "Earl Spencer Primary School",
+                  ukprn: nil
+                },
+                qualification: {
+                  name: "BA"
+                },
+                result: "Pass",
+                startDate: "2022-02-28",
+                subjects: [{ code: "100079", name: "business studies" }]
+              }
+            ]
+          end
+        ),
+      mandatoryQualifications: [
+        { awarded: "2023-02-28", specialism: "Visual impairment" }
+      ],
+      npqQualifications: [
+        {
+          awarded: "2023-02-27",
+          certificateUrl: trn ? nil : "/v3/certificates/npq/1",
+          type: {
+            code: "NPQH",
+            name: "NPQ headteacher"
+          }
+        },
+        {
+          awarded: "2023-01-27",
+          certificateUrl: "/v3/certificates/npq/missing",
+          type: {
+            code: "NPQSL",
+            name: "NPQ senior leadership"
+          }
+        }
+      ],
+      sanctions: trn == "987654321" ? [ { code: "C2", startDate: "2020-10-25" } ] : []
+    }
+  end
+end


### PR DESCRIPTION
### Context

When displaying a summary list with values that could be blank we should omit the blank rows.
Summary lists with no data should not be displayed.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

 - Hide blank rows in Qualification summary lists
 - Do not render summary list components with no data

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/Gpg69pIJ/208-hide-panel-rows-that-have-empty-data
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
