### PR TITLE
Update smoke tests

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -65,6 +65,6 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
 
   def then_i_see_the_aytq_service
     expect(page).to have_content "Access your teaching qualifications"
-    expect(page).to have_content "Sign in with DfE Identity"
+    expect(page).to have_content "Sign in"
   end
 end


### PR DESCRIPTION
Remove expectation for DfE Identity content to be on the page, as the service may be configured for One Login instead.
