### PR TITLE
Return `support_interface` namespace for `FeatureFlagsController`

### DIFF
--- a/app/controllers/concerns/dsi_authenticatable.rb
+++ b/app/controllers/concerns/dsi_authenticatable.rb
@@ -42,6 +42,8 @@ module DsiAuthenticatable
   end
 
   def path_prefix_from_namespace
+    return :support_interface if self.class.module_parent.name == "FeatureFlags"
+
     self.class.module_parent.name.underscore.to_sym
   end
 end


### PR DESCRIPTION
### Context

The `DsiAuthenicatable` controller concern [needs to construct some dynamic paths for the various namespaces in the app](https://github.com/DFE-Digital/access-your-teaching-qualifications/blob/main/app/controllers/concerns/dsi_authenticatable.rb#L36-L42). 
To do this it uses the underlying module name of the including controller, but in the case of feature flags, the module name is `FeatureFlags` and not a valid path prefix namespace because this module comes from the `govuk_feature_flags` gem.

See
https://dfe-teacher-services.sentry.io/issues/4800835259/?alert_rule_id=14607780&alert_type=issue&notification_uuid=f3464a07-1b7f-4cd1-b998-b29f289ce045&project=4505227155996672&referrer=slack


<!-- Why are you making this change? -->

### Changes proposed in this pull request

Return `:support_interface` when the underlying controller module name is `FeatureFlags`.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I considered adding `feature_flags_sign_*` paths as aliases to `support_interface_sign_*` in routes.rb but returning the correct namespace in code feels more explicit. 

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/OEyTBGcb/1568-fix-dsi-expiry-error-on-feature-flags-pages
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
