### PR TITLE
Add a new feature flag for AYTQ

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,6 +1,12 @@
 layout: support_layout
 parent_controller: "SupportInterface::SupportInterfaceController"
 feature_flags:
+  qualifications_service_open:
+    author: Felix Clack
+    description: Remove the basic authentication when accessing AYTQ.
+      This flag should always be inactive on non-production deployments, to
+      prevent accidental access by members of the public. Once the service goes
+      live, this flag should always be active on production.
   service_open:
     author: Felix Clack
     description: Remove the basic authentication when accessing the main


### PR DESCRIPTION
We want separate feature flags controlling access to each service in this app
rather than a single one.

This will give us more granular control over releasing the apps to the
public.

As AYTQ is already a live service, we need to introduce the new flag for
it and set it to active before deploying the changes to use the new
flag.

This will allow us to seamlessly make the switch to the new names
without interruption to the live service.