### PR TITLE
Guard against nil previous last name

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -21,7 +21,7 @@ module QualificationsApi
     def previous_names
       return [] unless api_data.previous_names&.any?
 
-      previous_last_names = api_data.previous_names.map(&:last_name).uniq(&:downcase)
+      previous_last_names = api_data.previous_names.map(&:last_name).compact.uniq(&:downcase)
       previous_last_names.reject { |name| name.downcase == last_name.downcase }.map(&:titleize)
     end
 

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -253,6 +253,11 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "lastName" => "Johnson",
           },
           {
+            "firstName" => "Johan",
+            "middleName" => "Smith",
+            "lastName" => nil,
+          },
+          {
             "firstName" => "Jim",
             "middleName" => "Smith",
             "lastName" => "JONES",


### PR DESCRIPTION
### Context

We've seen this error a few times in production, it's simple to guard against nil API data in this case.

Sentry error(s): https://dfe-teacher-services.sentry.io/issues/5210189890

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Filter out any nil last name values from a teacher's previous last names

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
