### PR TITLE
Hide previous names if empty

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -29,7 +29,7 @@
           { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
           { key: { text: "Date of birth" }, value: { text: Date.parse(@teacher.date_of_birth).to_fs(:long_uk) } },
           { key: { text: "Previous last names" }, value: { text: @teacher.previous_names&.join("<br />").html_safe } },
-        ])
+        ].select { |row| row[:value][:text].present? })
       %>
     </div>
 


### PR DESCRIPTION
### Context

We don't want to show the previous names field on the teacher record if there aren't any.

### Changes proposed in this pull request

Hide the empty rows in the personal details section. TRN and DOB should never be empty so this will only affect last names.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
