### PR TITLE
Ensure role is passed to `DsiUser.create_or_update_from_dsi`

### DIFF
--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -4,9 +4,11 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
   protect_from_forgery except: :dfe_bypass
   before_action :add_auth_attributes_to_session, only: :dfe
 
+  attr_reader :role
+
   def dfe
     unless CheckRecords::DfESignIn.bypass?
-      role = check_user_access_to_service
+      check_user_access_to_service
 
       return redirect_to check_records_not_authorised_path unless role
     end
@@ -29,14 +31,14 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
   end
 
   def check_user_access_to_service
-    DfESignInApi::GetUserAccessToService.new(
+    @role = DfESignInApi::GetUserAccessToService.new(
       org_id: auth.extra.raw_info.organisation.id,
       user_id: auth.uid,
     ).call
   end
 
   def create_or_update_dsi_user
-    @dsi_user = DsiUser.create_or_update_from_dsi(auth)
+    @dsi_user = DsiUser.create_or_update_from_dsi(auth, role:)
     session[:dsi_user_id] = @dsi_user.id
     session[:dsi_user_session_expiry] = 2.hours.from_now.to_i
   end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -5,7 +5,7 @@ class DsiUser < ApplicationRecord
   has_many :search_logs
   has_many :dsi_user_sessions, dependent: :destroy
 
-  def self.create_or_update_from_dsi(dsi_payload, role = nil)
+  def self.create_or_update_from_dsi(dsi_payload, role: nil)
     dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
 
     dsi_user.update!(

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe DsiUser, type: :model do
     context "when the user has a role" do
       it "creates a session record" do
         role = { "id" => "123", "code" => "TestRole_code" }
-        described_class.create_or_update_from_dsi(dsi_payload, role)
+        described_class.create_or_update_from_dsi(dsi_payload, role:)
 
         dsi_user_session = DsiUser.first.dsi_user_sessions.first
         expect(dsi_user_session).to be_present

--- a/spec/system/check_records/user_signs_in_spec.rb
+++ b/spec/system/check_records/user_signs_in_spec.rb
@@ -17,5 +17,6 @@ RSpec.describe "DSI authentication", host: :check_records do
   def then_i_am_signed_in
     within("header") { expect(page).to have_content "Sign out" }
     expect(DsiUser.count).to eq 1
+    expect(DsiUserSession.count).to eq 1
   end
 end


### PR DESCRIPTION


### Context

A bug arising from a refactor of `OmniAuthCallbacksController` has meant that the authorisation role isn't passed to `DsiUser.create_or_update_from_dsi` and so no `DsiUserSession` is created.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Ensure the role is passed on so that session records are created. 
- Add missing system spec expectation.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
