### PR TITLE
Add AYTQ evidence upload storage accounts to Terraform

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,6 +1,9 @@
 locals {
   aytq_env_vars = merge(try(local.infrastructure_secrets, null),
     {
+      AZURE_STORAGE_ACCOUNT_NAME            = azurerm_storage_account.evidence.name,
+      AZURE_STORAGE_ACCESS_KEY              = azurerm_storage_account.evidence.primary_access_key,
+      AZURE_STORAGE_CONTAINER               = azurerm_storage_container.uploads.name
       BIGQUERY_DATASET                      = "events_${var.environment_name}",
       BIGQUERY_PROJECT_ID                   = "teaching-qualifications",
       BIGQUERY_TABLE_NAME                   = "events",

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,17 +1,17 @@
 locals {
   aytq_env_vars = merge(try(local.infrastructure_secrets, null),
     {
-      DOCKER_REGISTRY_SERVER_URL            = "https://ghcr.io",
-      DATABASE_URL                          = "postgres://postgres@${local.postgres_server_name}.postgres.database.azure.com:5432"
-      DATABASE_PASSWORD                     = local.infrastructure_secrets.POSTGRES_ADMIN_PASSWORD
-      HOSTING_DOMAIN                        = var.domain != null ? "https://${var.domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
+      BIGQUERY_DATASET                      = "events_${var.environment_name}",
+      BIGQUERY_PROJECT_ID                   = "teaching-qualifications",
+      BIGQUERY_TABLE_NAME                   = "events",
       CHECK_RECORDS_DOMAIN                  = var.check_domain != null ? "https://${var.check_domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
+      ConnectionStrings__Redis              = azurerm_redis_cache.redis.primary_connection_string
+      DATABASE_PASSWORD                     = local.infrastructure_secrets.POSTGRES_ADMIN_PASSWORD
+      DATABASE_URL                          = "postgres://postgres@${local.postgres_server_name}.postgres.database.azure.com:5432"
+      DOCKER_REGISTRY_SERVER_URL            = "https://ghcr.io",
+      HOSTING_DOMAIN                        = var.domain != null ? "https://${var.domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
       HOSTING_ENVIRONMENT_NAME              = local.hosting_environment
       RAILS_SERVE_STATIC_FILES              = "true"
-      ConnectionStrings__Redis              = azurerm_redis_cache.redis.primary_connection_string
-      BIGQUERY_PROJECT_ID                   = "teaching-qualifications",
-      BIGQUERY_DATASET                      = "events_${var.environment_name}",
-      BIGQUERY_TABLE_NAME                   = "events",
       REDIS_URL                             = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:${azurerm_redis_cache.redis.ssl_port}/0"
     }
   )

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,35 @@
+resource "azurerm_storage_account" "evidence" {
+  name                              = var.evidence_storage_account_name
+  resource_group_name               = var.resource_group_name
+  location                          = var.region_name
+  account_replication_type          = var.environment_name != "production" ? "LRS" : "GRS"
+  account_tier                      = "Standard"
+  account_kind                      = "StorageV2"
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
+
+  blob_properties {
+    last_access_time_enabled = true
+
+    container_delete_retention_policy {
+      days = var.evidence_container_retention_in_days
+    }
+  }
+
+  depends_on = [data.azurerm_resource_group.group]
+}
+
+
+resource "azurerm_storage_encryption_scope" "evidence-encryption" {
+  name               = "microsoftmanaged"
+  storage_account_id = azurerm_storage_account.evidence.id
+  source             = "Microsoft.Storage"
+}
+
+
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name  = azurerm_storage_account.evidence.name
+  container_access_type = "private"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -147,6 +147,20 @@ variable "aytq_docker_image" {
   type = string
 }
 
+variable "evidence_container_retention_in_days" {
+  default = 7
+  type = number
+}
+
+variable "evidence_storage_account_name" {
+  default = null
+}
+
+variable "region_name" {
+  default = "west europe"
+  type = "string"
+}
+
 locals {
   hosting_environment          = var.environment_name
   aytq_web_app_name            = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-app"

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -7,5 +7,6 @@
   "storage_log_categories": [],
   "resource_prefix": "s165d01-aytq",
   "domain": "dev.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "dev.check-a-teachers-record.education.gov.uk"
+  "check_domain": "dev.check-a-teachers-record.education.gov.uk",
+  "evidence_storage_account_name": "s165d01aytqevidencedv"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -9,5 +9,6 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
   "domain": "preprod.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "preprod.check-a-teachers-record.education.gov.uk"
+  "check_domain": "preprod.check-a-teachers-record.education.gov.uk",
+  "evidence_storage_account_name": "s165d01aytqevidencepp"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -18,6 +18,8 @@
   ],
   "domain": "access-your-teaching-qualifications.education.gov.uk",
   "check_domain": "check-a-teachers-record.education.gov.uk",
+  "allegations_storage_account_name": "s165p01aytqevidencepd",
+  "evidence_container_retention_in_days": 30,
   "statuscake_alerts": {
     "access_your_teaching_qualifications_prod": {
       "website_name": "access-your-teaching-qualifications.education.gov.uk",

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -7,5 +7,6 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",
   "domain": "test.access-your-teaching-qualifications.education.gov.uk",
-  "check_domain": "test.check-a-teachers-record.education.gov.uk"
+  "check_domain": "test.check-a-teachers-record.education.gov.uk",
+  "evidence_storage_account_name": "s165d01aytqevidencets"
 }


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
We're building an account page in AYTQ where users can submit requests
to update their name and date of birth in the Teacher Record Service.
This requires accompanying evidence.
### Changes proposed in this pull request
These code changes set up the storage accounts on Azure where we'll
keep the uploaded evidence.

Based on https://github.com/DFE-Digital/refer-serious-misconduct/pull/147
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/TAjAbdH5/35-change-name-page
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
