### PR TITLE
Use the statusDescription field for induction

### DIFF
--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -35,7 +35,7 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
 
   def induction_rows
     [
-      { key: { text: "Induction status" }, value: { text: details.status&.to_s&.humanize } },
+      { key: { text: "Induction status" }, value: { text: details.status_description } },
       { key: { text: "Date completed" }, value: { text: awarded_at&.to_fs(:long_uk) } }
     ]
   end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -129,12 +129,5 @@ module QualificationsApi
     include Hashie::Extensions::MethodAccess
 
     coerce_key :result, ->(value) { value.underscore.humanize }
-    coerce_key :status, ->(value) do
-      value
-        .underscore
-        .humanize
-        .sub("Requiredto", "Required to")
-        .sub("wales", "Wales")
-    end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         "induction" => {
           "startDate" => "2015-01-01",
           "endDate" => "2015-07-01",
-          "status" => "complete",
+          "statusDescription" => "Complete",
           "certificateUrl" => "https",
           "periods" => [
             {
@@ -122,28 +122,6 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
       it "returns human readable values" do
         expect(qualifications.find { |q| q.type == :itt }.details.result).to eq("Deferred for skills tests")
-      end
-    end
-
-    context "Induction status field" do
-      context "when the status is FailedInWales" do
-        before do
-          api_data["induction"]["status"] = "FailedInWales"
-        end
-
-        it "returns human readable values" do
-          expect(qualifications.find { |q| q.type == :induction }.details.status).to eq("Failed in Wales")
-        end
-      end
-
-      context "when the status is RequiredtoComplete" do
-        before do
-          api_data["induction"]["status"] = "RequiredtoComplete"
-        end
-
-        it "returns human readable values" do
-          expect(qualifications.find { |q| q.type == :induction }.details.status).to eq("Required to complete")
-        end
       end
     end
 

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -18,6 +18,7 @@ module FakeQualificationsData
         startDate: "2022-09-01",
         endDate: "2022-10-01",
         status: "pass",
+        statusDescription: "Passed Induction",
         certificateUrl: "/v3/certificates/induction",
         periods: [
           {

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Pass")
+    expect(page).to have_content("Passed Induction")
     expect(page).to have_content("1 October 2022")
   end
 


### PR DESCRIPTION
The status field for the induction record is an enum that we don't
properly use in Check.

Instead of duplicating the values, the API now provides the human
friendly version of the enum as a new field, statusDescription.

This allows us to remove some code related to displaying the old field.

### Link to Trello card

https://trello.com/c/atfrZamb/249-249-use-statusdescription-for-induction-status

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
