### PR TITLE
Dont allow a name change if there is already one pending

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -25,6 +25,10 @@ module QualificationsApi
       previous_last_names.reject { |name| name.downcase == last_name.downcase }.map(&:titleize)
     end
 
+    def pending_name_change?
+      api_data.pending_name_change
+    end
+
     def qualifications
       @qualifications = []
 

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -30,8 +30,11 @@
           Teacher Reference number (TRN)<br /> 
           <strong><%= @teacher.trn %></strong>
         </p>
-
-        <%= govuk_link_to "View and update details", qualifications_identity_user_path %>
+        <% if @teacher.pending_name_change? %>
+          <strong class="govuk-tag govuk-tag--yellow">In review</strong>
+        <% else  %>
+          <%= govuk_link_to "View and update details", qualifications_identity_user_path %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Context
The account page allows users to submit a request to change the name on their teaching record. If a request has already been submitted and is in-flight the user should not be allowed to submit another.

### Changes proposed in this pull request

Amend the account page to show an In review tag in place of the Change link on the Name on certificates row if the TRS API returns pendingNameChange: true.

Don’t allow users to access any of the name change pages if the TRS API returns pendingNameChange: true.

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
(https://trello.com/c/Dao2Er0l/36-dont-allow-submitting-a-name-change-if-there-is-already-one-pending)
### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
