### PR TITLE
Add DSI user id to analytics events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
         .with_data(session_id: session[:session_id])
 
     request_event.with_user(current_user) if respond_to?(:current_user, true)
+    request_event.with_user(current_dsi_user) if respond_to?(:current_dsi_user, true)
     request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
 
     DfE::Analytics::SendEvents.do([request_event.as_json])


### PR DESCRIPTION
### Context
We’re currently sending the user ID in web requests from Check/AYTQ only if current_user is present.

DSI auth uses current_dsi_user and so nothing is being sent.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Add some code to conditionally send current_dsi_user
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/RP200QHc/235-send-user-id-to-bigquery-from-check
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
