### PR TITLE
Add identity uuid to users table

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -54,6 +54,7 @@ shared:
     - family_name
     - trn
     - date_of_birth
+    - identity_uuid
   :search_logs:
     - id
     - dsi_user_id

--- a/db/migrate/20231204210527_add_identity_uuid_to_users.rb
+++ b/db/migrate/20231204210527_add_identity_uuid_to_users.rb
@@ -1,0 +1,5 @@
+class AddIdentityUuidToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :identity_uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_115727) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_04_210527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -184,6 +184,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_115727) do
     t.string "family_name", limit: 510
     t.string "trn"
     t.date "date_of_birth"
+    t.uuid "identity_uuid"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
This may be useful to send to Sentry when specific errors occur, eg— communicating with the Quals API with the token that Identity provides.
