### PR TITLE
Sign out with Teacher Auth

### DIFF
--- a/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
@@ -15,6 +15,7 @@ module Qualifications
         session[:"#{provider}_user_id"] = @user.id
         session[:"#{provider}_user_token"] = auth.credentials.token
         session[:"#{provider}_user_token_expiry"] = auth.credentials.expires_in.seconds.from_now.to_i
+        session[:"#{provider}_id_token"] = auth.credentials.id_token
 
         log_auth_credentials_in_development(auth)
         redirect_to qualifications_dashboard_path

--- a/app/controllers/qualifications/users/sign_out_controller.rb
+++ b/app/controllers/qualifications/users/sign_out_controller.rb
@@ -13,8 +13,15 @@ module Qualifications
 
       def create
         if user_signed_in?
+          id_token = session[:onelogin_id_token]
+
           reset_session
-          redirect_to "/qualifications/users/auth/identity/logout"
+
+          if FeatureFlags::FeatureFlag.active?(:one_login)
+            redirect_to("/qualifications/users/auth/onelogin/logout?id_token_hint=#{id_token}")
+          else
+            redirect_to "/qualifications/users/auth/identity/logout"
+          end
         else
           redirect_to qualifications_start_path
         end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -63,13 +63,14 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :openid_connect,
+  provider :dfe_openid_connect,
            name: :onelogin,
            allow_authorize_params: %i[session_id trn_token],
            callback_path: "/qualifications/users/auth/onelogin/callback",
            send_scope_to_token_endpoint: false,
            client_options: {
              authorization_endpoint: "/oauth2/authorize",
+             end_session_endpoint: "/oauth2/logout",
              token_endpoint: "/oauth2/token",
              userinfo_endpoint: "/oauth2/userinfo",
              host: URI(ENV.fetch("ONELOGIN_API_DOMAIN", "not_set")).host,

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -12,6 +12,7 @@ namespace :qualifications do
   get "/sign-out", to: "users/sign_out#complete"
 
   get "/users/auth/identity/logout", to: "users/sign_out#complete"
+  get "/users/auth/onelogin/logout", to: "users/sign_out#complete"
 
   resource :start, only: [:show]
 

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -10,6 +10,12 @@ module QualificationAuthenticationSteps
     and_click_the_sign_in_button
   end
 
+  def and_i_am_signed_in_via_onelogin
+    given_onelogin_auth_is_mocked
+    when_i_go_to_the_sign_in_page
+    and_click_the_onelogin_sign_in_button
+  end
+
   def given_auth_is_mocked_for(provider:)
     OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new(
       {
@@ -22,6 +28,7 @@ module QualificationAuthenticationSteps
         },
         credentials: {
           token: "token",
+          id_token: "id_token",
           expires_in: 1.hour.to_i
         },
         extra: {

--- a/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "GOVUK One Login auth", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "User signs in via One Login", test: %i[with_stubbed_auth with_fake_quals_api] do
+  scenario "User signs in via One Login", test: %i[with_stubbed_auth with_fake_quals_api with_stubbed_session] do
     given_the_qualifications_service_is_open
     given_onelogin_authentication_is_active
     and_onelogin_auth_is_mocked

--- a/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "GOVUK One Login auth", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "User signs in via One Login", test: %i[with_stubbed_auth with_fake_quals_api with_stubbed_session] do
+  scenario "User signs in via One Login", test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_qualifications_service_is_open
     given_onelogin_authentication_is_active
     and_onelogin_auth_is_mocked

--- a/spec/system/qualifications/user_signs_out_via_onelogin_spec.rb
+++ b/spec/system/qualifications/user_signs_out_via_onelogin_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "GOVUK One Login auth", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario "User signs out", test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    given_onelogin_authentication_is_active
+    and_onelogin_auth_is_mocked
+    and_i_am_signed_in_via_onelogin
+    when_i_click_the_sign_out_link
+    and_confirm_my_sign_out
+    then_i_see_the_confirmation_page
+    when_i_click_the_button_to_take_me_back_to_the_service
+    then_i_am_on_service_start_page
+  end
+
+  private
+
+  def then_i_am_on_the_start_page
+    expect(page).to have_current_path(qualifications_sign_in_path)
+  end
+
+  def when_i_click_the_sign_out_link
+    click_link "Sign out"
+  end
+
+  def and_confirm_my_sign_out
+    click_button "Confirm"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content "You are now signed out"
+  end
+
+  def when_i_click_the_button_to_take_me_back_to_the_service
+   click_link "Back to GOV.UK"
+  end
+
+  def then_i_am_on_service_start_page
+    expect(page).to have_current_path qualifications_start_path
+  end
+end
+


### PR DESCRIPTION
### Context

AYTQ is moving to Teacher Auth so that users can be authenticated and verified via One Login.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds configuration and routing to handle signing out of AYTQ when authenticated with GOVUK One Login.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

This PR is based on [the sign in PR](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/629), the only commit to review is https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/630/commits/e4ac9294821318e4a03c0d5afbd84ae0ad908797
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/QWReE7W6/18-sign-out-with-teacher-auth
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
