### PR TITLE
Add new status tags

### DIFF
--- a/app/components/check_records/teacher_profile_summary_component.html.erb
+++ b/app/components/check_records/teacher_profile_summary_component.html.erb
@@ -8,7 +8,7 @@
       <% tags.each do |tag| %>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
           <dt class="govuk-summary-list__key govuk-!-width-full">
-          <strong class="govuk-tag govuk-tag--green"><%= tag %></strong>
+          <strong class="govuk-tag govuk-tag--<%=tag[:colour]%>"><%= tag[:message] %></strong>
           </dt>
         </div>
       <% end %>

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -13,25 +13,53 @@ class CheckRecords::TeacherProfileSummaryComponent < ViewComponent::Base
   end
 
   def build_tags
-    if teacher.qts_awarded?
-      tags.append "QTS"
-    end
-
-    if teacher.passed_induction?
-      tags.append "Passed induction"
-    end
-
-    if no_restrictions?
-      tags.append "No restrictions"
-    end
+    append_restriction_tag
+    append_teaching_status_tag
+    append_induction_tag
   end
 
   private
+
+  def append_restriction_tag
+    tags << if no_restrictions?
+      { message: 'No restrictions', colour: 'green'}
+    elsif possible_restriction?
+      { message: 'Possible restrictions', colour: 'blue'}
+    else
+      { message: 'Restriction', colour: 'red'}
+    end
+  end
+
+  def append_teaching_status_tag
+    tags << if teacher.qts_awarded?
+      { message: 'QTS', colour: 'green'}
+    elsif teacher.eyts_awarded?
+      { message: 'EYTS', colour: 'green'}
+    elsif teacher.eyps_awarded?
+      { message: 'EYPS', colour: 'green'}
+    else
+      { message: 'No QTS or EYTS', colour: 'blue'}
+    end
+  end
+
+  def append_induction_tag
+    tags << if teacher.passed_induction?
+      { message: 'Passed induction', colour: 'green'}
+    elsif teacher.exempt_from_induction?
+      { message: 'Exempt from induction', colour: 'green'}
+    else
+      { message: 'No induction', colour: 'blue'}
+    end
+  end
 
   def no_restrictions?
     return true if sanctions.blank?
     return false if sanctions.any?(&:possible_match_on_childrens_barred_list?)
     return true if sanctions.all?(&:guilty_but_not_prohibited?)
     false
+  end
+
+  def possible_restriction?
+    true if sanctions.any?(&:possible_match_on_childrens_barred_list?)
   end
 end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -47,8 +47,20 @@ module QualificationsApi
       api_data.qts&.awarded.present?
     end
 
+    def eyts_awarded?
+      api_data.eyts&.awarded.present?
+    end
+
+    def eyps_awarded?
+      api_data.eyps&.awarded.present?
+    end
+
     def passed_induction?
       api_data.induction&.status_description == "Pass"
+    end
+
+    def exempt_from_induction?
+      api_data.induction&.status == "Exempt"
     end
 
     private

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -6,113 +6,205 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component do
   let(:teacher) { QualificationsApi::Teacher.new({}) }
 
   describe "rendering" do
-    context "teacher#qts_awarded? is true" do
-      before { allow(teacher).to receive(:qts_awarded?).and_return(true) }
+    describe "teaching statuses" do
+      context "teacher#qts_awarded? is true" do
+        before { allow(teacher).to receive(:qts_awarded?).and_return(true) }
 
-      it "adds the QTS tag" do
-        render_inline described_class.new(teacher)
+        it "adds the QTS tag" do
+          render_inline described_class.new(teacher)
 
-        expect(page).to have_text("QTS")
+          expect(page).to have_text("QTS")
+        end
+      end
+
+      context "teacher#qts_awarded? is false" do
+        before { allow(teacher).to receive(:qts_awarded?).and_return(false) }
+
+        it "does not add the QTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No QTS or EYTS")
+        end
+      end
+
+      context "teacher#eyts_awarded? is true" do
+        before { allow(teacher).to receive(:eyts_awarded?).and_return(true) }
+
+        it "adds the EYTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("EYTS")
+        end
+      end
+
+      context "teacher#eyts_awarded? is false" do
+        before { allow(teacher).to receive(:eyts_awarded?).and_return(false) }
+
+        it "does not add the EYTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No QTS or EYTS")
+        end
+      end
+
+      context "teacher#eyps_awarded? is true" do
+        before { allow(teacher).to receive(:eyps_awarded?).and_return(true) }
+
+        it "adds the QTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("EYPS")
+        end
+      end
+
+      context "teacher#eyps_awarded? is false" do
+        before { allow(teacher).to receive(:eyps_awarded?).and_return(false) }
+
+        it "does not add the QTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).not_to have_text("EYPS")
+        end
+      end
+
+      context "no qts or etys" do
+        before { allow(teacher).to receive(:eyts_awarded?).and_return(false) }
+        before { allow(teacher).to receive(:eyps_awarded?).and_return(false) }
+        before { allow(teacher).to receive(:qts_awarded?).and_return(false) }
+
+
+        it "adds the No QTS or EYTS tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No QTS or EYTS")
+        end
       end
     end
 
-    context "teacher#qts_awarded? is false" do
-      before { allow(teacher).to receive(:qts_awarded?).and_return(false) }
+    describe 'induction statuses' do
 
-      it "does not add the QTS tag" do
-        render_inline described_class.new(teacher)
+      context "teacher#passed_induction? is true" do
+        before { allow(teacher).to receive(:passed_induction?).and_return(true) }
 
-        expect(page).not_to have_text("QTS")
+        it "adds the Passed induction tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("Passed induction")
+        end
+      end
+
+      context "teacher#passed_induction? is false" do
+        before { allow(teacher).to receive(:passed_induction?).and_return(false) }
+
+        it "does not add the Passed induction tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).not_to have_text("Passed induction")
+        end
+      end
+
+      context "teacher#exempt_from_induction? is true" do
+        before { allow(teacher).to receive(:exempt_from_induction?).and_return(true) }
+
+        it "adds the Passed induction tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("Exempt from induction")
+        end
+      end
+
+      context "teacher#exempt_from_induction? is false" do
+        before { allow(teacher).to receive(:exempt_from_induction?).and_return(false) }
+
+        it "does not add the Passed induction tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).not_to have_text("Exempt from induction")
+        end
+      end
+
+      context "teacher#exempt_from_induction? and teacher#passed_induction? is false" do
+        before { allow(teacher).to receive(:exempt_from_induction?).and_return(false) }
+        before { allow(teacher).to receive(:passed_induction?).and_return(false) }
+
+        it "does not add the Passed induction tag" do
+          render_inline described_class.new(teacher)
+
+          expect(page).to have_text("No induction")
+        end
       end
     end
 
-    context "teacher#passed_induction? is true" do
-      before { allow(teacher).to receive(:passed_induction?).and_return(true) }
+    describe 'restrictions statuses' do
+      describe "No restrictions tag" do
+        context "teacher#sanctions is blank" do
+          before { allow(teacher).to receive(:sanctions).and_return nil }
 
-      it "adds the Passed induction tag" do
-        render_inline described_class.new(teacher)
+          it "adds the No restrictions tag" do
+            render_inline described_class.new(teacher)
 
-        expect(page).to have_text("Passed induction")
-      end
-    end
-
-    context "teacher#passed_induction? is false" do
-      before { allow(teacher).to receive(:passed_induction?).and_return(false) }
-
-      it "does not add the Passed induction tag" do
-        render_inline described_class.new(teacher)
-
-        expect(page).not_to have_text("Passed induction")
-      end
-    end
-
-    describe "No restrictions tag" do
-      context "teacher#sanctions is blank" do
-        before { allow(teacher).to receive(:sanctions).and_return nil }
-
-        it "adds the No restrictions tag" do
-          render_inline described_class.new(teacher)
-
-          expect(page).to have_text("No restrictions")
-        end
-      end
-
-      context "teacher#sanctions returns a possible match on the childrens barred list " do
-        before do
-          allow(teacher).to receive(:sanctions).and_return(
-            [
-              instance_double(Sanction, possible_match_on_childrens_barred_list?: true),
-              instance_double(Sanction, possible_match_on_childrens_barred_list?: false)
-            ]
-          )
+            expect(page).to have_text("No restrictions")
+          end
         end
 
-        it "does not add the No restrictions tag" do
-          render_inline described_class.new(teacher)
+        context "teacher#sanctions returns a possible match on the childrens barred list " do
+          before do
+            allow(teacher).to receive(:sanctions).and_return(
+              [
+                instance_double(Sanction, possible_match_on_childrens_barred_list?: true),
+                instance_double(Sanction, possible_match_on_childrens_barred_list?: false)
+              ]
+            )
+          end
 
-          expect(page).not_to have_text("No restrictions")
-        end
-      end
+          it "does not add the No restrictions tag" do
+            render_inline described_class.new(teacher)
 
-      context "teacher#sanctions returns guilty but not prohibited sanctions only" do
-        before do
-          allow(teacher).to receive(:sanctions).and_return(
-            [
-              instance_double(
-                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
-              ),
-              instance_double(
-                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
-              )
-            ]
-          )
+            expect(page).not_to have_text("No restrictions")
+            expect(page).to have_text("Possible restriction")
+          end
         end
 
-        it "adds the No restrictions tag" do
-          render_inline described_class.new(teacher)
+        context "teacher#sanctions returns guilty but not prohibited sanctions only" do
+          before do
+            allow(teacher).to receive(:sanctions).and_return(
+              [
+                instance_double(
+                  Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+                ),
+                instance_double(
+                  Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+                )
+              ]
+            )
+          end
 
-          expect(page).to have_text("No restrictions")
+          it "adds the No restrictions tag" do
+            render_inline described_class.new(teacher)
+
+            expect(page).to have_text("No restrictions")
+          end
         end
-      end
 
-      context "teacher#sanctions returns any other kind of sanction" do
-        before do
-          allow(teacher).to receive(:sanctions).and_return(
-            [
-              instance_double(
-                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
-              ),
-              instance_double(
-                Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: false
-              )
-            ]
-          )
-        end
+        context "teacher#sanctions returns any other kind of sanction" do
+          before do
+            allow(teacher).to receive(:sanctions).and_return(
+              [
+                instance_double(
+                  Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: true
+                ),
+                instance_double(
+                  Sanction, possible_match_on_childrens_barred_list?: false, guilty_but_not_prohibited?: false
+                )
+              ]
+            )
+          end
 
-        it "does not add the No restrictions tag" do
-          render_inline described_class.new(teacher)
+          it "does not add the No restrictions tag" do
+            render_inline described_class.new(teacher)
 
-          expect(page).not_to have_text("No restrictions")
+            expect(page).not_to have_text("No restrictions")
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
Add new status tags with colouring to the profile summary component.

<!-- Why are you making this change? -->
To add at a glance summary of the state of a teachers qualificaitions.


### Link to Trello card

https://trello.com/c/igK7ijRt/48-dev-summary-tags-in-ctr
### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
