### PR TITLE
Improve tests for handling of null data from Qualifications API

### DIFF
--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -1,4 +1,5 @@
 require_relative "fake_qualifications_data"
+require_relative "fake_qualifications_data_with_nulling"
 
 class FakeQualificationsApi < Sinatra::Base
   include FakeQualificationsData
@@ -11,6 +12,8 @@ class FakeQualificationsApi < Sinatra::Base
       quals_data.to_json
     when "no-itt-token"
       quals_data(trn: "1234567", itt: false).to_json
+    when "nulled-quals-data"
+      FakeQualificationsDataWithNulling.generate.to_json
     when "invalid-token"
       halt 401
     end

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -38,21 +38,21 @@ module FakeQualificationsData
           else
             [
               {
-                ageRange: {
-                  description: "10 to 16 years"
+                qualification: {
+                  name: "BA"
                 },
+                startDate: "2022-02-28",
                 endDate: "2023-01-28",
                 programmeType: "HEI",
                 programmeTypeDescription: "Higher education institution",
+                result: "Pass",
+                ageRange: {
+                  description: "10 to 16 years"
+                },
                 provider: {
                   name: "Earl Spencer Primary School",
                   ukprn: nil
                 },
-                qualification: {
-                  name: "BA"
-                },
-                result: "Pass",
-                startDate: "2022-02-28",
                 subjects: [{ code: "100079", name: "business studies" }]
               }
             ]

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -8,11 +8,11 @@ module FakeQualificationsData
       previousNames: ["Jones", "Smith"],
       eyts: {
         awarded: "2022-04-01",
-        certificateUrl: trn ? nil : "/v3/certificates/eyts"
+        certificateUrl: "/v3/certificates/eyts"
       },
       qts: {
         awarded: "2023-02-27",
-        certificateUrl: trn ? nil : "/v3/certificates/qts"
+        certificateUrl: "/v3/certificates/qts"
       },
       induction: {
         startDate: "2022-09-01",
@@ -65,7 +65,7 @@ module FakeQualificationsData
       npqQualifications: [
         {
           awarded: "2023-02-27",
-          certificateUrl: trn ? nil : "/v3/certificates/npq/1",
+          certificateUrl: "/v3/certificates/npq/1",
           type: {
             code: "NPQH",
             name: "NPQ headteacher"

--- a/spec/support/fake_qualifications_data_with_nulling.rb
+++ b/spec/support/fake_qualifications_data_with_nulling.rb
@@ -1,0 +1,81 @@
+require_relative "fake_qualifications_data"
+
+class FakeQualificationsDataWithNulling
+  include FakeQualificationsData
+
+  # This returns an API response with most nullable fields set to nil. Although
+  # entire qualification fields are nullable, here we return data for each
+  # qualification but with mandatory values only.
+  # Reference: https://teacher-qualifications-api.education.gov.uk/swagger/v3.json
+  def self.generate
+    new.generate
+  end
+
+  def generate
+    @data = quals_data
+
+    @data[:dateOfBirth] = nil
+    @data[:lastName] = nil
+    @data[:previousNames] = []
+
+    minimal_eyts!
+    minimal_qts!
+    minimal_induction!
+    minimal_itt!
+    minimal_mandatory_qualifications!
+    minimal_npq!
+    minimal_sanctions!
+    @data
+  end
+
+  private
+
+  def minimal_eyts!
+    @data[:eyts][:certificateUrl] = nil
+  end
+
+  def minimal_qts!
+    @data[:qts][:certificateUrl] = nil
+  end
+
+  def minimal_induction!
+    @data[:induction][:startDate] = nil
+    @data[:induction][:endDate] = nil
+    @data[:induction][:status] = nil
+    @data[:induction][:statusDescription] = nil
+    @data[:induction][:certificateUrl] = nil
+    @data[:induction][:periods].each do |period|
+      period[:startDate] = nil
+      period[:endDate] = nil
+      period[:terms] = nil
+      period[:appropriateBody] = nil
+    end
+  end
+
+  def minimal_itt!
+    @data[:initialTeacherTraining].each do |itt|
+      itt[:qualification] = nil
+      itt[:startDate] = nil
+      itt[:endDate] = nil
+      itt[:programmeType] = nil
+      itt[:programmeTypeDescription] = nil
+      itt[:result] = nil
+      itt[:ageRange] = nil
+      itt[:provider] = nil
+    end
+  end
+
+  def minimal_mandatory_qualifications!
+    @data
+  end
+
+  def minimal_npq!
+    @data[:npqQualifications].each do |npq|
+      npq[:certificateUrl] = nil
+    end
+  end
+
+  def minimal_sanctions!
+    @data[:sanctions] = [ { code: "G1", startDate: nil } ]
+  end
+end

--- a/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
+++ b/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Handling null data", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario(
+    "User views qualifications with missing data",
+    test: %i[with_stubbed_auth with_fake_quals_api]
+  ) do
+    given_the_service_is_open
+    and_i_am_signed_in_via_identity_as_a_user_with_partial_quals_data
+
+    when_i_visit_the_qualifications_page
+    then_it_renders
+  end
+
+  private
+
+  def and_i_am_signed_in_via_identity_as_a_user_with_partial_quals_data
+    given_identity_auth_is_mocked
+    OmniAuth.config.mock_auth[:identity].credentials.token = "nulled-quals-data"
+    when_i_go_to_the_sign_in_page
+    and_click_the_sign_in_button
+  end
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_it_renders
+    expect(page).to have_content "Teaching qualifications"
+    expect(page).to have_content "Terry"
+    expect(page).to have_content "QTS"
+  end
+end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
We’ve recently had a couple of production sentry errors raised because we were relying on nullable Qualifications API fields. ie. these fields were not present in the response from the API.
### Changes proposed in this pull request

This PR deals specifically with how we test our handling of nullable fields. A separate PR may follow to deal with any remaining cases where we aren't correctly handling null fields, once we've completed a review.

Summary of changes:

- Do some minor tidying up of the existing `FakeQualificationsData` 
- Add a `FakeQualificationsDataWithNulling` class to return an API response with nullable fields set to nil
- Use this API response in a system spec which simply checks that the qualifications page renders without issue
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
I considered just copying the existing data structure in `FakeQualificationsData` and nulling fields that the [Swagger doc](https://teacher-qualifications-api.education.gov.uk/swagger/v3.json) says are nullable.

Instead I've opted for a new class (`FakeQualificationsDataWithNulling`) which takes the "full" API response and nils out specific fields. I think this makes it easier to see what the differences are between the full dataset and the nulled out one. This probably makes it easier to update in future if the API introduces any null field changes or if we discover cases we haven't accounted for.

There's some judgement exercised in deciding what to null. For example — although an entire qualification field (eg—`qts`) can be null according to the API docs, this isn't a case that's given us any issues. If there's a need to exhaustively test empty fields at this level of the data structure, we can write some more detailed unit tests for the view components that render qualifications.

There might also be a case for automatically generating the list of nullable fields (by using the Swagger doc) and applying the transformation based on this list, but I opted not to on the basis that it's a fairly heavy-handed/complex approach and the API is unlikely to change nullable properties frequently.


<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/5DfQw9oj/246-check-qualifications-api-client-code-for-dependencies-on-nullable-fields
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
