### PR TITLE
Seed roles from environment variables

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -12,5 +12,6 @@
     - id
     - code
     - enabled
+    - internal
     - created_at
     - updated_at

--- a/db/migrate/20240222100411_add_internal_to_roles.rb
+++ b/db/migrate/20240222100411_add_internal_to_roles.rb
@@ -1,0 +1,5 @@
+class AddInternalToRoles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :roles, :internal, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_160711) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_22_100411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -133,6 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_160711) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "internal", default: false
     t.index "lower((code)::text)", name: "index_roles_on_lower_code", unique: true
   end
 

--- a/lib/tasks/seed_role_codes.rake
+++ b/lib/tasks/seed_role_codes.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+namespace :db do
+  desc "Seeds role codes from environment into the database"
+  task seed_role_codes: :environment do
+    if ENV["DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"]
+      Role.find_or_create_by!(code: ENV["DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"]) do |role|
+        role.enabled = true
+        role.internal = true
+      end
+    end
+
+    if ENV["DFE_SIGN_IN_API_ROLE_CODES"]
+      ENV["DFE_SIGN_IN_API_ROLE_CODES"].split(",").each do |role_code|
+        Role.find_or_create_by!(code: role_code) do |role|
+          role.enabled = true
+        end
+      end
+    end
+
+    roles = Role.all
+
+    if roles.any?
+      puts "Roles in the database:"
+      Role.all.find_each do |role|
+        puts "Role: #{role.code} enabled: #{role.enabled} internal: #{role.internal}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We currently store role codes in env vars, but we will be changing this to storage and support UI management in the database.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Recreate existing roles from env vars in the database.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/UH6vbzE6/1853-seed-active-authorisation-roles-in-db
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
