### PR TITLE
Bugfix - use safe navigation when rendering Induction data in AYTQ

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -25,7 +25,7 @@ class InductionSummaryComponent < ViewComponent::Base
               text: "Appropriate body"
             },
             value: {
-              text: period.appropriate_body.name
+              text: period&.appropriate_body&.name
             }
           },
           {
@@ -33,7 +33,7 @@ class InductionSummaryComponent < ViewComponent::Base
               text: "Start date"
             },
             value: {
-              text: period.start_date.to_date.to_fs(:long_uk)
+              text: period.start_date&.to_date&.to_fs(:long_uk)
             }
           },
           {


### PR DESCRIPTION
### Context
https://dfe-teacher-services.sentry.io/issues/4658546206/?alert_rule_id=14804354&alert_type=issue&environment=production&notification_uuid=661be444-29b9-4b56-b050-46f8e1b5f854&project=4505227155996672&referrer=slack
<!-- Why are you making this change? -->

### Changes proposed in this pull request
We have a card to resolve this class of error comprehensively, but for now patch in safe navigation so we don't get an error when trying to render Inductions from the API where `period` fields are nil.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/5DfQw9oj/246-check-qualifications-api-client-code-for-dependencies-on-nullable-fields
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
