### PR TITLE
Revert "Bump sidekiq from 6.5.9 to 7.2.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.4"
 gem "rails", "~> 7.1.3"
 gem "rails_semantic_logger"
 gem "sentry-rails", "~> 5.16"
-gem "sidekiq", "~> 7"
+gem "sidekiq", "~> 6"
 gem "sidekiq-cron"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,8 +430,7 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
-    redis-client (0.19.1)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -517,11 +516,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (6.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.2.1)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.19.0)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.12.0)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -673,7 +671,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-rails (~> 5.16)
   shoulda-matchers
-  sidekiq (~> 7)
+  sidekiq (~> 6)
   sidekiq-cron
   sinatra
   solargraph


### PR DESCRIPTION
Reverts DFE-Digital/access-your-teaching-qualifications#532

Reverting this as v7 requires Redis >= 6.2.0 and we don't have that on Azure as yet.