### PR TITLE
Pin sidekiq < 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.4"
 gem "rails", "~> 7.1.3"
 gem "rails_semantic_logger"
 gem "sentry-rails", "~> 5.16"
-gem "sidekiq", "~> 6"
+gem "sidekiq", "< 7" #7 requires Redis >6.2 which isn't available on Azure currently
 gem "sidekiq-cron"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,6 +624,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -671,7 +672,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-rails (~> 5.16)
   shoulda-matchers
-  sidekiq (~> 6)
+  sidekiq (< 7)
   sidekiq-cron
   sinatra
   solargraph


### PR DESCRIPTION
Sidekiq 7 requires Redis 6.2. This isn't available on Azure currently

### Context

We use Sidekiq. It uses Redis. Sidekiq 7 requires Redis >= 6.2 which Azure doesn't currently support. Dependabot keeps opening an upgrade PR and when we merge it the worker instances can't start.

### Changes proposed in this pull request

Pin the Sidekiq version to < 7

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
