### PR TITLE
Add redirect if user submits repeat change request

### DIFF
--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -8,6 +8,7 @@ module Qualifications
       }.freeze
 
       before_action :redirect_to_root_unless_one_login_enabled
+      before_action :redirect_if_change_pending, only: [:create, :update]
 
       def new
         @date_of_birth_change_form = DateOfBirthChangeForm.new
@@ -71,6 +72,16 @@ module Qualifications
 
       def qualifications_api_client
         @qualifications_api_client ||= QualificationsApi::Client.new(token: session[user_token_session_key])
+      end
+
+      def redirect_if_change_pending
+        teacher = qualifications_api_client.teacher
+        if teacher.pending_date_of_birth_change?
+          flash[:warning] =
+            "You have a date of birth change request pending. \
+          Please wait until that is complete before submitting another."
+          redirect_to qualifications_one_login_user_path
+        end
       end
     end
   end

--- a/app/controllers/qualifications/one_login_users/name_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/name_changes_controller.rb
@@ -2,6 +2,7 @@ module Qualifications
   module OneLoginUsers
     class NameChangesController < QualificationsInterfaceController
       before_action :redirect_to_root_unless_one_login_enabled
+      before_action :redirect_if_change_pending, only: [:create, :update]
 
       def new
         @name_change_form = NameChangeForm.new
@@ -60,6 +61,16 @@ module Qualifications
 
       def qualifications_api_client
         @qualifications_api_client ||= QualificationsApi::Client.new(token: session[user_token_session_key])
+      end
+
+      def redirect_if_change_pending
+        teacher = qualifications_api_client.teacher
+        if teacher.pending_name_change?
+          flash[:warning] =
+            "You have a name change request pending. \
+          Please wait until that is complete before submitting another."
+          redirect_to qualifications_one_login_user_path
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

When a user submits a name or date of birth change request, they shouldn't be able to submit another until the pending one has been processed.

We deal with this in the UI by removing the 'change' link on the account page if the user has a change pending. They can still submit a repeat request, however, by hitting the back button after submitting a form and then resubmitting.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
This PR adds a check for the pending state of both name and date of birth changes, redirecting the user back to the account page if appropriate.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Manual testing:

Submit a change request.
Hit the back button.
Resubmit the form.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/1OaL0MRj/111-handling-one-login-name-dob-change-multiple-requests
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
