### PR TITLE
Dont allow submitting a details change if dob pending

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -25,6 +25,10 @@ module QualificationsApi
       previous_last_names.reject { |name| name.downcase == last_name.downcase }.map(&:titleize)
     end
 
+    def pending_dob_change?
+      api_data.pending_dob_change
+    end
+
     def qualifications
       @qualifications = []
 

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -30,8 +30,11 @@
           Teacher Reference number (TRN)<br /> 
           <strong><%= @teacher.trn %></strong>
         </p>
-
-        <%= govuk_link_to "View and update details", qualifications_identity_user_path %>
+        <% if @teacher.pending_dob_change? %>
+          <strong class="govuk-tag govuk-tag--yellow">In review</strong>
+        <% else  %>
+          <%= govuk_link_to "View and update details", qualifications_identity_user_path %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Context

The account page allows users to submit a request to change the date of birth on their teaching record. If a request has already been submitted and is in-flight the user should not be allowed to submit another.

### Changes proposed in this pull request

Amend the account page to show an In review tag in place of the Change link on the Date of birth row if the TRS API returns pendingDateOfBirthChange: true.

Don’t allow users to access any of the name change pages if the TRS API returns pendingDateOfBirthChange: true.
