### PR TITLE
Change how we display Mandatory Qualifications in Check

### DIFF
--- a/app/components/check_records/mq_summary_component.html.erb
+++ b/app/components/check_records/mq_summary_component.html.erb
@@ -1,0 +1,6 @@
+<% if rows.any? %>
+  <div class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-m">Mandatory qualifications (MQs) for specialist teachers of pupils with sensory impairments</h2>
+    <%= render GovukComponent::SummaryListComponent.new(rows:) %>
+  </div>
+<% end %>

--- a/app/components/check_records/mq_summary_component.rb
+++ b/app/components/check_records/mq_summary_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CheckRecords::MqSummaryComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :mqs
+
+  def rows
+    mqs.map do |mq|
+      {
+        key: {
+          text: key_text(mq)
+        },
+        value: {
+          text: mq.awarded_at.to_fs(:long_uk)
+        }
+      }
+    end
+  end
+
+  private
+
+  def key_text(mandatory_qualification)
+    "Date #{mandatory_qualification.details.specialism.downcase} MQ awarded"
+  end
+end

--- a/app/controllers/check_records/teachers_controller.rb
+++ b/app/controllers/check_records/teachers_controller.rb
@@ -5,7 +5,10 @@ module CheckRecords
       trn = SecureIdentifier.decode(params[:id])
       @teacher = client.teacher(trn:)
       @npqs = @teacher.qualifications.filter(&:npq?)
-      @other_qualifications = @teacher.qualifications.filter { |qualification| !qualification.npq? }
+      @mqs = @teacher.qualifications.filter(&:mq?)
+      @other_qualifications = @teacher.qualifications.reject do |qualification|
+        qualification.npq? || qualification.mq?
+      end
     rescue QualificationsApi::TeacherNotFoundError
       render "not_found"
     end

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -40,6 +40,10 @@
       <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
     <% end %>
 
+    <% if @mqs.present? %>
+      <%= render CheckRecords::MqSummaryComponent.new(mqs: @mqs) %>
+    <% end %>
+
     <% if @npqs.present? %>
       <%= render CheckRecords::NpqSummaryComponent.new(npqs: @npqs) %>
     <% end %>

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -57,7 +57,8 @@ module FakeQualificationsData
           end
         ),
       mandatoryQualifications: [
-        { awarded: "2023-02-28", specialism: "Visual impairment" }
+        { awarded: "2023-02-28", specialism: "Visual impairment" },
+        { awarded: "2022-01-01", specialism: "Hearing" }
       ],
       npqQualifications: [
         {

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -85,8 +85,9 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_mq_details
-    expect(page).to have_content("Mandatory qualification (MQ)")
-    expect(page).to have_content("Date awarded\t28 February 2023")
-    expect(page).to have_content("Specialism\tVisual impairment")
+    expect(page).to have_content("Date visual impairment MQ awarded")
+    expect(page).to have_content("28 February 2023")
+    expect(page).to have_content("Date hearing MQ awarded")
+    expect(page).to have_content("1 January 2022")
   end
 end


### PR DESCRIPTION

### Context
We need to support rendering of multiple MQs, and the headings need some adjustment.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add support for rendering multiple MQs by following the same approach we use for NPQs
- Change the MQ section heading and make the row key more specific to accommodate for the fact that we may be rendering multiple MQs for different specialisms
- Update test data and system spec to cover these changes

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->


![Screenshot_20231113_114733](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/f35c8ee6-07ac-436f-8080-173ea6d3cc12)

### Guidance to review
For simplicity I've put MQs just above NPQs, and below all other quals. Does ordering matter? An alternative ordering is possible but at the expense of code complexity.


<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/oz1IKYZ6/144-update-mq-and-npq-rendering
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
