### PR TITLE
Check for an internal user on Support UI pages

### DIFF
--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,6 +3,7 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     include DsiAuthenticatable
     include SupportNamespaceable
+    before_action :check_user_is_internal
 
     http_basic_authenticate_with(
       name: ENV.fetch("SUPPORT_USERNAME", nil),
@@ -29,6 +30,10 @@ module SupportInterface
       authenticate_or_request_with_http_basic do |username, password|
         valid_credentials.include?({ username:, password: })
       end
+    end
+
+    def check_user_is_internal
+      render "check_records/errors/not_found", status: :not_found unless current_dsi_user.internal?
     end
   end
 end

--- a/spec/system/support/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/support/unauthorised_user_signs_in_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe "DSI authentication" do
     then_i_am_redirected_to_the_unauthorised_page
   end
 
+  scenario "External user attempts to access support pages", host: :check_records, test: :with_stubbed_auth do
+    when_i_am_authorized_with_basic_auth
+    when_i_sign_in_via_dsi(authorised: true, internal: false)
+    when_i_visit_the_support_interface
+    then_i_see_the_not_found_page
+  end
+
   private
 
   def then_i_am_redirected_to_the_unauthorised_page
@@ -25,5 +32,13 @@ RSpec.describe "DSI authentication" do
       expect(page).not_to have_link("Sign in")
       expect(page).not_to have_link("Sign out")
     end
+  end
+
+  def when_i_visit_the_support_interface
+    visit "/support"
+  end
+
+  def then_i_see_the_not_found_page
+    expect(page).to have_content("Page not found")
   end
 end


### PR DESCRIPTION
### Context

Ensure we check for internal users on all support pages.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a before action to check for support users.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
