### PR TITLE
Filter DfE Analytics web request query params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require "dfe/analytics/filtered_request_event"
+
 class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
@@ -6,7 +8,7 @@ class ApplicationController < ActionController::Base
     return unless DfE::Analytics.enabled?
 
     request_event =
-      DfE::Analytics::Event
+      DfE::Analytics::FilteredRequestEvent
         .new
         .with_type("web_request")
         .with_request_details(request)

--- a/lib/dfe/analytics/filtered_request_event.rb
+++ b/lib/dfe/analytics/filtered_request_event.rb
@@ -1,0 +1,24 @@
+module DfE
+  module Analytics
+    class FilteredRequestEvent < Event
+      def with_request_details(rack_request)
+        @event_hash.merge!(
+          request_uuid: rack_request.uuid,
+          request_user_agent: ensure_utf8(rack_request.user_agent),
+          request_method: rack_request.method,
+          request_path: ensure_utf8(rack_request.path),
+          request_query: hash_to_kv_pairs(
+            request_query_filter.filter(Rack::Utils.parse_query(rack_request.query_string))),
+          request_referer: ensure_utf8(rack_request.referer),
+          anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request)
+        )
+
+        self
+      end
+
+      def request_query_filter
+        ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      end
+    end
+  end
+end

--- a/spec/lib/dfe/analytics/filtered_request_event_spec.rb
+++ b/spec/lib/dfe/analytics/filtered_request_event_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "dfe/analytics/filtered_request_event"
+
+RSpec.describe DfE::Analytics::FilteredRequestEvent do
+  describe "#with_request_details" do
+    it "filters the request query according to Rails config" do
+      allow(Rails.application.config).to receive(:filter_parameters).and_return([:date, :name])
+
+      rack_request = double(
+        Rack::Request,
+        uuid: "123",
+        user_agent: "foo",
+        method: "GET",
+        path: "/bar",
+        query_string: "foo=bar&search[name]=bar]&search[date(3i)]=10&search[date(2i)]=10&search[date(1i)]=2000",
+        referer: "http://example.com",
+        remote_ip: "1.3.22.21",
+      )
+
+      event = described_class.new.with_request_details(rack_request)
+
+      expect(event.as_json).to include(
+        "request_uuid" => "123",
+        "request_user_agent" => "foo",
+        "request_method" => "GET",
+        "request_path" => "/bar",
+        "request_query" => [
+          {"key"=>"foo", "value"=>["bar"]},
+          {"key"=>"search[name]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(3i)]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(2i)]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(1i)]", "value"=>["[FILTERED]"]},
+        ],
+        "request_referer" => "http://example.com",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to be able to filter any query parameters from DfE Analytics web requests but the underlying library doesn't yet support this.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a `FilteredRequestEvent` implementation to handle filtering sensitive request query parameters before sending analytics web request events.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I have deployed this branch to test. Need to check BQ data that filtered params are being sent.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/hj8inJwZ/1575-bigquery-issues
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
