### PR TITLE
Convert ITT and Induction qualification details fields where necessary

### DIFF
--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -42,8 +42,8 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
 
   def itt_rows
     [
-      { key: { text: "Qualification" }, value: { text: details.dig(:qualification, :name) } },
-      { key: { text: "ITT provider" }, value: { text: details.dig(:provider, :name) } },
+      { key: { text: "Qualification" }, value: { text: details.qualification&.name } },
+      { key: { text: "ITT provider" }, value: { text: details.provider&.name } },
       { key: { text: "Programme type" }, value: { text: details.programme_type_description } },
       {
         key: {

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -65,7 +65,7 @@ class QualificationSummaryComponent < ViewComponent::Base
           text: "Qualification"
         },
         value: {
-          text: details.dig(:qualification, :name)
+          text: details.qualification&.name
         }
       },
       {
@@ -73,7 +73,7 @@ class QualificationSummaryComponent < ViewComponent::Base
           text: "ITT provider"
         },
         value: {
-          text: details.dig(:provider, :name)
+          text: details.provider&.name
         }
       },
       {

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -82,7 +82,7 @@ module QualificationsApi
         .map do |itt_response|
           Qualification.new(
             awarded_at: itt_response.end_date&.to_date,
-            details: itt_response,
+            details: CoercedDetails.new(itt_response),
             name: "Initial teacher training (ITT)",
             type: :itt
           )
@@ -95,7 +95,7 @@ module QualificationsApi
       @qualifications << Qualification.new(
         awarded_at: api_data.induction.end_date&.to_date,
         certificate_url: api_data.induction&.certificate_url,
-        details: api_data.induction,
+        details: CoercedDetails.new(api_data.induction),
         name: "Induction",
         type: :induction
       )
@@ -125,6 +125,21 @@ module QualificationsApi
           type: :higher_education
         )
       end
+    end
+  end
+
+  class CoercedDetails < Hash
+    include Hashie::Extensions::Coercion
+    include Hashie::Extensions::MergeInitializer
+    include Hashie::Extensions::MethodAccess
+
+    coerce_key :result, ->(value) { value.underscore.humanize }
+    coerce_key :status, ->(value) do
+      value
+        .underscore
+        .humanize
+        .sub("Requiredto", "Required to")
+        .sub("wales", "Wales")
     end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -80,6 +80,38 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       )
     end
 
+    context "ITT result field" do
+      before do
+        api_data["initialTeacherTraining"][0]["result"] = "DeferredForSkillsTests"
+      end
+
+      it "returns human readable values" do
+        expect(qualifications.find { |q| q.type == :itt }.details.result).to eq("Deferred for skills tests")
+      end
+    end
+
+    context "Induction status field" do
+      context "when the status is FailedInWales" do
+        before do
+          api_data["induction"]["status"] = "FailedInWales"
+        end
+
+        it "returns human readable values" do
+          expect(qualifications.find { |q| q.type == :induction }.details.status).to eq("Failed in Wales")
+        end
+      end
+
+      context "when the status is RequiredtoComplete" do
+        before do
+          api_data["induction"]["status"] = "RequiredtoComplete"
+        end
+
+        it "returns human readable values" do
+          expect(qualifications.find { |q| q.type == :induction }.details.status).to eq("Required to complete")
+        end
+      end
+    end
+
     context "when a qualification has no awarded date" do
       let(:api_data) do
         {


### PR DESCRIPTION
### Context

The DQT API returns camelcase string values for certain fields, in the case of Induction status and ITT result fields these aren't normal human readable values. eg. `DeferredForSkillsTests`, `FailedinWales`

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Use the `Hashie::Coercion` mixin to convert the values of these fields to the desired human friendly values.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I did consider using i18n inside the procs used to coerce values. 
ie. 
```ruby
 coerce_key :status, ->(value) { I18n.t("qualification.induction.status.#{value}", value.underscore.humanize) }
```

But as there were only 2 substitutions required on the Induction status values it seemed simpler to keep the coercion code in one place.
Happy to go with concensus on this though.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/BD6V8rC0/114-ctr-present-enums-as-words
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
