### PR TITLE
Add result_count to SearchLog

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -17,11 +17,6 @@ module CheckRecords
       if @search.invalid?
         render :new
       else
-        SearchLog.create!(
-          dsi_user: current_dsi_user,
-          last_name: @search.last_name,
-          date_of_birth: @search.date_of_birth.to_s
-        )
         @total, @teachers =
           QualificationsApi::Client.new(
             token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"]
@@ -29,6 +24,13 @@ module CheckRecords
             date_of_birth: @search.date_of_birth,
             last_name: @search.last_name
           )
+
+        SearchLog.create!(
+          dsi_user: current_dsi_user,
+          last_name: @search.last_name,
+          date_of_birth: @search.date_of_birth.to_s,
+          result_count: @total
+        )
       end
     end
   end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -59,6 +59,7 @@ shared:
     - dsi_user_id
     - last_name
     - date_of_birth
+    - result_count
     - created_at
     - updated_at
   :staff:

--- a/db/migrate/20231116115727_add_result_count_to_search_log.rb
+++ b/db/migrate/20231116115727_add_result_count_to_search_log.rb
@@ -1,0 +1,5 @@
+class AddResultCountToSearchLog < ActiveRecord::Migration[7.0]
+  def change
+    add_column :search_logs, :result_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_120219) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_115727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -134,6 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_120219) do
     t.date "date_of_birth"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "result_count"
     t.index ["dsi_user_id"], name: "index_search_logs_on_dsi_user_id"
   end
 

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -43,8 +43,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def and_my_search_is_logged
-    expect(SearchLog.last.last_name).to eq "Walsh"
-    expect(SearchLog.last.date_of_birth.to_s).to eq "1992-04-05"
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
   end
 
   def when_i_click_on_the_teacher_record


### PR DESCRIPTION


### Context
Whenever a search happens in Check, we want to record the number of results returned. This will help with analysis and potentially provide some UX insight.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Add a `result_count` integer field to SearchLog
- Add this to the analytics.yml field list so it gets sent to BigQuery

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
[DNM] tag is because we need to confirm how to update dataform before merging this PR.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/iKCySmlO/218-surface-the-number-of-search-results-for-analytics
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
