### PR TITLE
Show previous last names in the search results

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -19,7 +19,7 @@ module QualificationsApi
              to: :api_data
 
     def previous_names
-      api_data.previous_names&.map(&:last_name)
+      api_data.previous_names&.map(&:last_name)&.select { |name| name != last_name }
     end
 
     def qualifications

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -19,7 +19,7 @@ module QualificationsApi
              to: :api_data
 
     def previous_names
-      api_data.previous_names.map(&:last_name)
+      api_data.previous_names&.map(&:last_name)
     end
 
     def qualifications

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -7,7 +7,7 @@ module QualificationsApi
     end
 
     def name
-      ::NameOfPerson::PersonName.full("#{first_name} #{last_name}")
+      ::NameOfPerson::PersonName.full("#{first_name} #{middle_name} #{last_name}")
     end
 
     delegate :date_of_birth,

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -27,6 +27,13 @@
                 row.with_key { "Date of birth" }
                 row.with_value { Date.parse(teacher.date_of_birth).to_fs(:long_uk) }
               end
+
+              if teacher.previous_names&.any?
+                summary_list.with_row do |row|
+                  row.with_key { "Previous last names" }
+                  row.with_value { teacher.previous_names&.join("<br />")&.html_safe }
+                end
+              end
             end %>
           </div>
         <% end %>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -95,6 +95,10 @@ class FakeQualificationsApi < Sinatra::Base
       firstName: "Terry",
       lastName: "Walsh",
       middleName: "John",
+      previousNames: [
+        { first_name: "Terry", last_name: "Jones", middle_name: "" },
+        { first_name: "Terry", last_name: "Smith", middle_name: "" }
+      ],
       sanctions: [],
       trn:
     }
@@ -106,6 +110,10 @@ class FakeQualificationsApi < Sinatra::Base
       firstName: "Teacher",
       lastName: "Restricted",
       middleName: "",
+      previousNames: [
+        { first_name: "Terry", last_name: "Jones", middle_name: "" },
+        { first_name: "Terry", last_name: "Smith", middle_name: "" }
+      ],
       sanctions: [
         {
           code: "G1",

--- a/spec/system/check_records/user_searches_with_invalid_values_spec.rb
+++ b/spec/system/check_records/user_searches_with_invalid_values_spec.rb
@@ -59,6 +59,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_the_search_is_successful
-    expect(page).to have_content "Terry Walsh"
+    expect(page).to have_content "Terry John Walsh"
   end
 end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     when_i_sign_in_via_dsi
     and_search_with_a_valid_name_and_dob
     then_i_see_a_teacher_record_in_the_results
+    then_i_see_previous_last_names
     and_my_search_is_logged
 
     when_i_click_on_the_teacher_record

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_a_teacher_record_in_the_results
-    expect(page).to have_content "Terry Walsh"
+    expect(page).to have_content "Terry John Walsh"
   end
 
   def then_the_trn_is_not_in_the_url
@@ -52,7 +52,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def when_i_click_on_the_teacher_record
-    click_on "Terry Walsh"
+    click_on "Terry John Walsh"
   end
 
   def then_i_see_induction_details


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Include any previous last names in search results as per the prototype.
- Includes teacher's middle name in full name.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/7biWAgpK/1393-previous-last-names-not-showing-in-the-search-results
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
