### PR TITLE
[BUG] CTR Fix new roles authorisation bug

### DIFF
--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -35,7 +35,7 @@ module SupportInterface
     def role_params
       params.require(:role).permit(:code, :enabled, :internal).tap do |rp|
         rp[:enabled] = ActiveRecord::Type::Boolean.new.cast(rp[:enabled])
-        rp[:internal] = ActiveRecord::Type::Boolean.new.cast(rp[:internal])
+        rp[:internal] ||= false
       end
     end
   end

--- a/app/views/support_interface/roles/edit.html.erb
+++ b/app/views/support_interface/roles/edit.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_role_path(@role), method: :put do |form| %>
       <%= form.govuk_text_field :code, required: true %>
-      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_check_box :internal, true, multiple: false %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/support_interface/roles/new.html.erb
+++ b/app/views/support_interface/roles/new.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_roles_path, method: :post do |form| %>
       <%= form.govuk_text_field :code, required: true %>
-      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_check_box :internal, true, multiple: false %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/db/migrate/20240311174726_add_not_null_constraint_to_roles_internal.rb
+++ b/db/migrate/20240311174726_add_not_null_constraint_to_roles_internal.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToRolesInternal < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :roles, :internal, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_22_100411) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_11_174726) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -133,7 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_22_100411) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "internal", default: false
+    t.boolean "internal", default: false, null: false
     t.index "lower((code)::text)", name: "index_roles_on_lower_code", unique: true
   end
 


### PR DESCRIPTION
### Context

A number of users who were invited to join CTR via the newly created roles have reported via Zendesk that they get the Not Authorised response.

Investigation showed that Role#internal was nil instead of false for two newly created roles, this was enough to some prevent users from successful authorisation.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Ensure `Role#internal` is set to `false` when the form field is unchecked
- Add not null constraint to `roles.internal`

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/oCd1cgTw/1897-roleinternal-should-not-be-nil
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
