### PR TITLE
[1647] Add SSL check for check-a-teachers-record domain

### DIFF
--- a/terraform/statuscake.tf
+++ b/terraform/statuscake.tf
@@ -22,7 +22,7 @@ resource "statuscake_uptime_check" "alert" {
 }
 
 resource "statuscake_ssl_check" "domain-alert" {
-  count = var.statuscake_ssl_contact_group != null ? 1 : 0
+  for_each = toset(var.statuscake_ssl_domains)
 
   check_interval   = 3600 # Check once per hour
   contact_groups   = [var.statuscake_ssl_contact_group]
@@ -38,6 +38,6 @@ resource "statuscake_ssl_check" "domain-alert" {
   }
 
   monitored_resource {
-    address = "https://${var.statuscake_domain}"
+    address = "https://${each.value}"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -147,10 +147,10 @@ variable "statuscake_ssl_contact_group" {
   description = "ID of the StatusCake contact group. If empty, SSL check is not enabled"
 }
 
-variable "statuscake_domain" {
-  type        = string
-  default     = null
-  description = "Domain/url for statuscake ssl check"
+variable "statuscake_ssl_domains" {
+  type        = list(string)
+  default     = []
+  description = "Domains/urls for statuscake ssl check"
 }
 
 variable "aytq_docker_image" {

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -12,7 +12,7 @@
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
   "enable_postgres_high_availability": true,
   "statuscake_ssl_contact_group": 288912,
-  "statuscake_domain": "access-your-teaching-qualifications.education.gov.uk",
+  "statuscake_ssl_domains": ["access-your-teaching-qualifications.education.gov.uk"],
   "domain": "access-your-teaching-qualifications.education.gov.uk",
   "check_domain": "check-a-teachers-record.education.gov.uk",
   "statuscake_alerts": {

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -12,7 +12,10 @@
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
   "enable_postgres_high_availability": true,
   "statuscake_ssl_contact_group": 288912,
-  "statuscake_ssl_domains": ["access-your-teaching-qualifications.education.gov.uk"],
+  "statuscake_ssl_domains": [
+    "access-your-teaching-qualifications.education.gov.uk",
+    "check-a-teachers-record.education.gov.uk"
+  ],
   "domain": "access-your-teaching-qualifications.education.gov.uk",
   "check_domain": "check-a-teachers-record.education.gov.uk",
   "statuscake_alerts": {


### PR DESCRIPTION
### Context
Monitor apex domains certificate expiry

### Changes proposed in this pull request
Allow a list of domains to monitor and add the new domain

### Guidance to review
Run terraform-plan:
```
make production terraform-plan TF_VAR_aytq_docker_image=ghcr.io/dfe-digital/access-your-teaching-qualifications:fd2c4be1a0c3ea0b7eafdbdb75395175c145998c
```

### Link to Trello card
https://trello.com/c/9WQqXVn8

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
