### PR TITLE
Redirect to /404 when external users attempt to access support UI

### DIFF
--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -33,7 +33,7 @@ module SupportInterface
     end
 
     def check_user_is_internal
-      render "check_records/errors/not_found", status: :not_found unless current_dsi_user.internal?
+      redirect_to "/404" unless current_dsi_user.internal?
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/585 introduced protection for support UI access by authenticated external users.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Redirect rather than render the 404 page.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/eAwSyVCM/1861-fix-service-name-in-ctr-error-pages-header

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
