### PR TITLE
Add accepted evidence types to name/DoB change forms

### DIFF
--- a/app/views/qualifications/one_login_users/date_of_birth_changes/_form.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: nil %>
+
+<h2 class="govuk-heading-s">Upload evidence</h2>
+<%= govuk_details(summary_text: "Documents we accept") do %>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>birth certificate</li>
+    <li>passport</li>
+    <li>driving license</li>
+  </ul>
+<% end %>
+
+<%= form.govuk_file_field :evidence, label: { text: "Upload evidence", hidden: true } %>
+<%= form.govuk_submit "Continue" %>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/edit.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/edit.html.erb
@@ -7,11 +7,7 @@
     <h1 class="govuk-heading-l">Change your date of birth</h1>
 
     <%= form_with model: @date_of_birth_change_form, url: qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change), method: :patch do |form| %>
-      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: nil %>
-
-      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
-
-      <%= form.govuk_submit "Continue" %>
+      <%= render "form", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/new.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/new.html.erb
@@ -7,11 +7,7 @@
     <h1 class="govuk-heading-l">Change your date of birth</h1>
 
     <%= form_with model: @date_of_birth_change_form, url: qualifications_one_login_user_date_of_birth_changes_path, method: :post do |form| %>
-      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: nil %>
-
-      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
-
-      <%= form.govuk_submit "Continue" %>
+      <%= render "form", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/qualifications/one_login_users/name_changes/_form.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form.govuk_text_field :first_name, label: { text: "First name" } %>
+<%= form.govuk_text_field :middle_name, label: { text: "Middle name" }, hint_text: "Optional" %>
+<%= form.govuk_text_field :last_name, label: { text: "Last name" } %>
+
+<h2 class="govuk-heading-s">Upload evidence</h2>
+
+<%= govuk_details(summary_text: "Documents we accept") do %>
+  <ul class="govuk-list govuk-list--bullet">
+    <li> marriage certificate </li>
+    <li> civil partnership certificate </li>
+    <li> decree absolute and birth certificate </li>
+    <li> statutory declaration </li>
+    <li> deed poll </li>
+  </ul>
+<% end %>
+
+<%= form.govuk_file_field :evidence, label: { text: "Upload evidence", hidden: true } %>
+
+<%= form.govuk_submit "Continue" %>

--- a/app/views/qualifications/one_login_users/name_changes/edit.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/edit.html.erb
@@ -7,13 +7,7 @@
     <h1 class="govuk-heading-l">Change your name on teaching certificates</h1>
 
     <%= form_with model: @name_change_form, url: qualifications_one_login_user_name_change_path(@name_change), method: :patch do |form| %>
-      <%= form.govuk_text_field :first_name, label: { text: "First name" } %>
-      <%= form.govuk_text_field :middle_name, label: { text: "Middle name" }, hint_text: "Optional" %>
-      <%= form.govuk_text_field :last_name, label: { text: "Last name" } %>
-
-      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
-
-      <%= form.govuk_submit "Continue" %>
+      <%= render "form", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/qualifications/one_login_users/name_changes/new.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/new.html.erb
@@ -7,13 +7,7 @@
     <h1 class="govuk-heading-l">Change your name on teaching certificates</h1>
 
     <%= form_with model: @name_change_form, url: qualifications_one_login_user_name_changes_path, method: :post do |form| %>
-      <%= form.govuk_text_field :first_name, label: { text: "First name" } %>
-      <%= form.govuk_text_field :middle_name, label: { text: "Middle name" }, hint_text: "Optional" %>
-      <%= form.govuk_text_field :last_name, label: { text: "Last name" } %>
-
-      <%= form.govuk_file_field :evidence, label: { text: "Upload evidence" } %>
-
-      <%= form.govuk_submit "Continue" %>
+      <%= render "form", form: form %>
     <% end %>
   </div>
 </div>

--- a/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_date_of_birth_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Account page", type: :system do
 
     and_click_change_date_of_birth
     then_i_am_on_the_date_of_birth_change_form
+    and_i_can_see_a_list_of_valid_evidence
 
     when_i_submit_the_form
     then_i_see_validation_errors
@@ -48,6 +49,12 @@ RSpec.feature "Account page", type: :system do
 
   def then_i_am_on_the_date_of_birth_change_form
     expect(page).to have_content "Change your date of birth"
+  end
+
+  def and_i_can_see_a_list_of_valid_evidence
+    within(".govuk-details") do
+      expect(page).to have_selector(:css, "li", text: "driving license", visible: :all)
+    end
   end
 
   def when_i_submit_the_form

--- a/spec/system/qualifications/user_submits_a_request_to_change_name_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_name_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Account page", type: :system do
     when_i_click_through_to_update_my_details
     and_click_change_name
     then_i_am_on_the_name_change_form
+    and_i_can_see_a_list_of_valid_evidence
     when_i_submit_the_form
     then_i_see_validation_errors
 
@@ -46,6 +47,12 @@ RSpec.feature "Account page", type: :system do
 
   def then_i_am_on_the_name_change_form
     expect(page).to have_content "Change your name on teaching certificates"
+  end
+
+  def and_i_can_see_a_list_of_valid_evidence
+    within(".govuk-details") do
+      expect(page).to have_selector(:css, "li", text: "deed poll", visible: :all)
+    end
   end
 
   def when_i_submit_the_form


### PR DESCRIPTION

### Context

Missed the "Documents we accept" block during initial build of these features.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
- Refactor name/dob form templates so that new/edit pages render a common partial for form fields
- Add a details block to each listing valid evidence types a user can submit

![Screenshot_20240522_153826](https://github.com/DFE-Digital/access-your-teaching-qualifications/assets/519250/d3240411-2567-427a-8b34-dd11db397316)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
na
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
na
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
