### PR TITLE
Use db sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.1"
 
+gem "activerecord-session_store"
 gem "amazing_print"
 gem "audits1984"
 gem "bootsnap", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "rails", "~> 7.1.2"
 gem "rails_semantic_logger"
 gem "sentry-rails", "~> 5.15"
 gem "sidekiq", "~> 6"
+gem "sidekiq-cron"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,13 @@ GEM
       activemodel (= 7.1.2)
       activesupport (= 7.1.2)
       timeout (>= 0.4.0)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activestorage (7.1.2)
       actionpack (= 7.1.2)
       activejob (= 7.1.2)
@@ -122,6 +129,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -606,6 +614,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store
   amazing_print
   audits1984
   bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,8 @@ GEM
       ruby2_keywords
     e2mmap (0.1.0)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     factory_bot (6.4.2)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.2)
@@ -184,6 +186,9 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-apis-bigquery_v2 (0.61.0)
@@ -366,6 +371,7 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8)
     rack-oauth2 (2.2.0)
@@ -512,6 +518,10 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.11.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -658,6 +668,7 @@ DEPENDENCIES
   sentry-rails (~> 5.15)
   shoulda-matchers
   sidekiq (~> 6)
+  sidekiq-cron
   sinatra
   solargraph
   solargraph-rails

--- a/app/jobs/trim_sessions_job.rb
+++ b/app/jobs/trim_sessions_job.rb
@@ -1,0 +1,8 @@
+require "rake"
+Rails.application.load_tasks
+
+class TrimSessionsJob < ApplicationJob
+  def perform
+    Rake::Task['db:sessions:trim'].invoke
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -2,3 +2,9 @@
 :shared:
   :data_migrations:
     - version
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: '_aytq_session'

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,3 @@
+trim_db_sessions:
+  cron: "0 4 * * *" # every day at 4am
+  class: "TrimSessionsJob"

--- a/db/migrate/20231207134215_add_sessions_table.rb
+++ b/db/migrate/20231207134215_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_04_210527) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_07_134215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -137,6 +137,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_210527) do
     t.datetime "updated_at", null: false
     t.integer "result_count"
     t.index ["dsi_user_id"], name: "index_search_logs_on_dsi_user_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### Context

One of the environments (test) is throwing cookie overflow errors on the callback from DSI. Switching to ActiveRecord sessions might avoid this.

### Changes proposed in this pull request

* switch to AR sessions
* install and use sidekiq-cron for keeping the sessions table tidy
* block the session data from BigQuery as we don't need it. We already record user logins via the dsi_user_sessions table.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
