### PR TITLE
Guard against a missing induction certificate

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -71,7 +71,7 @@ class InductionSummaryComponent < ViewComponent::Base
       }
     ]
 
-    if details.certificate_url.present?
+    if details.respond_to?(:certificate_url) && details.certificate_url.present?
       @rows << {
         key: {
           text: "Certificate"

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :component do
   describe "rendering" do
+    subject(:rendered) { render_inline(component) }
+
     let(:fake_quals_data) do
       Hashie::Mash.new(
         quals_data(trn: "1234567")
@@ -19,7 +21,6 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
       )
     end
     let(:component) { described_class.new(qualification:) }
-    let(:rendered) { render_inline(component) }
 
     it "renders the component title" do
       expect(rendered.css(".govuk-summary-card__title").text).to eq("Induction summary")
@@ -55,6 +56,18 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
 
       expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("Completed")
       expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("End date")
+    end
+
+    context "when the certificate URL is missing" do
+      let(:induction) do
+        fake_quals_data.fetch("induction").tap do |data|
+          data.delete(:certificate_url)
+        end
+      end
+
+      it "does not render the certificate row when certificate URL is missing" do
+        expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("Certificate")
+      end
     end
   end
 end


### PR DESCRIPTION
There are scenarios where an induction may be missing a certificate URL.

Currently, we're displaying an error message to the user but a better
experience would be to simply not show the certificate link.


### Link to Trello card

https://trello.com/c/Isi4gE7v/233-bug-aytq-not-handling-missing-certificateurl

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
