### PR TITLE
Encode TRNs in URLs

### DIFF
--- a/app/controllers/check_records/teachers_controller.rb
+++ b/app/controllers/check_records/teachers_controller.rb
@@ -2,7 +2,8 @@ module CheckRecords
   class TeachersController < CheckRecordsController
     def show
       client = QualificationsApi::Client.new(token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"])
-      @teacher = client.teacher(trn: params[:id])
+      trn = SecureIdentifier.decode(params[:id])
+      @teacher = client.teacher(trn:)
       @npqs = @teacher.qualifications.filter(&:npq?)
       @other_qualifications = @teacher.qualifications.filter { |qualification| !qualification.npq? }
     rescue QualificationsApi::TeacherNotFoundError

--- a/app/models/secure_identifier.rb
+++ b/app/models/secure_identifier.rb
@@ -1,0 +1,32 @@
+class SecureIdentifier
+  SECRET_KEY = Rails.application.credentials.secret_key_base.byteslice(0..31)
+  CIPHER = 'aes-256-cbc'.freeze
+
+  def self.encode(value)
+    raise ArgumentError, "value cannot be nil" if value.nil?
+    return value if value.empty?
+
+    cipher = OpenSSL::Cipher.new(CIPHER)
+    cipher.encrypt
+    cipher.key = SECRET_KEY
+
+    encrypted = cipher.update(value) + cipher.final # rubocop:disable Rails/SaveBang
+    Base64.urlsafe_encode64(encrypted).strip
+  end
+
+  def self.decode(value)
+    raise ArgumentError, "value cannot be nil" if value.nil?
+    return value if value.empty?
+
+    decipher = OpenSSL::Cipher.new(CIPHER)
+    decipher.decrypt
+    decipher.key = SECRET_KEY
+  
+    begin
+      decoded = Base64.urlsafe_decode64(value)
+      decipher.update(decoded) + decipher.final # rubocop:disable Rails/SaveBang
+    rescue ArgumentError
+      value
+    end
+  end
+end

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -14,7 +14,7 @@
         <% @teachers.each do |teacher| %>
           <div class="search-results__item">
             <h2 class="govuk-heading-s">
-              <%= link_to teacher.name, check_records_teacher_path(teacher.trn), class: "govuk-link--no-visited-state" %>
+              <%= link_to teacher.name, check_records_teacher_path(SecureIdentifier.encode(teacher.trn)), class: "govuk-link--no-visited-state" %>
             </h2>
             <% if teacher.sanctions.any? %>
               <strong class="govuk-tag govuk-tag--red">

--- a/spec/models/secure_identifier_spec.rb
+++ b/spec/models/secure_identifier_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe SecureIdentifier do
+  let(:plain_text) { 'Hello, World!' }
+
+  describe '.encode' do
+    subject { described_class.encode(plain_text) }
+
+    it { is_expected.not_to eq(plain_text) }
+
+    it 'returns a Base64 encoded string' do
+      is_expected.to eq(
+        Base64.strict_encode64(Base64.strict_decode64(SecureIdentifier.encode(plain_text)))
+      )
+    end
+
+    context 'when given an empty string' do
+      let(:plain_text) { '' }
+
+      it { is_expected.to eq(plain_text) }
+    end
+
+    context 'when given nil' do
+      let(:plain_text) { nil }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '.decode' do
+    subject { described_class.decode(encoded_text) }
+
+    let(:encoded_text) { described_class.encode(plain_text) }
+
+    it { is_expected.to eq(plain_text) }
+
+    context 'when given an invalid Base64 string' do
+      let(:encoded_text) { 'invalid' }
+
+      it 'returns the passed value' do
+        is_expected.to eq(encoded_text)
+      end
+    end
+
+    context 'when given an empty string' do
+      let(:encoded_text) { '' }
+
+      it { is_expected.to eq(encoded_text) }
+    end
+
+    context 'when given nil' do
+      let(:encoded_text) { nil }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     and_my_search_is_logged
 
     when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_itt_details
@@ -35,6 +36,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_a_teacher_record_in_the_results
     expect(page).to have_content "Terry Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
   end
 
   def and_my_search_is_logged


### PR DESCRIPTION
Exposing a TRN in the URL opens us up to someone being able to enumerate
through the values and capture data on people.

We want to prevent this by encoding the values passed in the URL. This
ensures that the UI is the only way to access someone's record.

I opted to use a symmetric encoding process to allow us to encode/decode
using a secret that we control.

This is an easy to understand encryption that is as secure as our secret
key.

### Link to Trello card

https://trello.com/c/RRrlB9fK/33-spike-dont-use-trn-in-the-url

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
