### PR TITLE
Use correct heading indices

### DIFF
--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -15,7 +15,7 @@
       </div>
 
       <div class="govuk-grid-column-one-third app__details-menu">
-        <h3 class="govuk-heading-m">Your details</h3>
+        <h2 class="govuk-heading-m">Your details</h2>
         <p>
           Name on certificates<br /> 
           <strong><%= [@teacher.first_name, @teacher.last_name].join(" ") %></strong>

--- a/app/views/qualifications/starts/show.html.erb
+++ b/app/views/qualifications/starts/show.html.erb
@@ -11,7 +11,7 @@
       <li>check your early career teacher induction status</li>
       <li>change the name on your teaching certificates</li>
     </ul>
-    <h1 class="govuk-heading-m">Before you start</h1>
+    <h2 class="govuk-heading-m">Before you start</h2>
 
     <p class="govuk-body">
       You’ll need to create a <strong>DfE Identity account</strong> to access your teaching qualifications. You'll use the account to sign-in to this service and other DfE teaching services.


### PR DESCRIPTION
h1 -> h2 -> h3

### Context

There are a couple of incorrectly defined heading tags.

### Changes proposed in this pull request

Fix 'em.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
