### PR TITLE
Amend 'GOVUK One Login' to 'GOV.UK One Login'

### DIFF
--- a/app/views/qualifications/users/sign_in/new.html.erb
+++ b/app/views/qualifications/users/sign_in/new.html.erb
@@ -2,11 +2,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sign in to access your teaching qualifications</h1>
     <% if FeatureFlags::FeatureFlag.active?(:one_login) %>
-      <p class="govuk-body">You’ll need a GOVUK One Login account to access your teaching qualifications.</p>
+      <p class="govuk-body">You’ll need a GOV.UK One Login account to access your teaching qualifications.</p>
       <p class="govuk-body">You can create an account if you do not have one already.</p>
       <%=
         govuk_button_to(
-          "Sign in with GOVUK One Login",
+          "Sign in with GOV.UK One Login",
           "/qualifications/users/auth/onelogin",
           method: :post
         )

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -61,6 +61,6 @@ module QualificationAuthenticationSteps
   end
 
   def and_click_the_onelogin_sign_in_button
-    click_button "Sign in with GOVUK One Login"
+    click_button "Sign in with GOV.UK One Login"
   end
 end


### PR DESCRIPTION
### Context

I noticed when testing out the Teacher Auth integration that we're saying 'GOVUK One Login' instead of 'GOV.UK One Login' on the sign in page.

### Changes proposed in this pull request

Amends 'GOVUK' to 'GOV.UK' on the sign in view.

### Guidance to review

View the sign in page with the One Login feature flag enabled.

### Link to Trello card

N/A

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
