### PR TITLE
Encrypt User#one_login_verified_name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   encrypts :email, deterministic: true
   encrypts :family_name, :given_name, :name
+  encrypts :one_login_verified_name
 
   has_many :name_changes
   has_many :date_of_birth_changes

--- a/db/migrate/20240528122038_clear_one_loging_verified_name_field.rb
+++ b/db/migrate/20240528122038_clear_one_loging_verified_name_field.rb
@@ -1,0 +1,5 @@
+class ClearOneLogingVerifiedNameField < ActiveRecord::Migration[7.1]
+  def change
+    User.update_all(one_login_verified_name: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_172408) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_28_122038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION

### Context
User#one_login_verified_name is PII, so we should encrypt it.


<!-- Why are you making this change? -->

### Changes proposed in this pull request
The One Login feature hasn't been activated in production yet, so we can adopt a fairly simple migration approach:

- Truncate this column in the database
- Specify that this is an encrypted field in the User model

If we don't truncate, attempts to read or update existing User records in the dev/test environment will cause an error (because the field will contain unencrypted data that Rails will try and decrypt). We could configure ActiveRecord Encryption to accept both encrypted and unencrypted data but this seems needlessly obtuse compared to the approach above.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
na
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/iAvx9mCE/85-change-how-we-handle-one-login-verified-fields
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
