### PR TITLE
Fix display of previous names

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -14,10 +14,13 @@ module QualificationsApi
              :first_name,
              :last_name,
              :middle_name,
-             :previous_names,
              :sanctions,
              :trn,
              to: :api_data
+
+    def previous_names
+      api_data.previous_names.map(&:last_name)
+    end
 
     def qualifications
       @qualifications = []

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -28,7 +28,7 @@
         rows: [
           { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
           { key: { text: "Date of birth" }, value: { text: Date.parse(@teacher.date_of_birth).to_fs(:long_uk) } },
-          { key: { text: "Previous last names" }, value: { text: @teacher.previous_names&.join("<br />") } },
+          { key: { text: "Previous last names" }, value: { text: @teacher.previous_names&.join("<br />").html_safe } },
         ])
       %>
     </div>

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -5,7 +5,10 @@ module FakeQualificationsData
       dateOfBirth: "2000-01-01",
       firstName: "Terry",
       lastName: "Walsh",
-      previousNames: ["Jones", "Smith"],
+      previousNames: [
+        { first_name: "Terry", last_name: "Jones", middle_name: "" }, 
+        { first_name: "Terry", last_name: "Smith", middle_name: "" }
+      ],
       eyts: {
         awarded: "2022-04-01",
         certificateUrl: trn ? nil : "/v3/certificates/eyts"

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -96,6 +96,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_previous_last_names
     expect(page).to have_content("Previous last names")
-    expect(page).to have_content("Jones<br />Smith")
+    expect(page).to have_content("Jones\nSmith")
   end
 end


### PR DESCRIPTION
The API returns the full names for previousNames and we need to reference the data correctly.

### Link to Trello card

https://trello.com/c/rluLNobI/250-250-previous-names-arent-being-correctly-displayed

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="737" alt="Screenshot 2023-11-30 at 10 02 06 am" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/3126/8683b03d-5c52-41d8-9d22-a3f4f4b734a5">

