### PR TITLE
Remove restrictions tag

### DIFF
--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -16,11 +16,6 @@
             <h2 class="govuk-heading-s">
               <%= link_to teacher.name, check_records_teacher_path(SecureIdentifier.encode(teacher.trn)), class: "govuk-link--no-visited-state" %>
             </h2>
-            <% if teacher.sanctions.any? %>
-              <strong class="govuk-tag govuk-tag--red">
-                Restrictions
-              </strong>
-            <% end %>
 
             <%= govuk_summary_list borders: false, classes: ['app-summary-list--compact'] do |summary_list|
               summary_list.with_row do |row|
@@ -32,22 +27,7 @@
                 row.with_key { "Date of birth" }
                 row.with_value { Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
               end
-
-              if teacher.sanctions.any?
-                summary_list.with_row do |row|
-                  row.with_key { "Restrictions" }
-                  row.with_value do
-                  %>
-                    <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
-                      <% teacher.sanctions.each do |sanction| %>
-                        <li><%= sanction.title %></li>
-                      <% end %>
-                    </ul>
-                  <% end
-                  end
-                end
-              end
-            %>
+            end %>
           </div>
         <% end %>
       </div>

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -5,23 +5,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
       <%= @teacher.name %>
-      <% if @teacher.sanctions.any? %>
-        <strong class="govuk-tag govuk-tag--red">
-          Restrictions
-        </strong>
-      <% end %>
     </h1>
 
     <% if @teacher.sanctions.any? %>
-      <h2 class="govuk-heading-m">Restrictions</h2>
       <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
         <% @teacher.sanctions.each do |sanction| %>
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-0">
             <%= sanction.title %>
-          </h3>
-          <p class="govuk-!-margin-bottom-1">
-            <%= sanction.start_date.to_fs(:long_uk) if sanction.start_date %>
-          </p>
+          </h2>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe "Teacher search with restrictions",
 
   def then_i_see_the_restriction_on_the_result
     expect(page).to have_title("Search results (1) - Check a teacher’s record")
-    expect(page).to have_content("RESTRICTIONS")
-    expect(page).to have_content("Failed induction")
-    expect(page).to have_content("Prohibition by the General Teaching Council England (GTCE)")
   end
 
   def when_i_click_on_the_result
@@ -39,9 +36,7 @@ RSpec.describe "Teacher search with restrictions",
   end
 
   def then_i_see_the_details_of_the_restriction
-    expect(page).to have_content("RESTRICTIONS")
     expect(page).to have_content("Failed induction")
-    expect(page).to have_content("25 October 2020")
     expect(page).to have_title("Terry Walsh - Check a teacher’s record")
   end
 end


### PR DESCRIPTION
We have decided to remove the restrictions tag from both the search
results page and the detail page for a teacher.

The reasoning is that it doesn't add any useful information at best and is
potentially confusing at worst.

We also want to remove the date of the sanction.

See [Trello](https://trello.com/c/zlTNQhY4/133-update-restrictions-display) for the details.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
