### PR TITLE
Add description to sanctions

### DIFF
--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -7,38 +7,225 @@ class Sanction
   end
 
   SANCTIONS = {
-    "A13" => { title: "Suspension order - with conditions" },
-    "A14" => { title: "Suspension order - with conditions" },
-    "A18" => { title: "Conditional registration order - conviction of a relevant offence" },
-    "A19" => { title: "Suspension order" },
-    "A1A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A1B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A2" => { title: "Suspension order" },
-    "A20" => { title: "Suspension order - with conditions" },
-    "A21A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A21B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A23" => { title: "Suspension order" },
-    "A24" => { title: "Suspension order - with conditions" },
-    "A25A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A25B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A3" => { title: "Conditional registration order - unacceptable professional conduct" },
-    "A5A" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A5B" => { title: "Prohibition by the General Teaching Council England (GTCE)" },
-    "A6" => { title: "Suspension order" },
-    "A7" => { title: "Conditional registration order  - serious professional incompetence" },
-    "B3" => { title: "Prohibition by the Secretary of State or an Independent Schools Tribunal" },
-    "C1" => { title: "Prohibition by the Secretary of State" },
-    "C2" => { title: "Failed induction" },
-    "C3" => { title: "Restriction by the Secretary of State" },
-    "G1" => { title: "Record found" },
-    "T1" => { title: "Prohibition by the Secretary of State" },
-    "T2" => { title: "Interim prohibition by the Secretary of State" },
-    "T3" => { title: "Prohibition by the Secretary of State - deregistered by GTC Scotland" },
-    "T4" => { title: "Prohibition by the Secretary of State  - refer to the Education Workforce Council, Wales" },
-    "T5" => { title: "Prohibition by the Secretary of State - refer to GTC Northern Ireland" },
-    "T6" => { title: "Secretary of State decision - no prohibition" },
-    "T7" => { title: "Section 128 barring direction" }
+    "A13" => { 
+      title: "Suspension order with conditions", 
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England. 
+
+        Must meet conditions to teach in a maintained school, pupil referral unit or non-maintained special school in England. 
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "A14" => { 
+      title: "Suspension order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England. 
+
+        Must meet conditions to teach in a maintained school, pupil referral unit or non-maintained special school in England. 
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "A18" => { 
+      title: "Registration order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Given a registration order by the General Teaching Council for England. 
+
+        Must meet conditions to teach in a maintained school, pupil referral unit or non-maintained special school in England. 
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "A1A" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of unacceptable professional conduct. 
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A1B" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of unacceptable professional conduct. 
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A20" => { 
+      title: "Suspension order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+
+        Must meet conditions to teach in a maintained school, pupil referral unit or non-maintained special school in England. 
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "A21A" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of a criminal offence which is relevant to fitness to teach.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A21B" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of a criminal offence which is relevant to their fitness to teach.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A3" => { 
+      title: "Registration order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Given a registration order by the General Teaching Council. 
+
+        Must meet conditions to teach in a maintained school, pupil referral unit or non-maintained special school in England. 
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "A5A" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of serious professional incompetence.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A5B" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the General Teaching Council for England because of serious professional incompetence.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "A7" => { 
+      title: "Registration order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Given a registration order by the General Teaching Council for England.
+
+        Must meet conditions to teach in maintained schools, pupil referral units and non-maintained special schools in England. 
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "B3" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching by the Secretary of State or an independent schools tribunal.
+
+        Cannot teach in any school in England, including sixth-form colleges, relevant youth accommodation and children’s homes.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "C1" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching because they failed probation.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "C2" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching because they failed induction.
+
+        Cannot teach in a maintained school, pupil referral unit or non-maintained special school in England.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "C3" => { 
+      title: "Restriction",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching because they failed probation. 
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "G1" => { 
+      title: "Possible match on the children’s barred list",
+      description: <<~DESCRIPTION.chomp
+        Email the Disclosure and Barring Service (DBS) at [dbscost@dbs.gov.uk](mailto:dbscost@dbs.gov.uk) to check if this person is allowed to work with children.
+      DESCRIPTION
+    },
+    "T1" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Found guilty of of serious misconduct.
+
+        Cannot teach in any school in England, including sixth-form colleges, relevant youth accommodation and children’s homes.
+        
+        Check the [list of published decisions on GOV.UK](https://www.gov.uk/search/all?parent=&keywords=panel+outcome+misconduct&level_one_taxon=&manual=&organisations%5B%5D=teaching-regulation-agency&organisations%5B%5D=national-college-for-teaching-and-leadership&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest) for more details.
+      DESCRIPTION
+    },
+    "T2" => { 
+      title: "Interim prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Prevented from teaching during an investigation for serious misconduct.
+
+        Cannot teach in any school in England, including sixth-form colleges, relevant youth accommodation and children’s homes.
+        
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
+      DESCRIPTION
+    },
+    "T3" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Deregistered by the General Teaching Council for Scotland because of serious misconduct. 
+
+        Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.
+      DESCRIPTION
+    },
+    "T4" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Deregistered by the Education Workforce Council, Wales because of serious misconduct.
+
+        Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.
+      DESCRIPTION
+    },
+    "T5" => { 
+      title: "Prohibition order",
+      description: <<~DESCRIPTION.chomp
+        Found guilty of serious misconduct by the General Teaching Council for Northern Ireland.
+
+        Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.
+      DESCRIPTION
+    },
+    "T6" => { 
+      title: "Found guilty by misconduct panel but not prevented from teaching",
+      description: <<~DESCRIPTION.chomp
+        Check the [list of published decisions on GOV.UK](https://www.gov.uk/search/all?parent=&keywords=panel+outcome+misconduct&level_one_taxon=&manual=&organisations%5B%5D=teaching-regulation-agency&organisations%5B%5D=national-college-for-teaching-and-leadership&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest) for more details.
+      DESCRIPTION
+    }
   }.freeze
+
+  def description
+    SANCTIONS[code][:description] if SANCTIONS[code]
+  end
 
   def title
     SANCTIONS[code][:title] if SANCTIONS[code]

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -13,6 +13,11 @@
           <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-0">
             <%= sanction.title %>
           </h2>
+          <% if sanction.description.present? %>
+            <div class="govuk-!-margin-bottom-1">
+              <%= GovukMarkdown.render(sanction.description).html_safe %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/models/sanction_spec.rb
+++ b/spec/models/sanction_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Sanction, type: :model do
     subject { sanction.title }
 
     context 'when type exists in SANCTIONS' do
-      it { is_expected.to eq('Suspension order - with conditions') }
+      it { is_expected.to eq('Suspension order with conditions') }
     end
 
     context 'when type does not exist in SANCTIONS' do
@@ -24,6 +24,27 @@ RSpec.describe Sanction, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#description' do
+    subject(:description) { sanction.description }
+
+    context 'when type exists in SANCTIONS' do
+      let(:code) { "G1" }
+      
+      it "returns the description as markdown" do
+        expect(description)
+          .to eq('Email the Disclosure and Barring Service (DBS) at [dbscost@dbs.gov.uk](mailto:dbscost@dbs.gov.uk) ' \
+                 'to check if this person is allowed to work with children.')
+      end
+    end
+
+    context 'when type does not exist in SANCTIONS' do
+      let(:code) { "Z99" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
 
   describe "start_date" do
     subject { sanction.start_date }

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -103,7 +103,7 @@ class FakeQualificationsApi < Sinatra::Base
       middleName: "",
       sanctions: [
         {
-          code: "C2",
+          code: "G1",
           startDate: "2019-10-25"
         },
         {

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -78,7 +78,7 @@ module FakeQualificationsData
           }
         }
       ],
-      sanctions: trn == "987654321" ? [ { code: "C2", startDate: "2020-10-25" } ] : []
+      sanctions: trn == "987654321" ? [ { code: "G1", startDate: "2020-10-25" } ] : []
     }
   end
 end

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Teacher search with restrictions",
   end
 
   def then_i_see_the_details_of_the_restriction
-    expect(page).to have_content("Failed induction")
+    expect(page).to have_content("Possible match on the children’s barred list")
     expect(page).to have_title("Terry Walsh - Check a teacher’s record")
   end
 end


### PR DESCRIPTION
We have expanded the sanctions list to also display a description
alongside the title.

This data isn't provided by the API so we opted to define it the same
way we do with the titles.

The descriptions contain links and we want them to be clickable so
using markdown made sense here.

The library is already being used elsewhere in the app, so there is no
extra dependency required. Also, we control the markdown text itself, so
there is no security risk by rendering this using the `html_safe`
method.

The use of `CHOMP` on the heredoc is to ensure we avoid the trailing
newline character that a heredoc automatically adds.

### Link to Trello card

https://trello.com/c/XqT7t8dV/150-add-a-description-field-for-sanctions

![capybara-202311141024554670423377](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/118bfe57-27f8-420f-b7ba-6a4bdede42ec)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
