### PR TITLE
Replace role management via environment variable with the support interface UI

### DIFF
--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -33,8 +33,9 @@ module SupportInterface
     private
 
     def role_params
-      params.require(:role).permit(:code, :enabled ).tap do |rp|
+      params.require(:role).permit(:code, :enabled, :internal).tap do |rp|
         rp[:enabled] = ActiveRecord::Type::Boolean.new.cast(rp[:enabled])
+        rp[:internal] = ActiveRecord::Type::Boolean.new.cast(rp[:internal])
       end
     end
   end

--- a/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
+++ b/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
@@ -13,8 +13,8 @@ module DfESignInApi
       response = client.get(endpoint)
 
       if response.success? && response.body.key?("roles")
-        response.body["roles"].find { |role| role["code"] == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE") } ||
-          response.body["roles"].find { |role| authorised_role_codes.include?(role["code"]) }
+        response.body["roles"].find { |role| Role.enabled.internal.pluck(:code).include?(role["code"]) } ||
+          response.body["roles"].find { |role| Role.enabled.external.pluck(:code).include?(role["code"]) }
       end
     end
 

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -27,7 +27,7 @@ class DsiUser < ApplicationRecord
   end
 
   def internal?
-    DfESignIn.bypass? || current_session&.role_code == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
+    DfESignIn.bypass? || Role.enabled.internal.pluck(:code).include?(current_session&.role_code)
   end
 
   def current_session

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,8 @@
 class Role < ApplicationRecord
   validates :code, presence: true
   validates :code, uniqueness: { case_sensitive: false }
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :internal, -> { where(internal: true) }
+  scope :external, -> { where(internal: false) }
 end

--- a/app/views/support_interface/roles/edit.html.erb
+++ b/app/views/support_interface/roles/edit.html.erb
@@ -5,6 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_role_path(@role), method: :put do |form| %>
       <%= form.govuk_text_field :code, required: true %>
+      <%= form.govuk_check_box :internal, true %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/support_interface/roles/new.html.erb
+++ b/app/views/support_interface/roles/new.html.erb
@@ -5,6 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_roles_path, method: :post do |form| %>
       <%= form.govuk_text_field :code, required: true %>
+      <%= form.govuk_check_box :internal, true %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -12,5 +12,6 @@
     - id
     - code
     - enabled
+    - internal
     - created_at
     - updated_at

--- a/db/migrate/20240222100411_add_internal_to_roles.rb
+++ b/db/migrate/20240222100411_add_internal_to_roles.rb
@@ -1,0 +1,5 @@
+class AddInternalToRoles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :roles, :internal, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_160711) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_22_100411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -133,6 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_160711) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "internal", default: false
     t.index "lower((code)::text)", name: "index_roles_on_lower_code", unique: true
   end
 

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :role do
-    code { "TestCode" }
+    sequence(:code) { |n| "TestCode-#{n}" }
     enabled { false }
+    internal { false }
+    trait :enabled do
+      enabled { true }
+    end
+    trait :internal do
+      internal { true }
+    end
   end
 end

--- a/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
+++ b/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe DfESignInApi::GetUserAccessToService do
     let(:org_id) { "123" }
     let(:user_id) { "456" }
     let(:role_id) { "789" }
-    let(:role_code) { ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first }
+    let(:role_code) { create(:role, :enabled).code }
+    let(:internal_role_code) { create(:role, :enabled, :internal).code }
     let(:endpoint) do
       "#{ENV.fetch("DFE_SIGN_IN_API_BASE_URL")}/services/checkrecordteacher/organisations/#{org_id}/users/#{user_id}"
     end
@@ -34,6 +35,23 @@ RSpec.describe DfESignInApi::GetUserAccessToService do
       end
 
       it { is_expected.to be_nil }
+    end
+
+    context "when the user has an internal and external role" do
+      before do
+        stub_request(:get, endpoint)
+        .to_return_json(
+          status: 200,
+          body: {
+            "roles" => [
+              { "id" => role_id, "code" => role_code },
+              { "id" => role_id, "code" => internal_role_code }
+            ]
+          },
+        )
+      end
+
+      it { is_expected.to eq({ "id" => role_id, "code" => internal_role_code }) }
     end
   end
 end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -81,11 +81,7 @@ module AuthenticationSteps
   end
 
   def role_code(internal: false)
-    if internal
-      ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
-    else
-      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first
-    end
+    @role_code ||= internal ? create(:role, :enabled, :internal).code : create(:role, :enabled).code
   end
 
   def organisations_endpoint


### PR DESCRIPTION
### Context

We currently identify valid internal and external roles via environment variables, these roles should be manageable in the support UI and persisted in the database. We have a support UI and database table thanks to https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/555
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Update the check for user access to the service so that it checks internal and external roles from the database.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/LlimrEZ7/1801-replace-role-management-via-environment-variable-with-the-support-interface-ui
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
