### PR TITLE
Correct prod workspace variable in terraform

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -18,7 +18,7 @@
   ],
   "domain": "access-your-teaching-qualifications.education.gov.uk",
   "check_domain": "check-a-teachers-record.education.gov.uk",
-  "allegations_storage_account_name": "s165p01aytqevidencepd",
+  "evidence_storage_account_name": "s165p01aytqevidencepd",
   "evidence_container_retention_in_days": 30,
   "statuscake_alerts": {
     "access_your_teaching_qualifications_prod": {


### PR DESCRIPTION
The evidence blob storage container is set to the wrong variable name. Correct it.
