### PR TITLE
Remove duplicated sign out link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,6 @@ module ApplicationHelper
 
             )
           end
-          header.with_navigation_item(href: main_app.check_records_sign_out_path, text: "Sign out")
         end
         if current_dsi_user
           header.with_navigation_item(


### PR DESCRIPTION
### Context

During some PR refactoring in https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/550 we've duplicated the sign out link in the support UI navigation.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Remove duplicate sign out link from header.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
