### PR TITLE
Deduplicate previous names

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -19,7 +19,10 @@ module QualificationsApi
              to: :api_data
 
     def previous_names
-      api_data.previous_names&.map(&:last_name)&.select { |name| name != last_name }
+      return [] unless api_data.previous_names&.any?
+
+      previous_last_names = api_data.previous_names.map(&:last_name).uniq(&:downcase)
+      previous_last_names.reject { |name| name.downcase == last_name.downcase }.map(&:titleize)
     end
 
     def qualifications

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -212,4 +212,73 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
     end
   end
+
+  describe "#name" do
+    let(:api_data) do
+      {
+        "firstName" => "Jane",
+        "middleName" => "Smith",
+        "lastName" => "Jones"
+      }
+    end
+    let(:teacher) { described_class.new(api_data) }
+
+    it "returns the full name" do
+      expect(teacher.name).to eq("Jane Smith Jones")
+    end
+  end
+
+  describe "#previous_names" do
+    let(:api_data) do
+      {
+        "firstName" => "Jane",
+        "middleName" => "Smith",
+        "lastName" => "Jones",
+        "previousNames" => [
+          {
+            "firstName" => "John",
+            "middleName" => "Smith",
+            "lastName" => "DOE",
+          },
+          {
+            "firstName" => "Johan",
+            "middleName" => "Smith",
+            "lastName" => "DoE",
+          },
+          {
+            "firstName" => "Johan",
+            "middleName" => "Smith",
+            "lastName" => "Johnson",
+          },
+          {
+            "firstName" => "Jim",
+            "middleName" => "Smith",
+            "lastName" => "JONES",
+          },
+        ]
+      }
+    end
+    let(:teacher) { described_class.new(api_data) }
+
+    it "returns an array of previous names" do
+      expect(teacher.previous_names).to eq(
+        %w[Doe Johnson]
+      )
+    end
+
+    context "when there are no previous names" do
+      let(:api_data) do
+        {
+          "firstName" => "Jane",
+          "middleName" => "Smith",
+          "lastName" => "Jones",
+          "previousNames" => []
+        }
+      end
+
+      it "returns an empty array" do
+        expect(teacher.previous_names).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

We should only show "unique" previous last name changes which are not the same as the teacher's current last name.
There's currently a bug where if a teacher has changed first or middle name we see duplicate previous last names.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

De-duplicate previous last names and add some test scenarios.

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/429ade20-25c0-4ff9-96c9-e5827542b1b4)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/xEkkf6fc/1520-last-name-rendering
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
