### PR TITLE
Increase the Cuprite `process_timeout` value

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,7 @@ require "dfe/analytics/rspec/matchers"
 WebMock.disable_net_connect!(allow_localhost: true)
 
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, timeout: 10, process_timeout: 30, window_size: [1200, 800])
+  Capybara::Cuprite::Driver.new(app, timeout: 30, process_timeout: 40, window_size: [1200, 800])
 end
 Capybara.default_driver = :cuprite
 Capybara.javascript_driver = :cuprite


### PR DESCRIPTION
### Context

We spend a lot of time re-running failed Rspec CI jobs because of `Ferrum::ProcessTimeoutError`s.

The default timeout for a response from the browser is 30 seconds [according to the Cuprite docs](https://www.rubydoc.info/gems/cuprite/0.6.0) but [we set it to 10 seconds](https://github.com/DFE-Digital/access-your-teaching-qualifications/blob/main/spec/rails_helper.rb#L20).


Note that the error message we regularly encounter is:

```
Ferrum::ProcessTimeoutError:
       Browser did not produce websocket url within 10 seconds, try to increase `:process_timeout`
```

The number of seconds displayed in the error message is misleading, according to the code, `options.process_timeout` should be displayed which we currently set to `30`.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Increase the Cuprite `process_timeout` config value from 30 to 40 seconds.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/CSxme5GH/1884-investigate-fix-ferrumprocesstimeout-errors-on-ci
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
