### PR TITLE
Update markdown initializer to work with Rails >= 7.1

### DIFF
--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
+
 class MarkdownTemplate
   def self.call(template, source)
+    source ||= template.source
+
+    # Rails >= 7.1 does not work with the Redcarpet markdown renderer.
+    # There is an argument mismatch where a string is expected but an OutputBuffer is provided.
+    # This is a workaround to convert the buffer to a string.
     erb_handler = ActionView::Template.registered_template_handler(:erb)
-    compiled_source = erb_handler.call(template, source)
+    compiled_source = ActionView::OutputBuffer.new( erb_handler.call( template, source ) )
+    compiled_source << '.to_s'
     "GovukMarkdown.render(begin;#{compiled_source};end).html_safe"
   end
 end


### PR DESCRIPTION
### Context

We have Sentry errors https://dfe-teacher-services.sentry.io/issues/4793849914 relating to an incompatibility between Rails >= 7.1 and RedCarpet, the underlying markdown library used by GovukMarkdown. A recent dependabot merge is likely the cause of the incompatibility.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a workaround in the govuk markdown initializer

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

Does the accessibility & cookies pages linked from the footer work correctly on the review app?
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/l7mThi3c/1555-fix-markdown-error-for-static-pages
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
