### PR TITLE
Minor changes to AYTQ auth flow

### DIFF
--- a/app/controllers/qualifications/users/sign_out_controller.rb
+++ b/app/controllers/qualifications/users/sign_out_controller.rb
@@ -5,8 +5,7 @@ module Qualifications
 
       def new
         if user_signed_in?
-          session[:identity_user_id] = nil
-          session[:identity_user_token] = nil
+          reset_session
           redirect_to "/qualifications/users/auth/identity/logout"
         else
           redirect_to qualifications_start_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com
-    generic_oauth_failure: There was a problem signing you in. Please try again.
+    generic_oauth_failure: There was a problem with your previous request. Please try again.
 
   activemodel:
     errors:

--- a/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/check_records/user_has_oauth_error_signing_in_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "DSI authentication", host: :check_records, type: :system do
   private
 
   def then_i_see_a_sign_in_error
-    expect(page).to have_content "There was a problem signing you in. Please try again."
+    expect(page).to have_content I18n.t("validation_errors.generic_oauth_failure")
   end
 
   def then_i_am_redirected_to_sign_in

--- a/spec/system/qualifications/user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/qualifications/user_has_oauth_error_signing_in_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe "DSI authentication", type: :system do
   end
 
   def then_i_see_a_sign_in_error
-    expect(page).to have_content "There was a problem signing you in. Please try again."
+    expect(page).to have_content I18n.t("validation_errors.generic_oauth_failure")
   end
 end

--- a/spec/system/support/staff_user_has_oauth_error_signing_in_spec.rb
+++ b/spec/system/support/staff_user_has_oauth_error_signing_in_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "DSI authentication", type: :system do
   private
 
   def then_i_see_a_sign_in_error
-    expect(page).to have_content "There was a problem signing you in. Please try again."
+    expect(page).to have_content I18n.t("validation_errors.generic_oauth_failure")
   end
 
   def then_i_am_redirected_to_sign_in


### PR DESCRIPTION

### Context

Some minor adjustments identified while investigating Sentry errors originating from the AuthFailuresController.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Adjust the error messaging when dealing with auth failure

  The current error makes reference to a problem "signing in". In some
  cases (CSRF issues caused by the back button), the user may have a
  perfectly valid session, and they can use the service by just
  clicking Continue from the start page. Make the error more generic
  while still prompting the user to try again.

- Use `reset_session` in the SignOutController

  Rather than deleting specific keys, simply clear the session on sign
  out.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
