### PR TITLE
Skip qualifications start page, redirect users to ID

### DIFF
--- a/app/controllers/qualifications/starts_controller.rb
+++ b/app/controllers/qualifications/starts_controller.rb
@@ -2,8 +2,47 @@ module Qualifications
   class StartsController < QualificationsInterfaceController
     skip_before_action :authenticate_user!
     skip_before_action :handle_expired_token!
+    around_action :skip_omniauth_request_validation_phase, only: :show
 
     def show
+      @identity_service_response = Faraday.post(identity_service_auth_url)
+      redirect_to_identity_service and return if redirect_present?
+    rescue Faraday::Error
+      render :show
+    end
+
+  private
+
+    attr_reader :identity_service_response
+
+    # Check that the response headers contain a redirect to the identity service
+    def redirect_present?
+      identity_service_response.status == 302 &&
+        identity_service_response.headers["location"]&.starts_with?(identity_api_domain)
+    end
+
+    def redirect_to_identity_service
+      redirect_to(identity_service_response.headers["location"], allow_other_host: true)
+    end
+
+    def identity_service_auth_url
+      %(#{ENV["HOSTING_DOMAIN"]}/qualifications/users/auth/identity?trn_token=#{params[:trn_token]})
+    end
+
+    # OmniAuth will default to validating the request using CSRF protection
+    # which is necessary when the request is sent from a browser.
+    # In this case, the request is sent from an action with limited parameters
+    # so CSRF protection is not necessary.
+    def skip_omniauth_request_validation_phase
+      request_validation_phase = OmniAuth.config.request_validation_phase
+      OmniAuth.config.request_validation_phase = nil
+      yield
+    ensure
+      OmniAuth.config.request_validation_phase = request_validation_phase
+    end
+
+    def identity_api_domain
+      ENV["IDENTITY_API_DOMAIN"]
     end
   end
 end

--- a/app/controllers/qualifications/starts_controller.rb
+++ b/app/controllers/qualifications/starts_controller.rb
@@ -2,13 +2,15 @@ module Qualifications
   class StartsController < QualificationsInterfaceController
     skip_before_action :authenticate_user!
     skip_before_action :handle_expired_token!
-    around_action :skip_omniauth_request_validation_phase, only: :show
+    #around_action :skip_omniauth_request_validation_phase, only: :show
 
     def show
-      @identity_service_response = Faraday.post(identity_service_auth_url)
-      redirect_to_identity_service and return if redirect_present?
-    rescue Faraday::Error
-      render :show
+      OmniAuth.config.allowed_request_methods = [:get, :post]
+      #@identity_service_response = Faraday.get(identity_service_auth_url)
+      #redirect_to_identity_service and return if redirect_present?
+      redirect_to identity_service_auth_url
+    #rescue Faraday::Error
+    #  render :show
     end
 
   private

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,7 @@ require "webmock/rspec"
 require "dfe/analytics/testing"
 require "dfe/analytics/rspec/matchers"
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: "http://qualifications.localhost")
 
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(app, timeout: 10, process_timeout: 30, window_size: [1200, 800])

--- a/spec/system/qualifications/skip_start_spec.rb
+++ b/spec/system/qualifications/skip_start_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Skipping the qualifications start page", type: :system do
+  include CommonSteps
+
+  scenario "when a user visits the start page path", test: :with_stubbed_auth do
+    given_the_qualifications_service_is_open
+    and_omniauth_request_phase_provides_a_valid_redirect
+
+    when_i_visit_the_qualifications_start_page
+    then_i_am_redirected_to_the_identity_service
+  end
+
+  private
+
+  def and_omniauth_request_phase_provides_a_valid_redirect
+    allow_any_instance_of(Qualifications::StartsController)
+      .to receive(:identity_api_domain).and_return("http://www.example.com")
+
+    stub_request(:post, identity_service_auth_url)
+      .to_return(status: 302, headers: { "location" => fake_identity_service_location })
+  end
+
+  def when_i_visit_the_qualifications_start_page
+    visit qualifications_start_path
+  end
+
+  def then_i_am_redirected_to_the_identity_service
+    expect(page).to have_current_path(fake_identity_service_location)
+  end
+
+  def identity_service_auth_url
+    %(#{ENV["HOSTING_DOMAIN"]}/qualifications/users/auth/identity?trn_token=)
+  end
+
+  def fake_identity_service_location
+    "http://www.example.com/fake-identity-service"
+  end
+end

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
 
     it "AYTQ works as expected" do
       when_i_visit_the_aytq_service
-      then_i_see_the_aytq_service
+      then_i_am_redirected_to_the_id_auth_service
     end
 
     it "/health/all returns 200" do
@@ -66,5 +66,9 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   def then_i_see_the_aytq_service
     expect(page).to have_content "Access your teaching qualifications"
     expect(page).to have_content "Start now"
+  end
+
+  def then_i_am_redirected_to_the_id_auth_service
+    expect(page).to have_content "Create a DfE Identity account"
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

- Skips qualifications start page by making a server side request to the configured omniauth request phase route.
- Redirects users to the location returned by the omniauth request phase call to the identity service. 
- Checks that the location for redirect is a valid identity service URL. 
- Renders the existing start page if Faraday encounters an error when making the server side request.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

### TODO

- [ ] Some additional tests needed
- [ ] Ensure behaviour for an authenticated visiting the start page is unchanged

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/dwGZgtlE/1385-redirect-users-from-govuk-directly-to-id
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
