### PR TITLE
Update / fix DfE signin flows

### DIFF
--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,9 +1,11 @@
 <%=
   govuk_header(service_name: t("check_records_service.name"), service_url: check_records_root_path) do |header|
-    if current_dsi_user
-      header.with_navigation_item(href: check_records_dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
-    else
-      header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
+    if request.path != check_records_not_authorised_path
+      if current_dsi_user
+        header.with_navigation_item(href: check_records_dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
+      else
+        header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
+      end
     end
   end
 %>

--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -3,7 +3,7 @@
     if request.path != check_records_not_authorised_path
       if current_dsi_user
         header.with_navigation_item(href: check_records_dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
-      else
+      elsif request.path != check_records_sign_in_path
         header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
       end
     end

--- a/app/controllers/auth_failures_controller.rb
+++ b/app/controllers/auth_failures_controller.rb
@@ -8,7 +8,7 @@ class AuthFailuresController < ApplicationController
     when :identity
       handle_failure_then_redirect_to qualifications_root_path
     when :dfe
-      handle_failure_then_redirect_to check_records_sign_in_path
+      handle_failure_then_redirect_to check_records_sign_in_path(oauth_failure: true)
     end
   end
 

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -2,25 +2,50 @@
 
 class CheckRecords::OmniauthCallbacksController < ApplicationController
   protect_from_forgery except: :dfe_bypass
+  before_action :clear_session_attributes
+  before_action :add_auth_attributes_to_session, only: :dfe
 
   def dfe
-    auth = request.env["omniauth.auth"]
-
     unless CheckRecords::DfESignIn.bypass?
-      role = DfESignInApi::GetUserAccessToService.new(
-        org_id: auth.extra.raw_info.organisation.id,
-        user_id: auth.uid,
-      ).call
+      role = check_user_access_to_service
 
       return redirect_to check_records_not_authorised_path unless role
     end
 
-    @dsi_user = DsiUser.create_or_update_from_dsi(auth, role)
-    session[:dsi_user_id] = @dsi_user.id
-    session[:id_token] = auth.credentials.id_token
-    session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
+    create_or_update_dsi_user
 
     redirect_to check_records_root_path
   end
   alias_method :dfe_bypass, :dfe
+
+  private
+
+  def auth
+    request.env["omniauth.auth"]
+  end
+
+  def add_auth_attributes_to_session
+    session[:id_token] = auth.credentials.id_token
+    session[:organisation_name] = auth.extra.raw_info.organisation.name
+  end
+
+  def check_user_access_to_service
+    DfESignInApi::GetUserAccessToService.new(
+      org_id: auth.extra.raw_info.organisation.id,
+      user_id: auth.uid,
+    ).call
+  end
+
+  def create_or_update_dsi_user
+    @dsi_user = DsiUser.create_or_update_from_dsi(auth)
+    session[:dsi_user_id] = @dsi_user.id
+    session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
+  end
+
+  def clear_session_attributes
+    session[:organisation_name] = nil
+    session[:id_token] = nil
+    session[:dsi_user_id] = nil
+    session[:dsi_user_session_expiry] = nil
+  end
 end

--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -2,7 +2,6 @@
 
 class CheckRecords::OmniauthCallbacksController < ApplicationController
   protect_from_forgery except: :dfe_bypass
-  before_action :clear_session_attributes
   before_action :add_auth_attributes_to_session, only: :dfe
 
   def dfe
@@ -40,12 +39,5 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
     @dsi_user = DsiUser.create_or_update_from_dsi(auth)
     session[:dsi_user_id] = @dsi_user.id
     session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
-  end
-
-  def clear_session_attributes
-    session[:organisation_name] = nil
-    session[:id_token] = nil
-    session[:dsi_user_id] = nil
-    session[:dsi_user_session_expiry] = nil
   end
 end

--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -2,6 +2,7 @@ module CheckRecords
   class SignInController < CheckRecordsController
     skip_before_action :authenticate_dsi_user!
     skip_before_action :handle_expired_session!
+    before_action :reset_session, except: :not_authorised
 
     def new
     end

--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -3,11 +3,18 @@ module CheckRecords
     skip_before_action :authenticate_dsi_user!
     skip_before_action :handle_expired_session!
     before_action :reset_session, except: :not_authorised
+    before_action :handle_failed_sign_in, only: :new, if: -> { params[:oauth_failure] == "true" }
 
     def new
     end
 
     def not_authorised
+    end
+
+    private
+
+    def handle_failed_sign_in
+      flash.now[:warning] = I18n.t("validation_errors.generic_oauth_failure")
     end
   end
 end

--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -1,6 +1,7 @@
 module CheckRecords
   class SignOutController < CheckRecordsController
     skip_before_action :handle_expired_session!
+    before_action :reset_session
 
     def new
       session[:dsi_user_id] = nil if dsi_user_signed_in?

--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -4,7 +4,6 @@ module CheckRecords
     before_action :reset_session
 
     def new
-      session[:dsi_user_id] = nil if dsi_user_signed_in?
       redirect_to check_records_sign_in_path
     end
   end

--- a/app/views/check_records/sign_in/not_authorised.html.erb
+++ b/app/views/check_records/sign_in/not_authorised.html.erb
@@ -1,5 +1,4 @@
-<h1 class="govuk-heading-l">Authorisation required</h1>
+<h1 class="govuk-heading-l">You cannot use the DfE Sign-in account for <%= session[:organisation_name] %> to check a teacher’s record</h1>
 <p class="govuk-body">
-  You are not authorised to access this service.
+  If you have access to another organisation in DfE Sign-in, you can <%= govuk_link_to("sign out and start again", check_records_dsi_sign_out_path(id_token_hint: session[:id_token])) %>.
 </p>
-

--- a/spec/support/system/check_records/authentication_steps.rb
+++ b/spec/support/system/check_records/authentication_steps.rb
@@ -24,6 +24,7 @@ module CheckRecords
             raw_info: {
               organisation: {
                 id: org_id,
+                name: "Test School",
               }
             }
           }

--- a/spec/system/check_records/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/check_records/unauthorised_user_signs_in_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe "DSI authentication", host: :check_records do
     expect(page).to have_current_path("/check-records/not-authorised")
     expect(page).to have_content("You cannot use the DfE Sign-in account for Test School to check a teacher’s record")
     expect(page).to have_link("sign out and start again", href: "/check-records/auth/dfe/sign-out?id_token_hint=abc123")
+
+    within(".govuk-header__content") do
+      expect(page).not_to have_link("Sign in")
+      expect(page).not_to have_link("Sign out")
+    end
   end
 end

--- a/spec/system/check_records/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/check_records/unauthorised_user_signs_in_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "DSI authentication", host: :check_records do
 
   def then_i_am_redirected_to_the_unauthorised_page
     expect(page).to have_current_path("/check-records/not-authorised")
-    expect(page).to have_content("You are not authorised to access this service")
+    expect(page).to have_content("You cannot use the DfE Sign-in account for Test School to check a teacher’s record")
+    expect(page).to have_link("sign out and start again", href: "/check-records/auth/dfe/sign-out?id_token_hint=abc123")
   end
 end

--- a/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
@@ -12,19 +12,28 @@ RSpec.describe "DSI authentication", host: :check_records, type: :system do
   end
 
   scenario "User has oauth error when signing in", test: :with_stubbed_auth do
-    given_dsi_auth_is_mocked_with_a_failure
-    when_i_visit_the_sign_in_page
-    and_click_the_dsi_sign_in_button
-    then_i_see_a_sign_in_error
+    given_dsi_auth_is_mocked_with_a_failure("invalid_credentials") do
+      when_i_visit_the_sign_in_page
+      and_click_the_dsi_sign_in_button
+      then_i_see_a_sign_in_error
+    end
+  end
+
+  scenario "User has sessionexpiry oauth error", test: :with_stubbed_auth do
+    given_dsi_auth_is_mocked_with_a_failure("sessionexpired") do
+      when_i_visit_the_sign_in_page
+      and_click_the_dsi_sign_in_button
+      then_i_am_redirected_to_sign_in
+    end
   end
 
   private
 
-  def given_dsi_auth_is_mocked_with_a_failure
-    OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
-  end
-
   def then_i_see_a_sign_in_error
     expect(page).to have_content "There was a problem signing you in. Please try again."
+  end
+
+  def then_i_am_redirected_to_sign_in
+    expect(page).to have_current_path(check_records_sign_in_path)
   end
 end


### PR DESCRIPTION
### Context

There's a CSRF issue with a user signing in, choosing an org, then signing out and signing back in again, this is due to the user session not being reset.
Similarly if a user signs in then visits the sign in path in another window they get the same error.
@malcolmbaig mentioned that a similar problem may also exist with clicking the back button after signing in.

If a user signs in to the service but does not have the appropriate role to access the service they see the _Not Authorised_ page.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Reset the session on sign out. This allows the subsequent sign in after sign out to work as expected.
- Reset the session on sign in, this allows the user to revisit the sign in page without error, either via the back button or another window.
- Update the content of the _Not Authorised_ page adding a link which takes the user back through DSI sign out and redirects them back to the service sign in page.
- Remove the Sign in/out header navigation item for the _Not Authorised_ page. (We may revisit this but it's confusing as is). 

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/947694ec-e646-42e4-b37a-724495b28e97)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

We will need to test the flows here in a non-review environment as we need real-world DSI integration.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/mmBx9QjY/232-update-fix-dfe-signin-flows
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
