### PR TITLE
Redirect root to a separate signin page

### DIFF
--- a/app/controllers/qualifications/users/sign_in_controller.rb
+++ b/app/controllers/qualifications/users/sign_in_controller.rb
@@ -1,0 +1,11 @@
+module Qualifications
+  module Users
+    class SignInController < QualificationsInterfaceController
+      skip_before_action :authenticate_user!
+      skip_before_action :handle_expired_token!
+
+      def new
+      end
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,6 +18,7 @@
 
     <%= stylesheet_link_tag :qualifications %>
     <%= javascript_include_tag :qualifications, defer: true %>
+    <%= yield :head %>
   </head>
 
   <body class="govuk-template__body">

--- a/app/views/layouts/qualifications_layout.html.erb
+++ b/app/views/layouts/qualifications_layout.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%= tag :meta, name: 'robots', content: 'noindex' %>
+<% end %>
+
 <% content_for :content do %>
   <%= yield %>
 <% end %>

--- a/app/views/qualifications/users/sign_in/new.html.erb
+++ b/app/views/qualifications/users/sign_in/new.html.erb
@@ -1,7 +1,14 @@
-<%=
-  govuk_button_to(
-    "Sign in with Identity",
-    "/qualifications/users/auth/identity",
-    method: :post
-  )
-%>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sign in to access your teaching qualifications</h1>
+    <p class="govuk-body">You’ll need a DfE Identity account to access your teaching qualifications.</p>
+    <p class="govuk-body">You can create an account if you do not have one already.</p>
+    <%=
+      govuk_button_to(
+        "Sign in with DfE Identity",
+        "/qualifications/users/auth/identity",
+        method: :post
+      )
+    %>
+  </div>
+</div>

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -26,4 +26,4 @@ scope via: :all do
   get '/500', to: 'qualifications/errors#internal_server_error'
 end
 
-root to: redirect("/qualifications/start"), as: :qualifications_root
+root to: redirect("/qualifications/sign-in"), as: :qualifications_root

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -10,6 +10,10 @@ module CommonSteps
     visit root_path
   end
 
+  def when_i_visit_the_qualifications_service
+    visit qualifications_root_path
+  end
+
   def when_i_visit_the_support_interface
     visit support_interface_path
   end

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -40,6 +40,6 @@ module QualificationAuthenticationSteps
   end
 
   def and_click_the_sign_in_button
-    click_button "Start now"
+    click_button "Sign in with DfE Identity"
   end
 end

--- a/spec/system/qualifications/user_signs_out_spec.rb
+++ b/spec/system/qualifications/user_signs_out_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Identity auth", type: :system do
   private
 
   def then_i_am_on_the_start_page
-    expect(page).to have_current_path(qualifications_start_path)
+    expect(page).to have_current_path(qualifications_sign_in_path)
   end
 
   def when_i_click_the_sign_out_link

--- a/spec/system/qualifications/user_visits_the_root_path_spec.rb
+++ b/spec/system/qualifications/user_visits_the_root_path_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "The root path", type: :system do
+  include CommonSteps
+
+  scenario "User visits the root path and is directed to signin" do
+    given_the_qualifications_service_is_open
+
+    when_i_visit_the_qualifications_service
+    then_i_see_the_signin_with_identity_page
+  end
+
+  def then_i_see_the_signin_with_identity_page
+    expect(page).to have_content(signin_button_text)
+  end
+
+  def signin_button_text
+    "Sign in with DfE Identity"
+  end
+end


### PR DESCRIPTION
### Context

We are going to move the start page to GOV.UK and so don't want users to see another full start page when they land on the service.

But... the existing one is still the first result on Google so we don't want those users to get the cut down login page as they won't have seen the content on GOV.UK.

### Changes proposed in this pull request

There is an existing slimmed down sign-in page that doesn't seem to be linked from anywhere so redirect to that when users land on root but leave the /qualifications/start in place until Google drops it from its index. We can redirect it then.

### Guidance to review

<img width="1061" alt="Screenshot 2023-12-13 at 16 56 33" src="https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/5216/9e777c54-b477-46e5-8195-ea3c652c4805">

### Link to Trello card

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
