### PR TITLE
Handle missing `programmeType` for ITT qualifications

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -77,7 +77,7 @@ module QualificationsApi
 
     def add_itt(qts: true)
       all_itt_data = api_data.fetch("initial_teacher_training", [])
-      eyts_itt_data, qts_itt_data = all_itt_data.partition { |itt| itt.programme_type.starts_with?("EYITT") }
+      eyts_itt_data, qts_itt_data = all_itt_data.partition { |itt| itt.programme_type&.starts_with?("EYITT") }
       itt_data = qts ? qts_itt_data : eyts_itt_data
 
       @qualifications << itt_data

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       )
     end
 
+    it "designates ITT qualifications as QTS if no programme type is present" do
+      itt_qualification = api_data["initialTeacherTraining"].first
+      itt_qualification["programmeType"] = nil
+      api_data["initialTeacherTraining"] = [itt_qualification]
+
+      expect(qualifications.map(&:type)).to eq(
+        %i[NPQSL NPQML mandatory induction qts itt eyts]
+      )
+    end
+
     context "ITT result field" do
       before do
         api_data["initialTeacherTraining"].each { |itt| itt["result"] = "DeferredForSkillsTests" }


### PR DESCRIPTION
### Context

We have a sentry error in production where the qualifications API returns no `programmeType` property for an ITT qualification.

https://dfe-teacher-services.sentry.io/issues/4650996545/?alert_rule_id=14607780&alert_type=issue&notification_uuid=27ce023f-8a29-4289-9d1a-844ca7425e8b&project=4505227155996672

[We recently added ordering of qualifications by type](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/423), and this included [differentiating ITT qualifications by programme type](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/423/files#diff-0c4f2f2f0c16019e6e072f5876f060c9c1cd9f556c363127d8b8b4438ae59c9cR79-R81).
This is likely the cause of the error.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Allow for null programmeType and default to adding the ITT qualification as a QTS type. 

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
