### PR TITLE
Add error for unexpected status

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -1,6 +1,6 @@
 module QualificationsApi
-  class InvalidCertificateUrlError < StandardError
-  end
+  class InvalidCertificateUrlError < StandardError; end
+  class UnknownError < StandardError; end
 
   class Client
     TIMEOUT_IN_SECONDS = 5
@@ -56,6 +56,8 @@ module QualificationsApi
         raise QualificationsApi::TeacherNotFoundError
       when 401
         raise QualificationsApi::InvalidTokenError
+      else
+        raise QualificationsApi::UnknownError, "API returned unhandled status #{response.status}"
       end
     end
 

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
         )
       end
     end
+
+    context "when an unknown error occurs" do
+      it "raises an error" do
+        client = described_class.new(token: "api-error")
+
+        expect { client.teacher }.to raise_error do |error|
+          expect(error).to be_a(QualificationsApi::UnknownError)
+          expect(error.message).to eq("API returned unhandled status 500")
+        end
+      end
+    end
   end
 
   describe "#certificate" do

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -13,6 +13,8 @@ class FakeQualificationsApi < Sinatra::Base
       quals_data(trn: "1234567", itt: false).to_json
     when "invalid-token"
       halt 401
+    when "api-error"
+      halt 500
     end
   end
 


### PR DESCRIPTION
### Context

We seem to be getting occasional responses from the API that we're not handling and so `QualificationsAPI::Client#teacher` is returning nil.

https://dfe-teacher-services.sentry.io/issues/4276090399/?project=4505227155996672&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

### Changes proposed in this pull request

Add another class so as they raise explicitly so as we can understand what's happening.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
