### PR TITLE
Update rendering of NPQ names in Check 

### DIFF
--- a/app/components/check_records/npq_summary_component.rb
+++ b/app/components/check_records/npq_summary_component.rb
@@ -9,12 +9,19 @@ class CheckRecords::NpqSummaryComponent < ViewComponent::Base
     npqs.map do |npq|
       {
         key: {
-          text: ["Date", npq.name, "awarded"].join(" ")
+          text: key_text(npq)
         },
         value: {
           text: npq.awarded_at.to_fs(:long_uk)
         }
       }
     end
+  end
+
+  private
+
+  def key_text(npq)
+    tidied_name = npq.name.gsub(/National Professional Qualification \(NPQ\) for /, '')
+    "Date NPQ for #{tidied_name} awarded"
   end
 end

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -74,7 +74,7 @@ module FakeQualificationsData
           certificateUrl: "/v3/certificates/npq/missing",
           type: {
             code: "NPQSL",
-            name: "NPQ senior leadership"
+            name: "National Professional Qualification (NPQ) for Early Years Leadership"
           }
         }
       ],

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_npq_details
-    expect(page).to have_content("Date NPQ headteacher awarded")
+    expect(page).to have_content("Date NPQ for Early Years Leadership awarded")
     expect(page).to have_content("27 February 2023")
   end
 


### PR DESCRIPTION

### Context
Currently the Qualifications API returns the NPQ name in the following form:

"National Professional Qualification (NPQ) for [name of NPQ]"

We want to remove the acronym expansion at the start so we can use the actual name of the qualification in a field heading.


<!-- Why are you making this change? -->

### Changes proposed in this pull request
Add a gsub to remove the prefix if it is present.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/oz1IKYZ6/144-update-mq-and-npq-rendering
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
