### PR TITLE
Display the restrictions in the search results

### DIFF
--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -20,19 +20,32 @@
               <%= teacher.sanctions.any? ? "Restrictions" : "No restrictions" %>
             </strong>
 
-            <%
-              rows = [
-                {
-                  key: { text: "TRN" },
-                  value: { text: teacher.trn }
-                },
-                {
-                  key: { text: "Date of birth" },
-                  value: { text: Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
-                }
-              ]
+            <%= govuk_summary_list borders: false, classes: ['app-summary-list--compact'] do |summary_list|
+              summary_list.with_row do |row|
+                row.with_key { "TRN" }
+                row.with_value { teacher.trn }
+              end
+
+              summary_list.with_row do |row|
+                row.with_key { "Date of birth" }
+                row.with_value { Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
+              end
+
+              if teacher.sanctions.any?
+                summary_list.with_row do |row|
+                  row.with_key { "Restrictions" }
+                  row.with_value do
+                  %>
+                    <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
+                      <% teacher.sanctions.each do |sanction| %>
+                        <li><%= sanction.title %></li>
+                      <% end %>
+                    </ul>
+                  <% end
+                  end
+                end
+              end
             %>
-            <%= render GovukComponent::SummaryListComponent.new(rows:, borders: false, classes: ['app-summary-list--compact']) %>
           </div>
         <% end %>
       </div>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -101,6 +101,10 @@ class FakeQualificationsApi < Sinatra::Base
         {
           code: "C2",
           startDate: "2019-10-25"
+        },
+        {
+          code: "A1A",
+          startDate: "2018-9-20"
         }
       ],
       trn: "987654321"

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe "Teacher search with restrictions",
   def then_i_see_the_restriction_on_the_result
     expect(page).to have_title("Search results (1) - Check a teacher’s record")
     expect(page).to have_content("RESTRICTIONS")
+    expect(page).to have_content("Failed induction")
+    expect(page).to have_content("Prohibition by the General Teaching Council England (GTCE)")
   end
 
   def when_i_click_on_the_result


### PR DESCRIPTION
The prototype for the search results now displays the restrictions of
the teacher as a list.

This change introduces the design to the service.

### Link to Trello card

https://trello.com/c/85LAPLZ2/207-show-restriction-titles-on-index

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

![teachers-search](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/2cbfb8de-2506-4985-993e-e1f7034d4502)
