### PR TITLE
Add guard condition to prevent accessing show page without params

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -7,6 +7,13 @@ module CheckRecords
     end
 
     def show
+      unless params["search"] &&
+        params["search"].key?("date_of_birth(1i)") &&
+        params["search"].key?("date_of_birth(2i)") &&
+        params["search"].key?("date_of_birth(3i)")
+        redirect_to check_records_search_path, notice: "Please enter a date of birth"
+        return
+      end
       date_of_birth = [
         params["search"]["date_of_birth(1i)"],
         params["search"]["date_of_birth(2i)"],


### PR DESCRIPTION
### Context

Sometimes a user makes it to the show page without having date of birth params accessible. This should be prevented as it throws an unspecified error. A redirection to the search page with a notice cleanly fixes this case.

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
(https://trello.com/c/Ro3rrutT/68-fix-search-params-bug-in-ctr)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
