### PR TITLE
Update check domains

### DIFF
--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -12,7 +12,7 @@ module CheckRecords
 
     # Differentiate web requests sent to BigQuery via dfe-analytics
     def current_namespace
-      "check-the-record-of-a-teacher"
+      "check-a-teachers-record"
     end
 
     def authenticate_dsi_user!

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -7,5 +7,5 @@
   "storage_log_categories": [],
   "resource_prefix": "s165d01-aytq",
   "domain": "dev.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "dev.check-the-record-of-a-teacher.education.gov.uk"
+  "check_domain": "dev.check-a-teachers-record.education.gov.uk"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -9,5 +9,5 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
   "domain": "preprod.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "preprod.check-the-record-of-a-teacher.education.gov.uk"
+  "check_domain": "preprod.check-a-teachers-record.education.gov.uk"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -13,5 +13,6 @@
   "enable_postgres_high_availability": true,
   "statuscake_ssl_contact_group": 249142,
   "statuscake_domain": "access-your-teaching-qualifications.education.gov.uk",
-  "domain": "access-your-teaching-qualifications.education.gov.uk"
+  "domain": "access-your-teaching-qualifications.education.gov.uk",
+  "check_domain": "check-a-teachers-record.education.gov.uk"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -7,5 +7,5 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
   "domain": "test.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "test.check-the-record-of-a-teacher.education.gov.uk"
+  "check_domain": "test.check-a-teachers-record.education.gov.uk"
 }


### PR DESCRIPTION
### Context

We are changing the URL that the 'Check a teachers record' is served from [DNS change PR here](https://github.com/DFE-Digital/tra-shared-services/pull/39)

### Changes proposed in this pull request

* Update the CHECK_RECORDS_DOMAIN environment variable in all envs to match
* Update the BigQuery namespace

### Guidance to review

The CHECK_RECORDS_DOMAIN has also been set in the secrets in key vault. I'll remove those prior to merging and coordinate merging with the other infra PR. As we're not live in production in any case it'll be ok to have a small bit of downtime in non prod.


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
