### PR TITLE
Remove improvment_suggestion from analytics_pii.yml

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -20,4 +20,3 @@
     - date_of_birth
   :feedbacks:
     - email
-    - improvement_suggestion


### PR DESCRIPTION
### Context

We filter PII from BigQuery and are currently filtering the `improvement_suggestion` field from the feedback from. We want to include this in the dashboards.

### Changes proposed in this pull request

Remove it from analytics_pii.yml. 

### Guidance to review

The likelihood of this containing PII is small and if that proves to be incorrect we can revisit.

- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
