### PR TITLE
Add qualifications_service_open flag

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -8,6 +8,12 @@ feature_flags:
       always be inactive on non-production deployments, to prevent accidental
       access by members of the public. Once the service goes live, this flag
       should always be active on production.
+  qualifications_service_open:
+    author: Graham Pengelly
+    description: Remove the basic authentication when accessing AYTQ.
+      This flag should always be inactive on non-production deployments, to
+      prevent accidental access by members of the public. Once the service goes
+      live, this flag should always be active on production.
   staff_http_basic_auth:
     author: Felix Clack
     description: Allow signing in as a staff user using HTTP Basic


### PR DESCRIPTION
This allows us to add/remove basic auth from the AYTQ service only. It currently isn't checked so this PR just adds it so as we can ensure the service stays open when we deploy the subsequent PR.

### Context

We have a service_open feature flag that adds basic auth but we need to be able to do that separately for AYTQ (which is already live) and Check... This is the first PR in splitting the flags.

### Changes proposed in this pull request

Add a, currently unused, qualifications_service_open feature flag.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
