### PR TITLE
Add current_namespace to ID callback controller

### DIFF
--- a/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
@@ -3,6 +3,11 @@
 module Qualifications
   module Users
     class OmniauthCallbacksController < ApplicationController
+      # Differentiate web requests sent to BigQuery via dfe-analytics
+      def current_namespace
+        "access-your-teaching-qualifications"
+      end
+
       def identity
         auth = request.env["omniauth.auth"]
         @user = User.from_identity(auth)


### PR DESCRIPTION
### Context

We add a namespace to the DfE Analytics web request payload to allow us to differentiate between Check and AYTQ requests. That is done in the service specific base controllers but the omniauth callback controller for AYTQ doesn't use that and so wasn't setting the namespace and consequently requests to `/qualifications/users/auth/identity/callback` aren't namespaced in BigQuery.

### Changes proposed in this pull request

Set the namespace explicitly in the controller.
