### PR TITLE
Sort qualifications by type and date

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -39,7 +39,6 @@ module QualificationsApi
           endpoint,
           {
             include: %w[
-              HigherEducationQualifications
               Induction
               InitialTeacherTraining
               NpqQualifications

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -120,19 +120,6 @@ module QualificationsApi
         )
       end
     end
-
-    def add_higher_education_qualifications
-      return if api_data.higher_education_qualifications.blank?
-
-      @qualifications << api_data.higher_education_qualifications.map do |heq|
-        Qualification.new(
-          awarded_at: heq.awarded&.to_date,
-          details: heq,
-          name: heq.name,
-          type: :higher_education
-        )
-      end
-    end
   end
 
   class CoercedDetails < Hash

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -223,29 +223,5 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         expect(qualifications.map(&:type)).to eq(%i[qts itt])
       end
     end
-
-    context "when a Higher Education qualification is returned" do
-      let(:api_data) do
-        {
-          "higherEducationQualifications" => [
-            {
-              "name" => "Some Qualification",
-              "awarded" => "2022-2-22",
-              "subjects" => [
-                { "code" => "100079", "name" => "Business Studies" }
-              ]
-            }
-          ]
-        }
-      end
-
-      it "creates a qualification with the correct attributes" do
-        expect(qualifications.first).to have_attributes(
-          type: :higher_education,
-          name: "Some Qualification",
-          awarded_at: Date.parse("2022-2-22")
-        )
-      end
-    end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         "initialTeacherTraining" => [
           {
             "qualification" => {
+              "name" => "PGCE"
+            },
+            "startDate" => "2011-01-17",
+            "endDate" => "2012-02-2",
+            "programmeType" => "EYITTSchoolDirectEarlyYears",
+            "programmeTypeDescription" => "Early Years Initial Teacher Training (School Direct)",
+            "result" => "Pass",
+            "ageRange" => {
+              "description" => "3 to 7 years"
+            },
+            "provider" => {
+              "name" => "Earl Spencer Primary School",
+              "ukprn" => nil
+            },
+            "subjects" => [{ "code" => "100079", "name" => "business studies" }]
+          },
+          {
+            "qualification" => {
               "name" => "BA"
             },
             "startDate" => "2012-02-28",
@@ -76,13 +94,20 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     it "sorts the qualifications in reverse chronological order by date of award" do
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML eyts qts induction mandatory itt]
+        %i[NPQSL NPQML mandatory induction qts itt eyts itt]
+      )
+    end
+
+    it "orders QTS ITT qualifications before EYTS ITT qualifications" do
+      itt_qualifications = qualifications.select { |q| q.type == :itt }
+      expect(itt_qualifications.map { |q| q.details.programme_type }).to eq(
+        %w[HEI EYITTSchoolDirectEarlyYears]
       )
     end
 
     context "ITT result field" do
       before do
-        api_data["initialTeacherTraining"][0]["result"] = "DeferredForSkillsTests"
+        api_data["initialTeacherTraining"].each { |itt| itt["result"] = "DeferredForSkillsTests" }
       end
 
       it "returns human readable values" do
@@ -150,8 +175,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         }
       end
 
-      it "sorts the qualifications in reverse chronological order by date of award" do
-        expect(qualifications.map(&:type)).to eq(%i[itt NPQML])
+      it "sorts the qualifications in reverse order by date of award and type" do
+        expect(qualifications.map(&:type)).to eq(%i[NPQML itt])
       end
     end
 


### PR DESCRIPTION
### Context

We’re currently combining all of the teacher qualifications and sorting by date awarded. 
This is leading to some inconsistent ordering between records.
A consistent order by qualification type, then awarded at date is preferrable.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Sorts qualifications by their type according to the typical career
progression of a teacher.
ie.
`NPQ or MQ | Induction | QTS | ITT (for QTS) | EYTS | ITT (for EYTS)`

This produces a consistent order for the types of qualification starting
with the most recent.

In the case of a specific type of qualification having multiple results,
the qualifications are sorted by reverse chronological awarded at date.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/auIQPskM/143-update-teacher-record-row-ordering
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
