### PR TITLE
Separate service open feature flags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,6 @@ class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
-  http_basic_authenticate_with(
-    name: ENV.fetch("SUPPORT_USERNAME", nil),
-    password: ENV.fetch("SUPPORT_PASSWORD", nil),
-    unless: -> { FeatureFlags::FeatureFlag.active?("service_open") }
-  )
-
   def trigger_request_event
     return unless DfE::Analytics.enabled?
 

--- a/app/controllers/check_records/check_records_controller.rb
+++ b/app/controllers/check_records/check_records_controller.rb
@@ -3,6 +3,12 @@ module CheckRecords
     before_action :authenticate_dsi_user!
     before_action :handle_expired_session!
 
+    http_basic_authenticate_with(
+      name: ENV.fetch("SUPPORT_USERNAME", nil),
+      password: ENV.fetch("SUPPORT_PASSWORD", nil),
+      unless: -> { FeatureFlags::FeatureFlag.active?("check_service_open") }
+    )
+
     layout "check_records_layout"
 
     def current_dsi_user

--- a/app/controllers/qualifications/qualifications_interface_controller.rb
+++ b/app/controllers/qualifications/qualifications_interface_controller.rb
@@ -3,6 +3,12 @@ module Qualifications
     before_action :authenticate_user!
     before_action :handle_expired_token!
 
+    http_basic_authenticate_with(
+      name: ENV.fetch("SUPPORT_USERNAME", nil),
+      password: ENV.fetch("SUPPORT_PASSWORD", nil),
+      unless: -> { FeatureFlags::FeatureFlag.active?("qualifications_service_open") }
+    )
+
     layout "qualifications_layout"
 
     def current_user

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,6 +3,12 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     include SupportNamespaceable
 
+    http_basic_authenticate_with(
+      name: ENV.fetch("SUPPORT_USERNAME", nil),
+      password: ENV.fetch("SUPPORT_PASSWORD", nil),
+      unless: -> { FeatureFlags::FeatureFlag.active?("support_service_open") }
+    )
+
     layout "support_layout"
 
     before_action :authenticate_staff!

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,13 +1,24 @@
 layout: support_layout
 parent_controller: "SupportInterface::SupportInterfaceController"
 feature_flags:
-  service_open:
+  check_service_open:
     author: Felix Clack
-    description: Remove the basic authentication when accessing the main
-      website. Keeps it in place for the support interface. This flag should
-      always be inactive on non-production deployments, to prevent accidental
-      access by members of the public. Once the service goes live, this flag
-      should always be active on production.
+    description: Remove the basic authentication when accessing Check a teacher's
+      record. This flag should always be inactive on non-production deployments,
+      to prevent accidental access by members of the public. Once the service
+      goes live, this flag should always be active on production.
+  qualifications_service_open:
+    author: Felix Clack
+    description: Remove the basic authentication when accessing AYTQ.
+      This flag should always be inactive on non-production deployments, to
+      prevent accidental access by members of the public. Once the service goes
+      live, this flag should always be active on production.
+  support_service_open:
+    author: Felix Clack
+    description: Remove the basic authentication when accessing the support
+      interface. This flag should always be inactive on non-production
+      deployments, to prevent accidental access by members of the public.
+      Once the service goes live, this flag should always be active on production.
   staff_http_basic_auth:
     author: Felix Clack
     description: Allow signing in as a staff user using HTTP Basic

--- a/spec/support/system/activate_features_steps.rb
+++ b/spec/support/system/activate_features_steps.rb
@@ -1,6 +1,14 @@
 module ActivateFeaturesSteps
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
+  def given_the_check_service_is_open
+    FeatureFlags::FeatureFlag.activate(:check_service_open)
+  end
+
+  def given_the_qualifications_service_is_open
+    FeatureFlags::FeatureFlag.activate(:qualifications_service_open)
+  end
+
+  def given_the_support_service_is_open
+    FeatureFlags::FeatureFlag.activate(:support_service_open)
   end
 
   def and_staff_http_basic_is_active

--- a/spec/system/check_records/user_gives_feedback_spec.rb
+++ b/spec/system/check_records/user_gives_feedback_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Feedback", host: :check_records, type: :system do
   include CheckRecords::AuthenticationSteps
 
   scenario "User gives feedback", test: :with_stubbed_auth do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_i_click_on_feedback
     then_i_see_the_feedback_form

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Teacher search with restrictions",
 
   scenario "User searches with a last name and date of birth and finds a restricted record",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_search_returns_a_restricted_record
     then_i_see_the_restriction_on_the_result

--- a/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
+++ b/spec/system/check_records/user_searches_with_an_invalid_trn_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "TRN search", host: :check_records, type: :system do
 
   scenario "User tries to view a teacher with invalid TRN",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_view_a_teacher_with_an_invalid_trn
     then_i_see_a_not_found_page

--- a/spec/system/check_records/user_searches_with_invalid_values_spec.rb
+++ b/spec/system/check_records/user_searches_with_invalid_values_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   scenario "User searches with invalid values and sees errors",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_press_find_record
     then_i_see_the_error_summary

--- a/spec/system/check_records/user_searches_with_no_matches_spec.rb
+++ b/spec/system/check_records/user_searches_with_no_matches_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "No matches", host: :check_records, type: :system do
 
   scenario "User searches with a last name and date of birth and finds no matches",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_search_returns_no_records
     then_i_see_no_records

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   scenario "User searches with a last name and date of birth and finds a record",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_sign_in_via_dsi
     and_search_with_a_valid_name_and_dob
     then_i_see_a_teacher_record_in_the_results

--- a/spec/system/check_records/user_session_expires_spec.rb
+++ b/spec/system/check_records/user_session_expires_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "DSI session expiry", host: :check_records, type: :system do
   after { travel_back }
 
   scenario "Session expires", test: :with_stubbed_auth do
-    given_the_service_is_open
+    given_the_check_service_is_open
     and_i_am_signed_in_via_dsi
     and_my_session_expires
     when_i_refresh_the_page

--- a/spec/system/check_records/user_views_check_records_homepage_spec.rb
+++ b/spec/system/check_records/user_views_check_records_homepage_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Check records homepage", host: :check_records do
   include CommonSteps
 
   scenario "User views Check records homepage" do
-    given_the_service_is_open
+    given_the_check_service_is_open
     when_i_visit_the_check_records_homepage
     then_i_see_the_check_records_nav
     and_event_tracking_is_working

--- a/spec/system/qualifications/start_spec.rb
+++ b/spec/system/qualifications/start_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "The qualifications start page", type: :system do
   include CommonSteps
 
   scenario "when a user views the start page", test: :with_stubbed_auth do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
 
     when_i_visit_the_qualifications_start_page
     then_i_see_the_start_page

--- a/spec/system/qualifications/user_signs_in_via_identity_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_identity_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Identity auth", type: :system do
   include QualificationAuthenticationSteps
 
   scenario "User signs in via Identity", test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_identity_auth_is_mocked
     when_i_go_to_the_sign_in_page
     and_click_the_sign_in_button

--- a/spec/system/qualifications/user_signs_out_spec.rb
+++ b/spec/system/qualifications/user_signs_out_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Identity auth", type: :system do
   include QualificationAuthenticationSteps
 
   scenario "User signs out", test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_identity_auth_is_mocked
     and_i_am_signed_in_via_identity
     when_i_click_the_sign_out_link

--- a/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
+++ b/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Identity auth", type: :system do
 
   scenario "Access token expires while viewing qualifications",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page

--- a/spec/system/qualifications/user_views_a_missing_certificate_spec.rb
+++ b/spec/system/qualifications/user_views_a_missing_certificate_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "User views their certificates", type: :system do
 
   scenario "when a certificate is missing",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page

--- a/spec/system/qualifications/user_views_and_updates_their_details_spec.rb
+++ b/spec/system/qualifications/user_views_and_updates_their_details_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "User views and updates their details" do
   include QualificationAuthenticationSteps
 
   scenario "User updates their details", test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
     when_i_visit_view_and_update_details
     then_i_see_the_landing_page

--- a/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
+++ b/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Handling null data", type: :system do
     "User views qualifications with missing data",
     test: %i[with_stubbed_auth with_fake_quals_api]
   ) do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity_as_a_user_with_partial_quals_data
 
     when_i_visit_the_qualifications_page

--- a/spec/system/qualifications/user_views_their_details_spec.rb
+++ b/spec/system/qualifications/user_views_their_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "User views their details" do
 
   scenario "The details are retrieved from the API",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
     then_i_see_my_details_as_returned_by_the_api
     and_event_tracking_is_working

--- a/spec/system/qualifications/user_views_their_qualifications_no_itt_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_no_itt_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "User views their qualifications", type: :system do
   include QualificationAuthenticationSteps
 
   scenario "when they have no ITT", test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   scenario "when they have qualifications",
            test: %i[with_stubbed_auth with_fake_quals_api] do
-    given_the_service_is_open
+    given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page

--- a/spec/system/support/basic_auth_user_spec.rb
+++ b/spec/system/support/basic_auth_user_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Basic auth user" do
   include CommonSteps
 
   scenario "Access is restricted by basic auth", type: :system do
-    given_the_service_is_open
+    given_the_support_service_is_open
     and_staff_http_basic_is_active
 
     when_i_visit_the_support_interface

--- a/spec/system/support/staff_change_password_spec.rb
+++ b/spec/system/support/staff_change_password_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Staff support", type: :system do
   include CommonSteps
 
   scenario "Staff changes password" do
-    given_the_service_is_open
+    given_the_support_service_is_open
     and_a_staff_user_exists
 
     when_i_visit_the_staff_page

--- a/spec/system/support/staff_http_flag_spec.rb
+++ b/spec/system/support/staff_http_flag_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Staff HTTP feature flag" do
   include CommonSteps
 
   scenario "Feature flag is disabled and no Staff accounts exist" do
-    given_the_service_is_open
+    given_the_support_service_is_open
 
     when_i_visit_the_support_interface
     then_i_am_unauthorized

--- a/spec/system/support/staff_invite_as_initial_support_user_spec.rb
+++ b/spec/system/support/staff_invite_as_initial_support_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Staff support", type: :system do
   include CommonSteps
 
   scenario "Initial support user invites Staff" do
-    given_the_service_is_open
+    given_the_support_service_is_open
     and_staff_http_basic_is_active
 
     when_i_am_authorized_with_basic_auth

--- a/spec/system/support/staff_invite_as_staff_member_spec.rb
+++ b/spec/system/support/staff_invite_as_staff_member_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Staff support', type: :system do
   include CommonSteps
 
   scenario "Staff user invites another Staff member" do
-    given_the_service_is_open
+    given_the_support_service_is_open
     and_a_staff_member_exists
     and_i_am_logged_in_as_a_staff_member
     when_i_visit_the_staff_page

--- a/spec/system/support/staff_login_spec.rb
+++ b/spec/system/support/staff_login_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Staff login" do
   include CommonSteps
 
   scenario "Staff user logs in" do
-    given_the_service_is_open
+    given_the_support_service_is_open
     and_a_staff_user_exists
     when_i_visit_the_support_interface
     then_i_see_the_staff_login_page

--- a/spec/system/support/staff_sign_out_spec.rb
+++ b/spec/system/support/staff_sign_out_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature "Staff sign out" do
   include CommonSteps
 
   scenario "Staff user signs out" do
-    given_the_service_is_open
+    given_the_support_service_is_open
+    given_the_qualifications_service_is_open
     and_a_staff_user_exists
     when_i_visit_the_support_interface
     then_i_see_the_staff_login_page


### PR DESCRIPTION
We have a single feature flag controlling access to 3 different apps,
which makes releasing them separately impossible.

There is no reason for them to share a single feature flag so I'm
introducing 2 extra flags to give us the granularity we want.

Each service, Check + Quals, will have a unique feature flag to control
opening the service up to the public. Also, there is now a separate
feature flag for the support interface too.

### Link to Trello card

https://trello.com/c/EiJ9iHfo/1382-add-feature-flag-to-enable-us-restrict-access-to-check-in-production-before-its-launched

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
