### PR TITLE
Add status to qts and eyts blocks in the teacher record

### DIFF
--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -13,6 +13,7 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
            :itt?,
            :mq?,
            :name,
+           :status_description,
            :type,
            to: :qualification
 
@@ -27,7 +28,10 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
       elsif induction?
         induction_rows if induction?
       else
-        [{ key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }]
+        [
+          { key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
+          { key: { text: "Status" }, value: { text: status_description } },
+        ]
       end
     )
     @rows.select { |row| row[:value][:text].present? }

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -42,6 +42,17 @@ class QualificationSummaryComponent < ViewComponent::Base
       }
     end
 
+    if qualification.status_description
+      @rows << {
+        key: {
+          text: "Status"
+        },
+        value: {
+          text: qualification.status_description
+        }
+      }
+    end
+
     if details.specialism
       @rows << {
         key: {

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -49,6 +49,7 @@ module QualificationsApi
         awarded_at: api_data.qts.awarded&.to_date,
         certificate_url: api_data.qts.certificate_url,
         name: "Qualified teacher status (QTS)",
+        status_description: api_data.qts.status_description,
         type: :qts
       )
     end
@@ -60,6 +61,7 @@ module QualificationsApi
         awarded_at: api_data.eyts.awarded&.to_date,
         certificate_url: api_data.eyts.certificate_url,
         name: "Early years teacher status (EYTS)",
+        status_description: api_data.qts.status_description,
         type: :eyts
       )
     end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,7 +1,7 @@
 class Qualification
   include ActiveModel::Model
 
-  attr_accessor :awarded_at, :certificate_url, :name, :type
+  attr_accessor :awarded_at, :certificate_url, :name, :status_description, :type
   attr_writer :details
 
   def certificate_type

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -60,4 +60,37 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.text).not_to include("Course result")
     end
   end
+
+  describe "rendering QTS" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        name: "QTS",
+        status_description: "Qualified (trained in the UK)",
+        type: :qts,
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the awarded at date" do
+      expect(rows[0].text).to include(qualification.awarded_at.to_fs(:long_uk))
+    end
+
+    it "renders the status description" do
+      expect(rows[1].text).to include(qualification.status_description)
+    end
+  end
 end

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -64,4 +64,37 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       expect(rows.text).not_to include("Course result")
     end
   end
+
+  describe "rendering QTS" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        name: "QTS",
+        status_description: "Qualified (trained in the UK)",
+        type: :qts,
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the awarded at date" do
+      expect(rows[0].text).to include(qualification.awarded_at.to_fs(:long_uk))
+    end
+
+    it "renders the status description" do
+      expect(rows[1].text).to include(qualification.status_description)
+    end
+  end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
           }
         ],
         "qts" => {
-          "awarded" => "2015-11-01"
+          "awarded" => "2015-11-01",
+          "statusDescription" => "Qualified (trained in the UK)",
         },
         "eyts" => {
           "awarded" => "2015-11-02",
@@ -202,7 +203,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             }
           ],
           "qts" => {
-            "awarded" => "2013-01-28"
+            "awarded" => "2013-01-28",
           }
         }
       end

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -6,16 +6,18 @@ module FakeQualificationsData
       firstName: "Terry",
       lastName: "Walsh",
       previousNames: [
-        { first_name: "Terry", last_name: "Jones", middle_name: "" }, 
+        { first_name: "Terry", last_name: "Jones", middle_name: "" },
         { first_name: "Terry", last_name: "Smith", middle_name: "" }
       ],
       eyts: {
         awarded: "2022-04-01",
-        certificateUrl: "/v3/certificates/eyts"
+        certificateUrl: "/v3/certificates/eyts",
+        statusDescription: "Qualified (trained in the UK)",
       },
       qts: {
         awarded: "2023-02-27",
-        certificateUrl: "/v3/certificates/qts"
+        certificateUrl: "/v3/certificates/qts",
+        statusDescription: "Qualified (trained in the UK)",
       },
       induction: {
         startDate: "2022-09-01",

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Awarded")
     expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Qualified (trained in the UK)")
     expect(page).to have_content("Download QTS certificate")
   end
 


### PR DESCRIPTION
### Context

Status description will be present for EYTS and QTS qualifications on the next release of the Qualifications API.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Include status description in qualifications summary list output.

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/3cc3201a-7b8f-4f1f-bded-96c8743d51cd)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/SQVlfB1z/1477-add-status-to-qts-and-eyts-blocks-in-the-teacher-record

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
