### PR TITLE
Add custom I18n exception handler

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,9 +49,6 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  # Raises error for missing translations.
-  config.i18n.raise_on_missing_translations = true
-
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,9 +43,6 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Raises error for missing translations.
-  config.i18n.raise_on_missing_translations = true
-
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,13 @@
+module I18n
+  class SentryExceptionHandler
+    def call(exception, _locale, _key, _options)
+      if Rails.env.production? && exception.is_a?(MissingTranslation)
+        Sentry.capture_exception(exception)
+      else
+        raise exception.respond_to?(:to_exception) ? exception.to_exception : exception
+      end
+    end
+  end
+end
+
+I18n.exception_handler = I18n::SentryExceptionHandler.new

--- a/spec/config/initializers/i18n_spec.rb
+++ b/spec/config/initializers/i18n_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe I18n::SentryExceptionHandler do
+  let(:key) { "missing.translation" }
+
+  describe "#call" do
+    it "raises exceptions in non-production environments" do
+      expect { I18n.translate(key) }.to raise_exception(I18n::MissingTranslationData)
+    end
+    context "in production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Sentry).to receive(:capture_exception)
+      end
+      it "captures the exception in Sentry" do
+        I18n.translate(key)
+        expect(Sentry).to have_received(:capture_exception).with(
+          I18n::MissingTranslation.new(:en, key)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

In the event of a missing or incorrect key, default i18n behaviour in Rails is to simply render a missing key error on the page. We can improve this to increase the likelihood of finding such errors.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a custom I18n exception handler which sends missing translation errors to Sentry when running in production mode.
In test/development mode it raises the exception.


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I opted to write a test for this, not sure I've put it in the right location but I though there was enough complexity in the handler to warrant it.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/D4UPWMWZ/226-improve-handling-of-missing-i18n-keys
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
