### PR TITLE
Add additional detail around 403s from Qualifications API

### DIFF
--- a/app/controllers/qualifications/qualifications_controller.rb
+++ b/app/controllers/qualifications/qualifications_controller.rb
@@ -5,11 +5,41 @@ module Qualifications
         client = QualificationsApi::Client.new(token: session[:identity_user_token])
         @teacher = client.teacher
       rescue QualificationsApi::InvalidTokenError
-        redirect_to qualifications_sign_out_path
-        return
+        redirect_to qualifications_sign_out_path and return
+      rescue QualificationsApi::ForbiddenError => e
+        send_additional_detail_to_sentry(e)
+        redirect_to qualifications_sign_out_path and return
       end
 
       @user = current_user
     end
+    private
+
+    def extract_payload(token)
+      _header, encoded_payload, _signature = token.split('.')
+      payload = Base64.urlsafe_decode64(encoded_payload)
+      JSON.parse payload
+    end
+
+    def send_additional_detail_to_sentry(exception)
+      api_token_payload = extract_payload(session[:identity_user_token])
+      Sentry.with_scope do |scope|
+        scope.set_user(id: current_user.id)
+        scope.set_context(
+          'Identity session',
+          {
+            trn: current_user.trn,
+            identity_uuid: current_user.identity_uuid,
+            api_tkn_expiry: Time.zone.at(session[:identity_user_token_expiry]),
+            "payload.trn" => api_token_payload["trn"],
+            "payload.scope" => api_token_payload["scope"],
+            "payload.identity_exp" => api_token_payload["exp"],
+            "payload.identity_exp_parsed" => Time.zone.at(api_token_payload["exp"]),
+          }
+        )
+        Sentry.capture_exception(exception)
+      end
+    end
+
   end
 end

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -1,5 +1,6 @@
 module QualificationsApi
   class InvalidCertificateUrlError < StandardError; end
+  class ForbiddenError < StandardError; end
   class UnknownError < StandardError; end
 
   class Client
@@ -54,6 +55,8 @@ module QualificationsApi
         QualificationsApi::Teacher.new response.body
       when 404
         raise QualificationsApi::TeacherNotFoundError
+      when 403
+        raise QualificationsApi::ForbiddenError
       when 401
         raise QualificationsApi::InvalidTokenError
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,8 @@ class User < ApplicationRecord
       family_name: auth_data.info.last_name,
       given_name: auth_data.info.first_name,
       name: auth_data.info.name,
-      trn: auth_data.extra.raw_info.trn
+      trn: auth_data.extra.raw_info.trn,
+      identity_uuid: auth_data.uid
     )
     user.tap(&:save!)
   end


### PR DESCRIPTION

### Context
We haven't been handling 403 errors from the API, and are starting to see quite a few in production. It isn't currently clear what's causing these errors.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
This commit adds a local Sentry scope that extracts various pieces of information about the Identity session and sends it to Sentry whenever this error occurs. This should help us with debugging the issue.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
I've tested this by setting the Sentry DSN in local dev and manually triggering the `QualificationsApi::ForbiddenError`.

This results in the Sentry issue being tagged with the user id and the following section appearing further down:

 
![Screenshot_20231205_134806](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/d34360ea-59ea-44d1-8dbb-f41b4cdac454)

@gunndabad fyi ^

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/yFP3gVsr
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
