### PR TITLE
Hide support navigation items from unauthorised users

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,17 +7,17 @@ module ApplicationHelper
     govuk_header(service_name: t("service.name")) do |header|
       case current_namespace
       when "support"
-        header.with_navigation_item(
-          active: current_page?(main_app.support_interface_feature_flags_path),
-          href: main_app.support_interface_feature_flags_path,
-          text: "Features"
-        )
-        header.with_navigation_item(
-          active: request.path.start_with?("/support/staff"),
-          text: "Staff",
-          href: main_app.support_interface_staff_index_path
-        )
         if current_staff
+          header.with_navigation_item(
+            active: current_page?(main_app.support_interface_feature_flags_path),
+            href: main_app.support_interface_feature_flags_path,
+            text: "Features"
+          )
+          header.with_navigation_item(
+            active: request.path.start_with?("/support/staff"),
+            text: "Staff",
+            href: main_app.support_interface_staff_index_path
+          )
           header.with_navigation_item(href: main_app.support_interface_sign_out_path, text: "Sign out")
         end
       when "qualifications"

--- a/spec/system/support/staff_user_signs_in_spec.rb
+++ b/spec/system/support/staff_user_signs_in_spec.rb
@@ -15,7 +15,11 @@ RSpec.describe "DSI authentication" do
   private
 
   def then_i_am_signed_in
-    within("header") { expect(page).to have_content "Sign out" }
+    within("header") do
+      expect(page).to have_link("Features")
+      expect(page).to have_link("Staff")
+      expect(page).to have_content "Sign out"
+    end
     expect(DsiUser.count).to eq 1
     expect(DsiUserSession.count).to eq 1
   end

--- a/spec/system/support/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/support/unauthorised_user_signs_in_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "DSI authentication" do
     expect(page).to have_link("sign out and start again", href: "/support/auth/staff/sign-out?id_token_hint=abc123")
 
     within(".govuk-header__content") do
+      expect(page).not_to have_link("Features")
+      expect(page).not_to have_link("Staff")
       expect(page).not_to have_link("Sign in")
       expect(page).not_to have_link("Sign out")
     end


### PR DESCRIPTION
### Context

We've spotted a bug while deploying the [DSI Support login PR](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/408) where unauthorised (ie. logged in but without support org/role) can still see the 'Features' and 'Staff' navigation links.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Only render support nav links to authorised support users.

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/35536b4e-ac57-473e-abab-71987a1d90ce)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
