### PR TITLE
Change AYTQ sign out flow to fix prefetch bug

### DIFF
--- a/app/controllers/qualifications/qualifications_interface_controller.rb
+++ b/app/controllers/qualifications/qualifications_interface_controller.rb
@@ -33,11 +33,11 @@ module Qualifications
     end
 
     def handle_expired_token!
-      redirect_to qualifications_sign_out_path unless session[:identity_user_token_expiry]
-
-      if Time.zone.at(session[:identity_user_token_expiry]).past?
+      token = session[:identity_user_token_expiry]
+      if token.blank? || Time.zone.at(token).past?
+        reset_session
         flash[:warning] = "Your session has expired. Please sign in again."
-        redirect_to qualifications_sign_out_path
+        redirect_to qualifications_sign_in_path
       end
     end
   end

--- a/app/controllers/qualifications/users/sign_out_controller.rb
+++ b/app/controllers/qualifications/users/sign_out_controller.rb
@@ -2,14 +2,21 @@ module Qualifications
   module Users
     class SignOutController < QualificationsInterfaceController
       skip_before_action :handle_expired_token!
+      skip_before_action :authenticate_user!, only: :complete
 
       def new
+      end
+
+      def create
         if user_signed_in?
           reset_session
           redirect_to "/qualifications/users/auth/identity/logout"
         else
           redirect_to qualifications_start_path
         end
+      end
+
+      def complete
       end
     end
   end

--- a/app/controllers/qualifications/users/sign_out_controller.rb
+++ b/app/controllers/qualifications/users/sign_out_controller.rb
@@ -4,6 +4,10 @@ module Qualifications
       skip_before_action :handle_expired_token!
       skip_before_action :authenticate_user!, only: :complete
 
+      rescue_from ActionController::InvalidAuthenticityToken do
+        redirect_to qualifications_start_path
+      end
+
       def new
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
             href: main_app.qualifications_identity_user_path,
             text: "Account"
           )
-          header.with_navigation_item(href: main_app.qualifications_sign_out_path, text: "Sign out")
+          header.with_navigation_item(href: main_app.qualifications_new_sign_out_path, text: "Sign out")
         end
       else
         if current_dsi_user.internal?

--- a/app/views/qualifications/users/sign_out/complete.html.erb
+++ b/app/views/qualifications/users/sign_out/complete.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You are now signed out</h1>
+
+    <%= govuk_button_link_to "Back to GOV.UK", qualifications_start_path  %>
+  </div>
+</div>

--- a/app/views/qualifications/users/sign_out/new.html.erb
+++ b/app/views/qualifications/users/sign_out/new.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You are now signed out</h1>
+    <h1 class="govuk-heading-xl">Are you sure you want to sign out?</h1>
 
-    <%= govuk_button_link_to "Back to GOV.UK", qualifications_root_path  %>
+    <%= govuk_button_to "Confirm", qualifications_confirm_sign_out_path, method: :post %>
   </div>
 </div>

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -6,8 +6,11 @@ namespace :qualifications do
 
   get "/users/auth/identity/callback", to: "users/omniauth_callbacks#identity"
   get "/sign-in", to: "users/sign_in#new"
-  get "/sign-out", to: "users/sign_out#new"
-  get "/users/auth/identity/logout", to: "users/sign_out#new"
+  get "/sign-out/new", to: "users/sign_out#new", as: :new_sign_out
+  post "/sign-out/confirm", to: "users/sign_out#create", as: :confirm_sign_out
+  get "/sign-out", to: "users/sign_out#complete"
+
+  get "/users/auth/identity/logout", to: "users/sign_out#complete"
 
   resource :start, only: [:show]
 

--- a/spec/system/qualifications/user_signs_out_spec.rb
+++ b/spec/system/qualifications/user_signs_out_spec.rb
@@ -10,7 +10,10 @@ RSpec.feature "Identity auth", type: :system do
     and_identity_auth_is_mocked
     and_i_am_signed_in_via_identity
     when_i_click_the_sign_out_link
-    then_i_am_on_the_start_page
+    and_confirm_my_sign_out
+    then_i_see_the_confirmation_page
+    when_i_click_the_button_to_take_me_back_to_the_service
+    then_i_am_on_service_start_page
   end
 
   private
@@ -22,4 +25,21 @@ RSpec.feature "Identity auth", type: :system do
   def when_i_click_the_sign_out_link
     click_link "Sign out"
   end
+
+  def and_confirm_my_sign_out
+    click_button "Confirm"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content "You are now signed out"
+  end
+
+  def when_i_click_the_button_to_take_me_back_to_the_service
+   click_link "Back to GOV.UK"
+  end
+
+  def then_i_am_on_service_start_page
+    expect(page).to have_current_path qualifications_start_path
+  end
 end
+

--- a/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
+++ b/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Identity auth", type: :system do
   end
 
   def then_i_am_required_to_sign_in_again
-    expect(page).to have_content "You need to sign in to continue."
+    expect(page).to have_content "Your session has expired. Please sign in again."
+    expect(page).to have_current_path qualifications_sign_in_path
   end
 end


### PR DESCRIPTION
### Context
We've had reports of users being signed out immediately after sign in,
likely because of link prefetching in the browser hitting the sign out
link.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Sign out should probably be a POST request anyway, so rework the flow as
follows:

- Change the sign out link to be a GET request to a confirmation page
- Have the confirmation page POST the user confirmation, resulting in
  session deletion
- Redirect the user to a sign out complete page from where they can
  navigate back to the service start page

Also:

- [Add CSRF error handling to AYTQ sign out controller](https://github.com/DFE-Digital/access-your-teaching-qualifications/commit/420765f94f2c7c4c6bfa58b4d2c70624085e561f)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested locally by signing in via Identity and then clicking sign out link in header.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/m5in3SCr
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
