### PR TITLE
Add GOVUK One Login feature flag

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -7,6 +7,10 @@ feature_flags:
       record. This flag should always be inactive on non-production deployments,
       to prevent accidental access by members of the public. Once the service
       goes live, this flag should always be active on production.
+  one_login:
+    author: Steve Laing
+    description: Changes the AYTQ authentication service from Teacher Identity to GOVUK One Login.
+      This flag allows us to switch OAuth2 provider, this will impact how users authenticate with the service.
   qualifications_service_open:
     author: Graham Pengelly
     description: Remove the basic authentication when accessing AYTQ.

--- a/spec/support/system/activate_features_steps.rb
+++ b/spec/support/system/activate_features_steps.rb
@@ -10,4 +10,8 @@ module ActivateFeaturesSteps
   def given_the_support_service_is_open
     FeatureFlags::FeatureFlag.activate(:support_service_open)
   end
+
+  def given_onelogin_authentication_is_active
+    FeatureFlags::FeatureFlag.activate(:one_login)
+  end
 end


### PR DESCRIPTION
### Context

We'd like to switch AYTQ authentication from Identity to One Login.  
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Add a feature flag for GOVUK One Login.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/QUaZYxsH/43-add-one-login-feature-flag
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
