### PR TITLE
Add search metadata to results page

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -13,7 +13,11 @@ module CheckRecords
         params["search"]["date_of_birth(3i)"]
       ]
       @search =
-        Search.new(date_of_birth:, last_name: params[:search][:last_name])
+        Search.new(
+          date_of_birth:,
+          last_name: params[:search][:last_name],
+          searched_at: Time.zone.now
+        )
       if @search.invalid?
         render :new
       else

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -8,8 +8,9 @@ class Search
 
   include ActiveModel::Model
 
-  attr_accessor :last_name
+  attr_accessor :last_name, :searched_at
   attr_reader :date_of_birth
+
 
   validates :last_name, presence: true
   validate :date_of_birth_is_valid
@@ -23,6 +24,10 @@ class Search
     date_fields[1] = word_to_month_number(date_fields[1]) if month_is_a_word
 
     @date_of_birth = DateOfBirth.new(*date_fields)
+  end
+
+  def searched_at_to_s
+    searched_at.strftime("%-I:%M%P on %-d %B %Y")
   end
 
   private

--- a/app/views/check_records/search/show.html.erb
+++ b/app/views/check_records/search/show.html.erb
@@ -1,15 +1,26 @@
 <% content_for :page_title, "Search results (#{@total})" %>
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
+
+  <span class="govuk-caption-m">
+    Searched at <%= @search.searched_at_to_s %>
+  </span>
+<% end %>
+
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Search results (<%= @total %>)</h1>
     <% if @total.zero? %>
+      <h1 class="govuk-heading-l">No records found</h1>
       <p class="govuk-body">
-        No teachers found.
-        <%= govuk_link_to("Try another search", check_records_search_path) %>.
+        No record found for <%= @search.last_name %> born on <%= @search.date_of_birth.to_s.to_date.strftime("%e %B %Y") %>
+      </p>
+      <p class="govuk-body">
+        <%= govuk_link_to("Search again", check_records_search_path) %>
       </p>
     <% else %>
+      <h1 class="govuk-heading-l">Search results (<%= @total %>)</h1>
       <div class="search-results">
         <% @teachers.each do |teacher| %>
           <div class="search-results__item">

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -26,7 +26,7 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
-      return { total: 0, results: [] }.to_json if params["lastName"] == "No match"
+      return { total: 0, results: [] }.to_json if params["lastName"] == "No-match-last-name"
 
       {
         total: 1,

--- a/spec/system/check_records/user_searches_with_no_matches_spec.rb
+++ b/spec/system/check_records/user_searches_with_no_matches_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "No matches", host: :check_records, type: :system do
   private
 
   def and_search_returns_no_records
-    fill_in "Last name", with: "No match"
+    fill_in "Last name", with: "No-match-last-name"
     fill_in "Day", with: "1"
     fill_in "Month", with: "1"
     fill_in "Year", with: "1990"
@@ -23,7 +23,7 @@ RSpec.describe "No matches", host: :check_records, type: :system do
   end
 
   def then_i_see_no_records
-    expect(page).to have_content("No teachers found")
-    expect(page).to have_link("Try another search")
+    expect(page).to have_content("No record found for No-match-last-name born on 1 January 1990")
+    expect(page).to have_link("Search again")
   end
 end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -6,14 +6,19 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   include ActivateFeaturesSteps
   include AuthenticationSteps
 
+  after { travel_back }
+
   scenario "User searches with a last name and date of birth and finds a record",
            test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_check_service_is_open
+    and_time_is_frozen
+
     when_i_sign_in_via_dsi
     and_search_with_a_valid_name_and_dob
     then_i_see_a_teacher_record_in_the_results
     then_i_see_previous_last_names
     and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
@@ -27,6 +32,11 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
 
   def and_search_with_a_valid_name_and_dob
     fill_in "Last name", with: "Walsh"
@@ -98,5 +108,9 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   def then_i_see_previous_last_names
     expect(page).to have_content("Previous last names")
     expect(page).to have_content("Jones\nSmith")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
   end
 end


### PR DESCRIPTION


### Context
In some cases it’s important for users to be able to record that they performed a search that returned no results. To enable this we need to display the search terms (and date) on the no results page.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Display a timestamp for when the search was carried out
- When no results are present, add a string summary of what was searched
- Change link copy from "Try another search" to "Search again"
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
The trello card asks for the search timestamp to be displayed on the no results page, but I've opted to display it regardless of whether there are any results. The timestamp is fairly innocuous and skipping the logical check keeps the code simpler.

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/ce748774-ee7b-4319-a921-82dcc7bd7087)

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/BbMBBCtj/1881-no-results-metadata
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
