### PR TITLE
Filter last_name and date_of_birth parameters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,4 +13,6 @@ Rails.application.config.filter_parameters += %i[
   certificate
   otp
   ssn
+  last_name
+  date_of_birth
 ]


### PR DESCRIPTION
### Context

We use last_name and date_of_birth as search params and these can contain PII

### Changes proposed in this pull request

Filter the parameters used in search to avoid PII leaking.


