### PR TITLE
Add request date of birth change to One Login account page

### DIFF
--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -1,0 +1,41 @@
+module Qualifications
+  module OneLoginUsers
+    class DateOfBirthChangesController < QualificationsInterfaceController
+      DOB_CONVERSION = {
+        "date_of_birth(3i)" => "day",
+        "date_of_birth(2i)" => "month",
+        "date_of_birth(1i)" => "year",
+      }.freeze
+
+      before_action :redirect_to_root_unless_one_login_enabled
+
+      def new
+        @date_of_birth_change_form = DateOfBirthChangeForm.new
+      end
+
+      def create
+        @date_of_birth_change_form = DateOfBirthChangeForm.new(date_of_birth_change_form_params)
+        date_of_birth_change = @date_of_birth_change_form.save
+
+        if date_of_birth_change
+          redirect_to qualifications_one_login_user_date_of_birth_change_path(date_of_birth_change)
+        else
+          render :new
+        end
+      end
+
+      private
+
+      def date_of_birth_change_form_params
+
+        params
+          .require(:qualifications_one_login_users_date_of_birth_change_form)
+          .permit(:evidence, *DOB_CONVERSION.keys)
+          .merge(user: current_user)
+          .transform_keys do |key|
+            DOB_CONVERSION.keys.include?(key) ? DOB_CONVERSION[key] : key
+          end
+      end
+    end
+  end
+end

--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -24,6 +24,10 @@ module Qualifications
         end
       end
 
+      def show
+        @date_of_birth_change = current_user.date_of_birth_changes.find(params[:id])
+      end
+
       private
 
       def date_of_birth_change_form_params

--- a/app/controllers/qualifications/one_login_users/name_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/name_changes_controller.rb
@@ -1,6 +1,8 @@
 module Qualifications
   module OneLoginUsers
     class NameChangesController < QualificationsInterfaceController
+      before_action :redirect_to_root_unless_one_login_enabled
+
       def new
         @name_change_form = NameChangeForm.new
       end

--- a/app/controllers/qualifications/one_login_users_controller.rb
+++ b/app/controllers/qualifications/one_login_users_controller.rb
@@ -7,13 +7,5 @@ module Qualifications
       client = QualificationsApi::Client.new(token: session[user_token_session_key])
       @teacher = client.teacher
     end
-
-    private
-
-    def redirect_to_root_unless_one_login_enabled
-      unless FeatureFlags::FeatureFlag.active?(:one_login)
-        redirect_to qualifications_root_path
-      end
-    end
   end
 end

--- a/app/controllers/qualifications/qualifications_interface_controller.rb
+++ b/app/controllers/qualifications/qualifications_interface_controller.rb
@@ -71,5 +71,11 @@ module Qualifications
         ActiveStorage::Current.url_options = { host: 'localhost', port: 3000, protocol: 'http' }
       end
     end
+
+    def redirect_to_root_unless_one_login_enabled
+      unless FeatureFlags::FeatureFlag.active?(:one_login)
+        redirect_to qualifications_root_path
+      end
+    end
   end
 end

--- a/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
+++ b/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
@@ -1,0 +1,45 @@
+module Qualifications
+  module OneLoginUsers
+    class DateOfBirthChangeForm
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :day, :month, :year, :evidence, :user
+
+      validate do |search|
+        DayMonthYearValidator.new.validate(search, :date_of_birth)
+      end
+
+      validates :evidence, presence: true
+      validate :validate_file_size
+      validate :validate_content_type
+
+      def date_of_birth
+        Date.new(year.to_i, month.to_i, day.to_i)
+      rescue StandardError
+        InvalidDate.new(day:, month:, year:)
+      end
+
+      def save
+        return false unless valid?
+      end
+
+      private
+
+      def validate_file_size
+        max_size = 3.megabytes
+        if evidence && evidence.size > max_size
+          errors.add(:evidence, "The selected file must be smaller than 3MB")
+        end
+      end
+
+      def validate_content_type
+        allowed_types = ["image/jpeg", "image/png", "application/pdf"]
+        if evidence && !allowed_types.include?(evidence.content_type)
+          errors.add(:evidence, "The selected file must be an image or a PDF")
+        end
+      end
+    end
+  end
+end
+

--- a/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
+++ b/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
@@ -14,10 +14,14 @@ module Qualifications
       validate :validate_file_size
       validate :validate_content_type
 
-      def date_of_birth
-        Date.new(year.to_i, month.to_i, day.to_i)
-      rescue StandardError
-        InvalidDate.new(day:, month:, year:)
+      def self.initialize_with(date_of_birth_change:)
+        new(
+          day: date_of_birth_change.date_of_birth.day,
+          month: date_of_birth_change.date_of_birth.month,
+          year: date_of_birth_change.date_of_birth.year,
+          evidence: date_of_birth_change.evidence,
+          user: date_of_birth_change.user,
+        )
       end
 
       def save
@@ -26,6 +30,22 @@ module Qualifications
         date_of_birth_change = user.date_of_birth_changes.create!(date_of_birth:)
         date_of_birth_change.evidence.attach evidence
         date_of_birth_change
+      end
+
+      def update(date_of_birth_change)
+        return false unless valid?
+
+        date_of_birth_change.update!(
+          date_of_birth:
+        )
+        date_of_birth_change.evidence.attach evidence
+        date_of_birth_change
+      end
+
+      def date_of_birth
+        Date.new(year.to_i, month.to_i, day.to_i)
+      rescue StandardError
+        InvalidDate.new(day:, month:, year:)
       end
 
       private

--- a/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
+++ b/app/forms/qualifications/one_login_users/date_of_birth_change_form.rb
@@ -22,6 +22,10 @@ module Qualifications
 
       def save
         return false unless valid?
+
+        date_of_birth_change = user.date_of_birth_changes.create!(date_of_birth:)
+        date_of_birth_change.evidence.attach evidence
+        date_of_birth_change
       end
 
       private

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -37,6 +37,29 @@ module QualificationsApi
       response.body.fetch "caseNumber"
     end
 
+    def send_date_of_birth_change(date_of_birth_change:)
+      client.headers["X-Api-Version"] = "20240416"
+      endpoint = "v3/teacher/date-of-birth-changes"
+
+      body = {
+        email: date_of_birth_change.user.email,
+        dateOfBirth: date_of_birth_change.date_of_birth.to_s,
+        evidenceFileName: date_of_birth_change.evidence_filename,
+        evidenceFileUrl: date_of_birth_change.expiring_evidence_url,
+      }.to_json
+
+      response = client.post(endpoint) do |req|
+        req.body = body
+      end
+
+      # TODO: the client has no API version set by default. Consider setting
+      # a default version for all requests handled by this client, updating the
+      # FakeQualificationsApi and any tests if required.
+      client.headers["X-Api-Version"] = nil
+
+      response.body.fetch "caseNumber"
+    end
+
     def certificate(name:, type:, url:)
       unless valid_certificate_path?(url)
         raise QualificationsApi::InvalidCertificateUrlError

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -67,6 +67,10 @@ module QualificationsApi
       api_data.pending_name_change == true
     end
 
+    def pending_date_of_birth_change?
+      api_data.pending_date_of_birth_change == true
+    end
+
     private
 
     def add_qts

--- a/app/models/date_of_birth_change.rb
+++ b/app/models/date_of_birth_change.rb
@@ -1,4 +1,10 @@
 class DateOfBirthChange < ApplicationRecord
   belongs_to :user
   has_one_attached :evidence
+
+  delegate :filename, to: :evidence, prefix: true
+
+  def expiring_evidence_url
+    evidence.url(expires_in: 5.minutes.in_seconds)
+  end
 end

--- a/app/models/date_of_birth_change.rb
+++ b/app/models/date_of_birth_change.rb
@@ -1,0 +1,4 @@
+class DateOfBirthChange < ApplicationRecord
+  belongs_to :user
+  has_one_attached :evidence
+end

--- a/app/models/invalid_date.rb
+++ b/app/models/invalid_date.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# The InvalidDate class is an ActiveModel model used for situations when
+# the date provided is not valid. This date is passed to the view so it is
+# rendered as a normal date via the attribues: `day`, `month` and `year`.
+#
+class InvalidDate
+  include ActiveModel::Model
+
+  attr_accessor :day, :month, :year
+
+  def blank?
+    [day, month, year].any?(&:blank?)
+  end
+
+  def present?
+    false
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   encrypts :family_name, :given_name, :name
 
   has_many :name_changes
+  has_many :date_of_birth_changes
 
   def self.from_auth(auth_data)
     email = auth_data.info.email

--- a/app/validators/day_month_year_validator.rb
+++ b/app/validators/day_month_year_validator.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class DayMonthYearValidator
+  attr_accessor :attribute, :record
+
+  def validate(record, attribute)
+    self.attribute = attribute
+    self.record = record
+
+    validate_date_parts_presence
+
+    unless valid?
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    record.errors.add(attribute, :invalid_year) if invalid_year?
+    record.errors.add(attribute, :future) if date.future?
+    record.errors.add(attribute, :over_100) if over_100?
+    record.errors.add(attribute, :under_16) if under_16?
+  end
+
+  private
+
+  def all_present?
+    @record.day.present? && @record.month.present? && @record.year.present?
+  end
+
+  def valid?
+    day = @record.day.to_i
+    month = @record.month.to_i
+    year = @record.year.to_i
+
+    return false unless [day, month, year].all?(&:positive?)
+
+    Date.valid_date?(year, month, day)
+  rescue ArgumentError
+    false
+  end
+
+  def invalid_year?
+    @record.year.length != 4
+  end
+
+  def under_16?
+    date >= 16.years.ago
+  end
+
+  def over_100?
+    date <= 100.years.ago
+  end
+
+  def date
+    @date ||= Date.new(@record.year.to_i, @record.month.to_i, @record.day.to_i)
+  end
+
+  def validate_date_parts_presence
+    if record.day.blank? && record.month.blank?
+      record.errors.add(attribute, :missing_day_and_month)
+      return
+    end
+
+    if record.day.blank? && record.year.blank?
+      record.errors.add(attribute, :missing_day_and_year)
+      return
+    end
+
+    if record.month.blank? && record.year.blank?
+      record.errors.add(attribute, :missing_month_and_year)
+      return
+    end
+
+    if record.day.blank?
+      record.errors.add(attribute, :missing_day) 
+      return
+    end
+
+    if record.month.blank?
+      record.errors.add(attribute, :missing_month)
+      return
+    end
+
+    if record.year.blank?
+      record.errors.add(attribute, :missing_year)
+    end
+  end
+end

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/edit.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "Change your date of birth" %>
+<% content_for :back_link_url, qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Change your date of birth</h1>
+
+    <%= form_with model: @date_of_birth_change_form, url: qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change), method: :patch do |form| %>
+      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: nil %>
+
+      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
+
+      <%= form.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/new.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "Change your date of birth" %>
+<% content_for :back_link_url, qualifications_one_login_user_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Change your date of birth</h1>
+
+    <%= form_with model: @date_of_birth_change_form, url: qualifications_one_login_user_date_of_birth_changes_path, method: :post do |form| %>
+      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: nil %>
+
+      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
+
+      <%= form.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/show.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "Change your date of birth" %>
+<% content_for :back_link_url, edit_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l"> Confirm change </h1>
+
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Date of birth" }
+        row.with_value { @date_of_birth_change.date_of_birth.to_fs(:long_uk) }
+        row.with_action(text: "Change", href: edit_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change), visually_hidden_text: "date_of_birth")
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Evidence" }
+        row.with_value { @date_of_birth_change.evidence.filename.to_s }
+        row.with_action(text: "Change", href: edit_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change), visually_hidden_text: "evidence")
+      end
+    end %>
+
+    <%= govuk_button_to "Continue", confirm_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change), method: :post %>
+  </div>
+</div>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/submitted.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/submitted.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, "Change your date of birth" %>
+<%= govuk_back_link text: "Back to change your teaching qualifications", href: qualifications_one_login_user_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= govuk_panel(title_text: "Date of birth change request submitted") do %>
+      Your reference number
+      <br />
+
+      <strong>
+        <%= @date_of_birth_change.reference_number %>
+      </strong>
+    <% end %>
+
+    <p class="govuk-body">We have sent you a confirmation email.</p>
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">We’ll check the evidence you submitted. We’ll contact you if we need any more information.</p>
+  </div>
+</div>

--- a/app/views/qualifications/one_login_users/show.html.erb
+++ b/app/views/qualifications/one_login_users/show.html.erb
@@ -45,12 +45,16 @@
         Date of birth
         </dt>
         <dd class="govuk-summary-list__value">
-        <p class="govuk-body">_TODO</p>
+        <p class="govuk-body"><%= @teacher.date_of_birth.to_date.to_fs(:long_uk) %></p>
         </dd>
         <dd class="govuk-summary-list__actions">
+        <% if @teacher.pending_date_of_birth_change? %>
+          <%= govuk_tag(text: "In review", colour: "yellow") %>
+        <% else %>
           <ul class="govuk-summary-list__actions-list">
-            <%= govuk_link_to "Change", "#", visually_hidden_text: "Date of birth" %>
+            <%= govuk_link_to "Change", new_qualifications_one_login_user_date_of_birth_change_path, visually_hidden_text: "Name on certificates" %>
           </ul>
+        <% end %>
         </dd>
       </div>
     </dl>
@@ -76,25 +80,25 @@
         end
       %>
 
-      <p class="govuk-body">
-        <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link">Find out how to contact GOV.UK One Login support</a>.
-      </p>
-    <% end %>
-
-    <h2 class="govuk-heading-m">
-      GOV.UK One Login security details
-    </h2>
-
-    <p class="govuk-body">You can change these details for your GOV.UK One Login:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>email address</li>
-      <li>password</li>
-      <li>how you get security codes to sign in</li>
-    </ul>
-
     <p class="govuk-body">
-      <a href="https://home.account.gov.uk" class="govuk-link">Change your GOV.UK One login security details</a>.
+      <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link">Find out how to contact GOV.UK One Login support</a>.
     </p>
+  <% end %>
+
+  <h2 class="govuk-heading-m">
+    GOV.UK One Login security details
+  </h2>
+
+  <p class="govuk-body">You can change these details for your GOV.UK One Login:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>email address</li>
+    <li>password</li>
+    <li>how you get security codes to sign in</li>
+  </ul>
+
+  <p class="govuk-body">
+    <a href="https://home.account.gov.uk" class="govuk-link">Change your GOV.UK One login security details</a>.
+  </p>
   </div>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -21,6 +21,12 @@ shared:
     - record_id
     - blob_id
     - created_at
+  :date_of_birth_changes:
+    - id
+    - user_id
+    - date_of_birth
+    - created_at
+    - updated_at
   :dsi_users:
     - id
     - email

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -27,6 +27,7 @@ shared:
     - date_of_birth
     - created_at
     - updated_at
+    - reference_number
   :dsi_users:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -4,6 +4,8 @@
     - filename
   :active_storage_attachments:
     - name
+  :date_of_birth_changes:
+    - date_of_birth
   :dsi_users:
     - email
     - first_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,8 @@ en:
               missing_month_and_year: Date of birth must include a month and year
               over_100: Date of birth cannot be more than 100 years ago
               under_16: Date of birth must be at least 16 years ago
+            evidence:
+              blank: Select a file
 
   activerecord:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,21 @@ en:
               too_long: Last name must be 100 characters or less
             evidence:
               blank: Select a file
+        qualifications/one_login_users/date_of_birth_change_form:
+          attributes:
+            date_of_birth:
+              blank: Enter a date of birth
+              future: Date of birth must be in the past
+              invalid: Date of birth must be a real date
+              invalid_year: Year must include 4 numbers
+              missing_day: Date of birth must include a day
+              missing_month: Date of birth must include a month
+              missing_year: Date of birth must include a year
+              missing_day_and_month: Date of birth must include a day and month
+              missing_day_and_year: Date of birth must include a day and year
+              missing_month_and_year: Date of birth must include a month and year
+              over_100: Date of birth cannot be more than 100 years ago
+              under_16: Date of birth must be at least 16 years ago
 
   activerecord:
     errors:

--- a/config/routes/aytq.rb
+++ b/config/routes/aytq.rb
@@ -25,6 +25,14 @@ namespace :qualifications do
       post "/confirm", on: :member, to: "name_changes#confirm"
       get "/submitted", on: :member, to: "name_changes#submitted"
     end
+
+    resources :date_of_birth_changes,
+      only: [:new, :create, :show, :edit, :update],
+      path: "date-of-birth-changes",
+      module: "one_login_users" do
+      post "/confirm", on: :member, to: "date_of_birth_changes#confirm"
+      get "/submitted", on: :member, to: "date_of_birth_changes#submitted"
+    end
   end
   resource :npq_certificate, only: [:show]
 

--- a/db/migrate/20240516142128_create_date_of_birth_changes.rb
+++ b/db/migrate/20240516142128_create_date_of_birth_changes.rb
@@ -1,0 +1,10 @@
+class CreateDateOfBirthChanges < ActiveRecord::Migration[7.1]
+  def change
+    create_table :date_of_birth_changes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :date_of_birth
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240516172408_add_reference_number_to_date_of_birth_change.rb
+++ b/db/migrate/20240516172408_add_reference_number_to_date_of_birth_change.rb
@@ -1,0 +1,5 @@
+class AddReferenceNumberToDateOfBirthChange < ActiveRecord::Migration[7.1]
+  def change
+    add_column :date_of_birth_changes, :reference_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_13_122026) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_16_142128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_122026) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "date_of_birth_changes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "date_of_birth"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_date_of_birth_changes_on_user_id"
   end
 
   create_table "dsi_user_sessions", force: :cascade do |t|
@@ -186,5 +194,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_122026) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "date_of_birth_changes", "users"
   add_foreign_key "search_logs", "dsi_users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_142128) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_16_172408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,6 +95,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_142128) do
     t.date "date_of_birth"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "reference_number"
     t.index ["user_id"], name: "index_date_of_birth_changes_on_user_id"
   end
 

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -336,4 +336,44 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
     end
   end
+
+  describe "#pending_name_change?" do
+    let(:teacher) { described_class.new(api_data) }
+
+    context "pendingNameChange field is false" do
+      let(:api_data) { { "pendingNameChange" => false } }
+
+      it "returns false" do
+        expect(teacher.pending_name_change?).to eq false
+      end
+    end
+
+    context "pendingNameChange field is true" do
+      let(:api_data) { { "pendingNameChange" => true } }
+
+      it "returns true" do
+        expect(teacher.pending_name_change?).to eq true
+      end
+    end
+  end
+
+  describe "#pending_date_of_birth_change?" do
+    let(:teacher) { described_class.new(api_data) }
+
+    context "pendingDateOfBirthChange field is false" do
+      let(:api_data) { { "pendingDateOfBirthChange" => false } }
+
+      it "returns false" do
+        expect(teacher.pending_date_of_birth_change?).to eq false
+      end
+    end
+
+    context "pendingDateOfBirthChange field is true" do
+      let(:api_data) { { "pendingDateOfBirthChange" => true } }
+
+      it "returns true" do
+        expect(teacher.pending_date_of_birth_change?).to eq true
+      end
+    end
+  end
 end

--- a/spec/models/date_of_birth_change_spec.rb
+++ b/spec/models/date_of_birth_change_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe DateOfBirthChange, type: :model do
+end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -89,6 +89,12 @@ class FakeQualificationsApi < Sinatra::Base
     { caseNumber: "CASE-TEST-123" }.to_json
   end
 
+  post "/v3/teacher/date-of-birth-changes" do
+    content_type :json
+
+    { caseNumber: "CASE-TEST-123" }.to_json
+  end
+
   private
 
   def teacher_data(sanctions: false, trn: "1234567")

--- a/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
@@ -16,9 +16,9 @@ RSpec.feature "Account page", type: :system do
     when_i_submit_the_form
     then_i_see_validation_errors
 
-    # when_i_complete_the_form
-    # and_i_submit_the_form
-    # then_i_see_the_confirmation_page
+    when_i_complete_the_form
+    and_i_submit_the_form
+    then_i_see_the_confirmation_page
 
     # when_i_edit_the_date_of_birth
     # and_i_submit_the_form
@@ -58,5 +58,19 @@ RSpec.feature "Account page", type: :system do
   def then_i_see_validation_errors
     expect(page).to have_content "Date of birth must include a day and month"
     expect(page).to have_content "Select a file"
+  end
+
+  def when_i_complete_the_form
+    fill_in("Day", with: 5)
+    fill_in("Month", with: 12)
+    fill_in("Year", with: 1990)
+
+    attach_file "Upload evidence", Rails.root.join("spec/fixtures/test-upload.pdf")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content "Confirm change"
+    expect(page).to have_content "5 December 1990"
+    expect(page).to have_content "test-upload.pdf"
   end
 end

--- a/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
@@ -20,12 +20,12 @@ RSpec.feature "Account page", type: :system do
     and_i_submit_the_form
     then_i_see_the_confirmation_page
 
-    # when_i_edit_the_date_of_birth
-    # and_i_submit_the_form
-    # and_i_confirm_my_changes
+    when_i_edit_the_date_of_birth
+    and_i_submit_the_form
+    and_i_confirm_my_changes
 
-    # then_my_request_is_submitted
-    # and_my_evidence_is_uploaded
+    then_my_request_is_submitted
+    and_my_evidence_is_uploaded
   end
 
   private
@@ -72,5 +72,28 @@ RSpec.feature "Account page", type: :system do
     expect(page).to have_content "Confirm change"
     expect(page).to have_content "5 December 1990"
     expect(page).to have_content "test-upload.pdf"
+  end
+
+  def when_i_edit_the_date_of_birth
+    change_links = all('a', text: 'Change')
+    change_links[0].click
+    fill_in "Month", with: 3
+
+    attach_file "Upload evidence", Rails.root.join("spec/fixtures/test-upload.pdf")
+  end
+
+  def and_i_confirm_my_changes
+    click_button "Continue"
+  end
+
+  def then_my_request_is_submitted
+    expect(page).to have_content "Date of birth change request submitted"
+    expect(page).to have_content "CASE-TEST-123"
+    expect(DateOfBirthChange.last.date_of_birth.to_s).to eq "1990-03-05"
+    expect(DateOfBirthChange.last.reference_number).to eq "CASE-TEST-123"
+  end
+
+  def and_my_evidence_is_uploaded
+    expect(DateOfBirthChange.last.evidence.attached?).to be true
   end
 end

--- a/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Account page", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  scenario "User submits a request to change date of birth", test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    given_i_am_signed_in_via_one_login
+    when_i_click_through_to_update_my_details
+
+    and_click_change_date_of_birth
+    then_i_am_on_the_date_of_birth_change_form
+
+    when_i_submit_the_form
+    then_i_see_validation_errors
+
+    # when_i_complete_the_form
+    # and_i_submit_the_form
+    # then_i_see_the_confirmation_page
+
+    # when_i_edit_the_date_of_birth
+    # and_i_submit_the_form
+    # and_i_confirm_my_changes
+
+    # then_my_request_is_submitted
+    # and_my_evidence_is_uploaded
+  end
+
+  private
+
+  def given_i_am_signed_in_via_one_login
+    given_onelogin_authentication_is_active
+    and_onelogin_auth_is_mocked
+    when_i_go_to_the_sign_in_page
+    and_click_the_onelogin_sign_in_button
+  end
+
+  def when_i_click_through_to_update_my_details
+    click_link "View and update details"
+  end
+
+  def and_click_change_date_of_birth
+    change_links = all('a', text: 'Change')
+    change_links[1].click
+  end
+
+  def then_i_am_on_the_date_of_birth_change_form
+    expect(page).to have_content "Change your date of birth"
+  end
+
+  def when_i_submit_the_form
+    click_button "Continue"
+  end
+  alias_method :and_i_submit_the_form, :when_i_submit_the_form
+
+  def then_i_see_validation_errors
+    expect(page).to have_content "Date of birth must include a day and month"
+    expect(page).to have_content "Select a file"
+  end
+end

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -1,0 +1,190 @@
+require "rails_helper"
+
+class Validatable
+  include ActiveModel::Model
+  attr_accessor :day, :month, :year, :date_attribute
+
+  validate do |record|
+    DayMonthYearValidator.new.validate(record, :date_attribute)
+  end
+end
+
+RSpec.describe DayMonthYearValidator do
+  # We don't have translations for our Validatable test class
+  # avoid I18n::MissingTranslationData exceptions by turning off
+  # I18n.exception_handler for this particular spec.
+  around do |example|
+    exception_handler = I18n.exception_handler
+    I18n.exception_handler = nil
+    example.run
+    I18n.exception_handler = exception_handler
+  end
+
+  subject(:validatable) { Validatable.new(attributes) }
+
+  describe "#validate" do
+    context "when the date is valid" do
+      let(:attributes) { { day: "15", month: "6", year: "1990" } }
+
+      it "passes validation" do
+        validatable.valid?
+
+        expect(validatable).to be_valid
+      end
+    end
+
+    context "when the day is invalid" do
+      let(:attributes) { { day: "32", month: "6", year: "1990" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute]).to include("is invalid")
+      end
+    end
+
+    context "when the month is invalid" do
+      let(:attributes) { { day: "15", month: "60", year: "1990" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute]).to include("is invalid")
+      end
+    end
+
+    context "when the date is negative" do
+      let(:attributes) { { day: -1, month: "6", year: "1990" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute]).to include("is invalid")
+      end
+    end
+
+    context "when the year does not have 4 numbers" do
+      let(:attributes) { { day: "15", month: "6", year: "90" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("invalid_year")
+      end
+    end
+
+    context "when the date is in the future" do
+      let(:attributes) { { day: "15", month: "6", year: 1.year.from_now.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("future")
+      end
+    end
+
+    context "when the date less than 16 years ago" do
+      let(:attributes) { { day: "15", month: "6", year: 15.years.ago.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("under_16")
+      end
+    end
+
+    context "when the date more than 100 years ago" do
+      let(:attributes) { { day: "15", month: "6", year: 101.years.ago.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("over_100")
+      end
+    end
+
+    context "when day is missing" do
+      let(:attributes) { { day: nil, month: "6", year: "1990" } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day")
+      end
+    end
+
+    context "when month is missing" do
+      let(:attributes) { { day: "15", month: nil, year: "1990" } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_month")
+      end
+    end
+
+    context "when year is missing" do
+      let(:attributes) { { day: "15", month: "6", year: nil } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_year")
+      end
+    end
+
+    context "when day and month are missing" do
+      let(:attributes) { { day: nil, month: nil, year: "1990" } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day_and_month")
+      end
+    end
+
+    context "when day and year are missing" do
+      let(:attributes) { { day: nil, month: "6", year: nil } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day_and_year")
+      end
+    end
+
+    context "when month and year are missing" do
+      let(:attributes) { { day: "15", month: nil, year: nil } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_month_and_year")
+      end
+    end
+  end
+end


### PR DESCRIPTION

### Context
<!-- Why are you making this change? -->
The AYTQ account page allows users to submit a request to change their DOB, along with supporting evidence.
### Changes proposed in this pull request

A form that accepts DOB change details including an evidence upload.

PR contains complete workflow and all config changes to persist files to Azure Blob Storage via ActiveStorage.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Per-commit review highly recommended.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/G7R2eYEO/37-change-dob-page
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
