### PR TITLE
Add feedback form to AYTQ

### DIFF
--- a/app/controllers/qualifications/feedbacks_controller.rb
+++ b/app/controllers/qualifications/feedbacks_controller.rb
@@ -1,7 +1,7 @@
-module CheckRecords
-  class FeedbacksController < CheckRecordsController
-    skip_before_action :authenticate_dsi_user!
-    skip_before_action :handle_expired_session!
+module Qualifications
+  class FeedbacksController < QualificationsInterfaceController
+    skip_before_action :authenticate_user!
+    skip_before_action :handle_expired_token!
 
     def new
       @feedback = Feedback.new
@@ -9,10 +9,10 @@ module CheckRecords
 
     def create
       @feedback = Feedback.new(feedback_params)
-      @feedback.service = :check
+      @feedback.service = :aytq
 
       if @feedback.save
-        redirect_to check_records_success_path
+        redirect_to qualifications_success_path
       else
         render :new
       end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,4 +1,6 @@
 class Feedback < ApplicationRecord
+  enum service: {check: "check", aytq: "aytq"}
+
   SATISFACTION_RATINGS = %w[
     very_satisfied
     satisfied

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -29,7 +29,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
-        This is a new service – <%= govuk_link_to("your feedback will help us to improve it", t('service.feedback_form')) %>.
+        This is a new service – your <%= govuk_link_to("feedback", main_app.qualifications_feedbacks_path) %> will help us to improve it.
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>

--- a/app/views/qualifications/feedbacks/new.html.erb
+++ b/app/views/qualifications/feedbacks/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "Give feedback about Access your Teaching Qualifications" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Give feedback about Access your Teaching Qualifications
+    </h1>
+
+    <%= form_with model: [:qualifications, @feedback] do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+            :satisfaction_rating,
+            satisfaction_rating_options(Feedback::SATISFACTION_RATINGS),
+            :value,
+            :label,
+            legend: { text: "How satisfied are you with the service?", size: "m" },
+            ) %>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_area :improvement_suggestion, label: { text: "How can we improve the service?", size: "m" } %>
+      </div>
+
+      <%= f.govuk_radio_buttons_fieldset :contact_permission_given, legend: { size: "m", text: "Can we contact you about your feedback?" } do %>
+        <%= f.govuk_radio_button :contact_permission_given, 'true', label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+        <% end %>
+        <%= f.govuk_radio_button :contact_permission_given, 'false', label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Send feedback" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/qualifications/feedbacks/success.html.erb
+++ b/app/views/qualifications/feedbacks/success.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Feedback sent" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_panel(title_text: "Feedback sent") %>
+
+    <h2 class="govuk-heading-m">What you can do next</h2>
+
+    <p class="govuk_body">
+      Return to <%= govuk_link_to("Access your Teaching Qualifications", qualifications_root_path) %>.
+    </p>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -104,3 +104,4 @@ shared:
     - email
     - created_at
     - updated_at
+    - service

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -20,6 +20,12 @@ namespace :qualifications do
   resource :npq_certificate, only: [:show]
 
   root to: "qualifications#show", as: :dashboard
+
+  scope "/feedback" do
+    get "/", to: "feedbacks#new", as: :feedbacks
+    post "/", to: "feedbacks#create"
+    get "/success", to: "feedbacks#success"
+  end
 end
 
 scope via: :all do

--- a/db/migrate/20240422123545_add_service_to_feedback.rb
+++ b/db/migrate/20240422123545_add_service_to_feedback.rb
@@ -1,0 +1,8 @@
+class AddServiceToFeedback < ActiveRecord::Migration[7.1]
+  def change
+    change_table :feedbacks  do |f|
+      f.column :service, :string, default: :check, null: false
+    end
+    change_column_default :feedbacks, :service, from: :check, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_144005) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_123545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -126,6 +126,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_144005) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "service", null: false
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/factories/feedback.rb
+++ b/spec/factories/feedback.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:email) { |n| "someone-#{n}@example.com" }
     satisfaction_rating { "very_satisfied" }
     improvement_suggestion { "I would like to see more of this" }
+    service { "check" }
     contact_permission_given { true }
   end
 end

--- a/spec/system/qualifications/user_gives_feedback_spec.rb
+++ b/spec/system/qualifications/user_gives_feedback_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Feedback", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario "User gives feedback", test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+    and_i_click_on_feedback
+    then_i_see_the_feedback_form
+    when_i_press_send_feedback
+    then_i_see_validation_errors
+    when_i_choose_satisfied
+    when_i_fill_in_how_we_can_improve
+    when_i_choose_yes
+    when_i_enter_an_email
+    when_i_press_send_feedback
+    then_i_see_the_feedback_sent_page
+    and_my_feedback_is_saved
+  end
+
+  private
+
+  def and_i_visit_the_search_page
+    visit search_path
+  end
+
+  def and_i_click_on_feedback
+    click_on "feedback"
+  end
+
+  def then_i_see_the_feedback_form
+    expect(page).to have_current_path("/qualifications/feedback")
+    expect(page).to have_title("Give feedback about Access your Teaching Qualifications")
+    expect(page).to have_content("How satisfied are you with the service?")
+  end
+
+  def when_i_press_send_feedback
+    click_on "Send feedback"
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content("There’s a problem")
+  end
+
+  def when_i_choose_satisfied
+    choose "Satisfied", visible: false
+  end
+
+  def when_i_fill_in_how_we_can_improve
+    fill_in "How can we improve the service?", with: "Make it better"
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_enter_an_email
+    fill_in "Email address", with: "my_email@example.com"
+  end
+
+  def then_i_see_the_feedback_sent_page
+    expect(page).to have_current_path("/qualifications/feedback/success")
+    expect(page).to have_title("Feedback sent")
+    expect(page).to have_content("What you can do next")
+  end
+
+  def and_my_feedback_is_saved
+    expect(Feedback.where(service: "aytq").count).to eq(1)
+  end
+end


### PR DESCRIPTION
### Context
CTR and CBL both have built in feedback forms but AYTQ is still using a Microsoft form which shold be replaced as it  and doesn’t automatically link to BigQuery.

Note the migration to add the AYTQ class isnt present yet; postgres issues on my end are preventing a migration file from being created. 

### Link to Trello card

](https://trello.com/c/9qSAiX4y/1-add-bespoke-feedback-form-for-aytq)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
