### PR TITLE
Display One Login verified fields on account page

### DIFF
--- a/app/controllers/qualifications/one_login_users_controller.rb
+++ b/app/controllers/qualifications/one_login_users_controller.rb
@@ -1,14 +1,14 @@
 module Qualifications
   class OneLoginUsersController < QualificationsInterfaceController
-    before_action :redirct_to_root_unless_one_login_enabled
+    before_action :redirect_to_root_unless_one_login_enabled
 
     def show
     end
 
     private
 
-    def redirct_to_root_unless_one_login_enabled
-      unless FeatureFlag::Features.active?(:one_login)
+    def redirect_to_root_unless_one_login_enabled
+      unless FeatureFlags::FeatureFlag.active?(:one_login)
         redirect_to qualifications_root_path
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,8 @@ class User < ApplicationRecord
   def name
     ::NameOfPerson::PersonName.full(self[:name])
   end
+
+  def verified_by_one_login?
+    one_login_verified_name.present? & one_login_verified_birth_date.present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,14 +5,19 @@ class User < ApplicationRecord
   def self.from_auth(auth_data)
     email = auth_data.info.email
     user = find_or_initialize_by(email:)
+
     user.assign_attributes(
+      # TODO: review how much of this PII we need to persist. We may no longer
+      # have a requirement for it.
       date_of_birth: auth_data.extra.raw_info.birthdate,
       family_name: auth_data.info.last_name,
       given_name: auth_data.info.first_name,
       name: auth_data.info.name,
       trn: auth_data.extra.raw_info.trn,
       auth_uuid: auth_data.uid,
-      auth_provider: auth_data.provider
+      auth_provider: auth_data.provider,
+      one_login_verified_name: auth_data.extra.raw_info.onelogin_verified_names&.first&.join(' '),
+      one_login_verified_birth_date: auth_data.extra.raw_info.onelogin_verified_birthdates&.first
     )
     user.tap(&:save!)
   end

--- a/app/views/qualifications/one_login_users/show.html.erb
+++ b/app/views/qualifications/one_login_users/show.html.erb
@@ -37,31 +37,33 @@
       end
     %>
 
-    <h2 class="govuk-heading-m">
-      GOV.UK One Login personal details
-    </h2>
+    <% if current_user.verified_by_one_login? %>
+      <h2 class="govuk-heading-m">
+        GOV.UK One Login personal details
+      </h2>
 
-    <p class="govuk-body">You use your GOV.UK One Login to sign in to a some government services. This includes signing in to access your teaching qualifications.</p>
-    <p class="govuk-body">You’ll need to ask for support to change these details.</p>
+      <p class="govuk-body">You use your GOV.UK One Login to sign in to a some government services. This includes signing in to access your teaching qualifications.</p>
+      <p class="govuk-body">You’ll need to ask for support to change these details.</p>
 
-    <%=
-      govuk_summary_list do |summary_list|
-        summary_list.with_row do |row|
-          row.with_key { "Name" }
-          row.with_value { "_TODO" }
-          row.with_action(text: "Change", href: "#", visually_hidden_text: "Name")
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { "Name" }
+            row.with_value { current_user.one_login_verified_name }
+            row.with_action(text: "Change", href: "#", visually_hidden_text: "Name")
+          end
+          summary_list.with_row do |row|
+            row.with_key { "Date of birth" }
+            row.with_value { current_user.one_login_verified_birth_date.to_fs(:long_uk) }
+            row.with_action(text: "Change", href: "#", visually_hidden_text: "Date of birth")
+          end
         end
-        summary_list.with_row do |row|
-          row.with_key { "Date of birth" }
-          row.with_value { "_TODO" }
-          row.with_action(text: "Change", href: "#", visually_hidden_text: "Date of birth")
-        end
-      end
-    %>
+      %>
 
-    <p class="govuk-body">
-      <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link">Find out how to contact GOV.UK One Login support</a>.
-    </p>
+      <p class="govuk-body">
+        <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link">Find out how to contact GOV.UK One Login support</a>.
+      </p>
+    <% end %>
 
     <h2 class="govuk-heading-m">
       GOV.UK One Login security details

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -23,7 +23,7 @@
 
         <p>
           Date of birth<br />
-          <strong><%= @user.date_of_birth&.to_fs(:long_uk) %></strong>
+          <strong><%= @teacher.date_of_birth&.to_date&.to_fs(:long_uk) %></strong>
         </p>
 
         <p>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -56,6 +56,8 @@ shared:
     - date_of_birth
     - auth_uuid
     - auth_provider
+    - one_login_verified_name
+    - one_login_verified_birth_date
   :search_logs:
     - id
     - dsi_user_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -15,6 +15,8 @@
     - given_name
     - name
     - trn
+    - one_login_verified_name
+    - one_login_verified_birth_date
   :search_logs:
     - last_name
     - date_of_birth

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -14,4 +14,5 @@ Rails.application.config.filter_parameters += %i[
   ssn
   last_name
   date_of_birth
+  birth_date
 ]

--- a/db/migrate/20240429140623_add_one_login_verified_fields_to_user.rb
+++ b/db/migrate/20240429140623_add_one_login_verified_fields_to_user.rb
@@ -1,0 +1,8 @@
+class AddOneLoginVerifiedFieldsToUser < ActiveRecord::Migration[7.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :one_login_verified_name
+      t.date :one_login_verified_birth_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_123545) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_29_140623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -168,6 +168,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_123545) do
     t.date "date_of_birth"
     t.string "auth_uuid"
     t.string "auth_provider"
+    t.string "one_login_verified_name"
+    t.date "one_login_verified_birth_date"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,14 @@ RSpec.describe User, type: :model do
             first_name: "Test",
             last_name: "User"
           ),
-        extra: OpenStruct.new(raw_info: OpenStruct.new(birthdate: "1986-01-02", trn: "123456"))
+        extra: OpenStruct.new(
+          raw_info: OpenStruct.new(
+            birthdate: "1986-01-02",
+            trn: "123456",
+            onelogin_verified_names: [["Test User"]],
+            onelogin_verified_birthdates: ["1992-02-03"]
+          )
+        )
       )
     end
 
@@ -28,6 +35,8 @@ RSpec.describe User, type: :model do
       expect(user.date_of_birth.to_s).to eq "1986-01-02"
       expect(user.auth_uuid).to eq "123-abc"
       expect(user.auth_provider).to eq "an-oauth2-provider"
+      expect(user.one_login_verified_name).to eq "Test User"
+      expect(user.one_login_verified_birth_date.to_s).to eq "1992-02-03"
     end
 
     context "a user exists" do


### PR DESCRIPTION
### Context
With ID being replaced by Teacher Auth & One Login, the Account page is moving into AYTQ.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Persist the verified fields on the User record at sign in. 

If these fields are present, display them on the account page.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->


![image](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/371830ac-a201-4271-b953-6af6040670c0)

### Guidance to review
I'll write a system spec covering the (auth->view account page) flow as part of https://trello.com/c/TAjAbdH5/35-change-name-page


<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/ooWQEAhV/34-account-page
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
