### PR TITLE
Add teacher record summary panel to Check

### DIFF
--- a/app/assets/stylesheets/check_records.scss
+++ b/app/assets/stylesheets/check_records.scss
@@ -106,3 +106,9 @@ h1 .govuk-tag {
 .app-inset-text--red {
   border-color: govuk-colour("red");
 }
+
+.app-teacher-summary-panel {
+  .govuk-tag {
+    max-width: 100%;
+  }
+}

--- a/app/components/check_records/teacher_profile_summary_component.html.erb
+++ b/app/components/check_records/teacher_profile_summary_component.html.erb
@@ -1,14 +1,17 @@
 <% unless tags.blank? %>
-  <h2 class="govuk-heading-m">Summary</h2>
-  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <div class="app-teacher-summary-panel">
 
-  <%= govuk_summary_list(borders: false) do |summary_list| %>
-    <%= tags.each do |tag| %>
-      <%= summary_list.with_row do |row| %>
-        <% row.with_key do %>
-          <%= govuk_tag(text: tag, colour: "green") %>
-        <% end %>
+    <h2 class="govuk-heading-m">Summary</h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+      <% tags.each do |tag| %>
+        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+          <dt class="govuk-summary-list__key govuk-!-width-full">
+          <strong class="govuk-tag govuk-tag--green"><%= tag %></strong>
+          </dt>
+        </div>
       <% end %>
-    <% end %>
-  <% end %>
+    </dl>
+  </div>
 <% end %>

--- a/app/components/check_records/teacher_profile_summary_component.html.erb
+++ b/app/components/check_records/teacher_profile_summary_component.html.erb
@@ -1,0 +1,14 @@
+<% unless tags.blank? %>
+  <h2 class="govuk-heading-m">Summary</h2>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+  <%= govuk_summary_list(borders: false) do |summary_list| %>
+    <%= tags.each do |tag| %>
+      <%= summary_list.with_row do |row| %>
+        <% row.with_key do %>
+          <%= govuk_tag(text: tag, colour: "green") %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CheckRecords::TeacherProfileSummaryComponent < ViewComponent::Base
+  attr_reader :teacher, :sanctions
+  attr_accessor :tags
+
+  def initialize(teacher)
+    super
+    @teacher = teacher
+    @sanctions = teacher.sanctions
+    @tags = []
+    build_tags
+  end
+
+  def build_tags
+    if teacher.qts_awarded?
+      tags.append "QTS"
+    end
+
+    if teacher.passed_induction?
+      tags.append "Passed induction"
+    end
+
+    if no_restrictions?
+      tags.append "No restrictions"
+    end
+  end
+
+  private
+
+  def no_restrictions?
+    return true if sanctions.blank?
+    return false if sanctions.any?(&:possible_match_on_childrens_barred_list?)
+    return true if sanctions.all?(&:guilty_but_not_prohibited?)
+    false
+  end
+end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -40,7 +40,15 @@ module QualificationsApi
     end
 
     def sanctions
-      api_data.sanctions.map { |sanction| Sanction.new(sanction) }
+      api_data.sanctions&.map { |sanction| Sanction.new(sanction) }
+    end
+
+    def qts_awarded?
+      api_data.qts&.awarded.present?
+    end
+
+    def passed_induction?
+      api_data.induction&.status_description == "Pass"
     end
 
     private

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -234,4 +234,12 @@ class Sanction
   def title
     SANCTIONS[code][:title] if SANCTIONS[code]
   end
+
+  def possible_match_on_childrens_barred_list?
+    code == "G3"
+  end
+
+  def guilty_but_not_prohibited?
+    code == "T6"
+  end
 end

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -37,7 +37,9 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render CheckRecords::TeacherProfileSummaryComponent.new(@teacher) %>
+    <% if FeatureFlags::FeatureFlag.active?(:teacher_profile_tags) %>
+      <%= render CheckRecords::TeacherProfileSummaryComponent.new(@teacher) %>
+    <% end %>
 
     <h2 class="govuk-heading-m">Personal details</h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -22,16 +22,6 @@
       <% end %>
     <% end %>
 
-    <div class="govuk-!-margin-bottom-9">
-      <h2 class="govuk-heading-m">Personal details</h2>
-      <%= govuk_summary_list(
-        rows: [
-          { key: { text: "Teacher reference number (TRN)" }, value: { text: @teacher.trn } },
-          { key: { text: "Date of birth" }, value: { text: Date.parse(@teacher.date_of_birth).to_fs(:long_uk) } },
-          { key: { text: "Previous last names" }, value: { text: @teacher.previous_names&.join("<br />").html_safe } },
-        ].select { |row| row[:value][:text].present? })
-      %>
-    </div>
 
     <% if @mqs.present? %>
       <%= render CheckRecords::MqSummaryComponent.new(mqs: @mqs) %>
@@ -44,6 +34,39 @@
     <% @other_qualifications.each do |qualification| %>
       <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
     <% end %>
+  </div>
 
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Personal details</h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <ul class="govuk-list govuk-!-font-size-16">
+      <% if @teacher.trn.present? %>
+        <li>
+          <h4>Teacher Reference number (TRN)</h4>
+        </li>
+        <li>
+          <p><%= @teacher.trn  %></p>
+        </li>
+      <% end %>
+
+      <% if @teacher.date_of_birth.present? %>
+          <li>
+            <h4>Date of birth</h4>
+          </li>
+          <li>
+            <p><%= Date.parse(@teacher.date_of_birth).to_fs(:long) %></p>
+          </li>
+      <% end %>
+
+      <% if @teacher.previous_names.present? %>
+          <li>
+            <h4>Previous last names</h4>
+          </li>
+          <% @teacher.previous_names.each do |name| %>
+            <li><%= name %></li>
+          <% end %>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -37,6 +37,8 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
+    <%= render CheckRecords::TeacherProfileSummaryComponent.new(@teacher) %>
+
     <h2 class="govuk-heading-m">Personal details</h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -24,3 +24,7 @@ feature_flags:
     description: Add a section to the Support interface that allows us to
       manage DSI roles. These are used to authorise access to Check the record
       of a teacher.
+  teacher_profile_tags:
+    author: Malcolm Baig
+    description: Add a profile summary to the teacher show page which contains
+      various tags summarising the profile.

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component do
+  let(:teacher) { QualificationsApi::Teacher.new({}) }
+
+  describe "rendering" do
+    context "teacher#qts_awarded? is true" do
+      before { allow(teacher).to receive(:qts_awarded?).and_return(true) }
+
+      it "adds the QTS tag" do
+        render_inline described_class.new(teacher)
+
+        expect(page).to have_text("QTS")
+      end
+    end
+
+    context "teacher#qts_awarded? is false" do
+      before { allow(teacher).to receive(:qts_awarded?).and_return(false) }
+
+      it "does not add the QTS tag" do
+        render_inline described_class.new(teacher)
+
+        expect(page).not_to have_text("QTS")
+      end
+    end
+
+    context "teacher#passed_induction? is true" do
+      before { allow(teacher).to receive(:passed_induction?).and_return(true) }
+
+      it "adds the Passed induction tag" do
+        render_inline described_class.new(teacher)
+
+        expect(page).to have_text("Passed induction")
+      end
+    end
+
+    context "teacher#passed_induction? is false" do
+      before { allow(teacher).to receive(:passed_induction?).and_return(false) }
+
+      it "does not add the Passed induction tag" do
+        render_inline described_class.new(teacher)
+
+        expect(page).not_to have_text("Passed induction")
+      end
+    end
+
+    describe "No restrictions tag" do
+      context "teacher#sanctions is blank" do
+        before { allow(teacher).to receive(:sanctions).and_return nil }
+
+        it "adds the No restrictions tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No restrictions")
+        end
+      end
+
+      context "teacher#sanctions returns a possible match on the childrens barred list " do
+        before do
+          allow(teacher).to receive(:sanctions).and_return(
+            [
+              instance_double(Sanction, possible_match_on_childrens_barred_list?: true),
+              instance_double(Sanction, possible_match_on_childrens_barred_list?: false)
+            ]
+          )
+        end
+
+        it "does not add the No restrictions tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).not_to have_text("No restrictions")
+        end
+      end
+
+      context "teacher#sanctions returns guilty but not prohibited sanctions only" do
+        before do
+          allow(teacher).to receive(:sanctions).and_return(
+            [
+              instance_double(
+                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+              ),
+              instance_double(
+                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+              )
+            ]
+          )
+        end
+
+        it "adds the No restrictions tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No restrictions")
+        end
+      end
+
+      context "teacher#sanctions returns any other kind of sanction" do
+        before do
+          allow(teacher).to receive(:sanctions).and_return(
+            [
+              instance_double(
+                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+              ),
+              instance_double(
+                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: false
+              )
+            ]
+          )
+        end
+
+        it "does not add the No restrictions tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).not_to have_text("No restrictions")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -283,4 +283,52 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
     end
   end
+
+  describe "qts_awarded?" do
+    let(:teacher) { described_class.new(api_data) }
+
+    context "qts awarded timestamp is present" do
+      let(:api_data) { { "qts" => { "awarded" => "2013-01-28", } } }
+
+      it "returns true" do
+        expect(teacher.qts_awarded?).to eq true
+      end
+    end
+
+    context "qts awarded timestamp is blank" do
+      let(:api_data) { { "qts" => {} } }
+
+      it "returns false" do
+        expect(teacher.qts_awarded?).to eq false
+      end
+    end
+  end
+
+  describe "passed_induction?" do
+    let(:teacher) { described_class.new(api_data) }
+
+    context "induction status is 'Pass'" do
+      let(:api_data) { { "induction" => { "status_description" => "Pass", } } }
+
+      it "returns true" do
+        expect(teacher.passed_induction?).to eq true
+      end
+    end
+
+    context "induction status is anything other than 'Pass'" do
+      let(:api_data) { { "induction" => { "status_description" => "Fail", } } }
+
+      it "returns false" do
+        expect(teacher.passed_induction?).to eq false
+      end
+    end
+
+    context "induction status is blank" do
+      let(:api_data) { { "induction" => {} } }
+
+      it "returns false" do
+        expect(teacher.passed_induction?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
We have an updated layout for the teacher record page that gives the user a colour coded summary of the teacher record.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Move the Personal details section into a panel on the right side.

Display a set of tags summarising the state of the teacher
profile. To begin with, we conditionally show three tags:

- "QTS" if QTS is present and has an awarded timestamp
- "Passed induction" if the induction is present and has a status
  description of 'Pass'
- "No restrictions" if any of the following are true:
  * No sanctions are present
  * There are no possible matches on the childrens barred list
  * The returned sanctions are 'guilty but not prohibited' only
 
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Testing Check locally:
- Bypass signin
- Search for last name Test and date of birth 1/1/1980 to get a set of useful results (assuming you're pointing to the preprod Quals API).
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/BZWU6qmV/1880-teacher-record-summary-panel
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
