### PR TITLE
Use status_description for induction

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -58,7 +58,7 @@ class InductionSummaryComponent < ViewComponent::Base
           text: "Status"
         },
         value: {
-          text: details.status.to_s.humanize
+          text: details.status_description.to_s.humanize
         }
       },
       {

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
     it "renders the component rows" do
       rows = rendered.css(".govuk-summary-list__row")
       expect(rows[0].css(".govuk-summary-list__key").text).to eq("Status")
-      expect(rows[0].css(".govuk-summary-list__value").text).to eq("Pass")
+      expect(rows[0].css(".govuk-summary-list__value").text).to eq("Passed induction")
 
       expect(rows[1].css(".govuk-summary-list__key").text).to eq("Completed")
       expect(rows[1].css(".govuk-summary-list__value").text).to eq(" 1 October 2022")


### PR DESCRIPTION
### Context

We moved CTR to using the status description for all statuses as this is returned with a more human readable version of the status (which is an enum in the API).

### Changes proposed in this pull request

Update the InductionSummaryComponent to use it too as this was missed.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
