### PR TITLE
Display Role#internal value on roles index

### DIFF
--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -10,6 +10,7 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Code</th>
           <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Access</th>
           <th scope="col" class="govuk-table__header"></th>
         </tr>
       </thead>
@@ -23,6 +24,9 @@
               <% else %>
                 <%= govuk_tag(text: "not enabled", colour: "red") %>
               <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= govuk_tag(text: role.internal? ? "internal" : "external", colour: "orange") %>
             </td>
             <td class="govuk-table__cell"><%= link_to "Edit", edit_support_interface_role_path(role) %></td>
           </tr>

--- a/spec/system/support/staff_user_views_check_role_codes_spec.rb
+++ b/spec/system/support/staff_user_views_check_role_codes_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Viewing Check role codes" do
   def when_i_add_a_role
     click_link "Add role"
     fill_in "Code", with: "AnotherCode"
+    check "Internal", visible: false
     click_button "Continue"
   end
 
@@ -53,6 +54,7 @@ RSpec.describe "Viewing Check role codes" do
 
     within last_row_of_roles_table do
       expect(page).to have_content "enabled"
+      expect(page).to have_content "internal"
     end
   end
 
@@ -62,6 +64,7 @@ RSpec.describe "Viewing Check role codes" do
     end
 
     fill_in "Code", with: "UpdatedCode"
+    uncheck "Internal", visible: false
     select "No", from: "Enabled"
     click_button "Continue"
   end
@@ -72,6 +75,7 @@ RSpec.describe "Viewing Check role codes" do
 
     within last_row_of_roles_table do
       expect(page).to have_content "not enabled"
+      expect(page).to have_content "external"
     end
   end
 


### PR DESCRIPTION
### Context

Currently the internal status of a Role is not displayed on the roles index table. We display it on the CBL service so we should be consistent.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Display the internal status of a Role on the roles index table.

![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/93511/4f4fa512-146f-44ca-b7a6-ca9196fbb24d)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/MLOMyEH4/1900-amend-cbl-roleinternal-checkbox
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
