### PR TITLE
Don't filter `certificate` parameter

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,7 +10,6 @@ Rails.application.config.filter_parameters += %i[
   _key
   crypt
   salt
-  certificate
   otp
   ssn
   last_name


### PR DESCRIPTION
### Context

We have a non sensitive `certificate` parameter in AYTQ and this is currently being filtered from analytics.

This is added as a cautious default in the initial Rails app so we can remove it from filtering.

### Changes proposed in this pull request

Remove `certificate` from the filtered params

### Guidance to review

I don't think we have any instances of an 'actual' certificate paramater that we wouldn't want to log but a second opinion on that would be good.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
