### PR TITLE
Refactor navigation code to fix error pages

### DIFF
--- a/app/components/qualifications/navigation_component.html.erb
+++ b/app/components/qualifications/navigation_component.html.erb
@@ -1,0 +1,20 @@
+<%=
+  govuk_header(service_name: t("service.name"), service_url: qualifications_root_path) do |header|
+    if current_user
+      if FeatureFlags::FeatureFlag.active?(:one_login)
+        header.with_navigation_item(
+          active: current_page?(qualifications_identity_user_path),
+          href: qualifications_one_login_user_path,
+          text: "Account"
+        )
+      else
+        header.with_navigation_item(
+          active: current_page?(qualifications_identity_user_path),
+          href: qualifications_identity_user_path,
+          text: "Account"
+        )
+      end
+      header.with_navigation_item(href: qualifications_new_sign_out_path, text: "Sign out")
+    end
+  end
+%>

--- a/app/components/qualifications/navigation_component.rb
+++ b/app/components/qualifications/navigation_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Qualifications::NavigationComponent < ViewComponent::Base
+  attr_accessor :current_user
+
+  def initialize(current_user:)
+    super
+    @current_user = current_user
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,44 +3,34 @@ module ApplicationHelper
     request.path.split("/").second
   end
 
-  def navigation
-    govuk_header(service_name: t("service.name")) do |header|
-      if current_namespace == "qualifications"
-        if current_user
+  # TODO: refactor Support navigation into a component
+  def support_navigation
+    govuk_header(service_name: "AYTQ / CTR Support") do |header|
+      if current_dsi_user.internal?
+        header.with_navigation_item(
+          active: current_page?(main_app.support_interface_feature_flags_path),
+          href: main_app.support_interface_feature_flags_path,
+          text: "Features"
+        )
+        header.with_navigation_item(
+          active: request.path.start_with?("/support/feedback"),
+          text: "Feedback",
+          href: main_app.support_interface_feedback_index_path
+        )
+        if FeatureFlags::FeatureFlag.active?(:manage_roles)
           header.with_navigation_item(
-            active: current_page?(main_app.qualifications_identity_user_path),
-            href: main_app.qualifications_identity_user_path,
-            text: "Account"
-          )
-          header.with_navigation_item(href: main_app.qualifications_new_sign_out_path, text: "Sign out")
-        end
-      else
-        if current_dsi_user.internal?
-          header.with_navigation_item(
-            active: current_page?(main_app.support_interface_feature_flags_path),
-            href: main_app.support_interface_feature_flags_path,
-            text: "Features"
-          )
-          header.with_navigation_item(
-            active: request.path.start_with?("/support/feedback"),
-            text: "Feedback",
-            href: main_app.support_interface_feedback_index_path
-          )
-          if FeatureFlags::FeatureFlag.active?(:manage_roles)
-            header.with_navigation_item(
-              active: request.path.start_with?("/support/roles"),
-              text: "Check role codes",
-              href: main_app.support_interface_roles_path
+            active: request.path.start_with?("/support/roles"),
+            text: "Check role codes",
+            href: main_app.support_interface_roles_path
 
-            )
-          end
-        end
-        if current_dsi_user
-          header.with_navigation_item(
-            href: main_app.check_records_dsi_sign_out_path(id_token_hint: session[:id_token]),
-            text: "Sign out"
           )
         end
+      end
+      if current_dsi_user
+        header.with_navigation_item(
+          href: main_app.check_records_dsi_sign_out_path(id_token_hint: session[:id_token]),
+          text: "Sign out"
+        )
       end
     end
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -25,7 +25,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= navigation %>
+    <%= yield :navigation %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>

--- a/app/views/layouts/qualifications_layout.html.erb
+++ b/app/views/layouts/qualifications_layout.html.erb
@@ -2,6 +2,10 @@
   <%= tag :meta, name: 'robots', content: 'noindex' %>
 <% end %>
 
+<% content_for :navigation do %>
+  <%= render(Qualifications::NavigationComponent.new(current_user: current_user)) %>
+<% end %>
+
 <% content_for :content do %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -2,4 +2,8 @@
   <%= yield %>
 <% end %>
 
+<% content_for :navigation do %>
+  <%= support_navigation %>
+<% end %>
+
 <%= render template: 'layouts/base' %>

--- a/spec/components/qualifications/navigation_component_spec.rb
+++ b/spec/components/qualifications/navigation_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Qualifications::NavigationComponent, type: :component do
+  context "current_user is nil" do
+    it "renders a nav for a signed out user" do
+      render_inline(described_class.new(current_user: nil))
+      expect(page).not_to have_content "Sign out"
+    end
+  end
+
+  context "given a current_user" do
+    let(:user) { instance_double(User) }
+
+    it "renders a Sign Out link" do
+      render_inline(described_class.new(current_user: user))
+      expect(page).to have_link("Sign out", href: path_helpers.qualifications_new_sign_out_path)
+    end
+
+    context "if one_login feature active" do
+      before { FeatureFlags::FeatureFlag.activate(:one_login) }
+
+      it "renders a link to the One Login account page" do
+        render_inline(described_class.new(current_user: user))
+        expect(page).to have_link("Account", href: path_helpers.qualifications_one_login_user_path)
+      end
+    end
+
+    context "if one_login feature flag is not active" do
+      it "renders a link to the Identity account page" do
+        render_inline(described_class.new(current_user: user))
+        expect(page).to have_link("Account", href: path_helpers.qualifications_identity_user_path)
+        expect(page).not_to have_link("Account", href: path_helpers.qualifications_one_login_user_path)
+      end
+    end
+  end
+
+  private
+
+  def path_helpers
+    Rails.application.routes.url_helpers
+  end
+end


### PR DESCRIPTION



### Context
AYTQ 404 pages (and other HTTP error pages) aren't rendering properly because of a bug in the navigation helper. Summary:

- The error pages sit in routes without a service-specific namespace, eg - http://hostname.tld/404
- The navigation helper relies on a 'qualifications' namespace being present to render the AYTQ nav
- If this isn't present, the helper attempts to render the support nav instead
- This fails because there isn't a valid dsi_user signed in (but even if there was this would be the wrong thing to do regardless)

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Fix this by doing the following:

- Extract a Qualifications::NavigationComponent out of the navigation helper method
- Update the base layout to allow the navigation to be specified in a content_for block
- Have the AYTQ layout use the new nav component, while the Support layout continues to use the helper method

This leaves us in the following state:

- AYTQ uses its own navigation component, removing the logical check and thus fixing the bug described above.
- CTR remains unchanged as it was using its own nav component already.
- Support renders its nav with a renamed helper method, although this should probably be extracted into a component at some point as well.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested locally by simply navigating to AYTQ, Check, and Support, and observing the nav they each render.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/tGuDFTRO/70-fix-404-page-rendering
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
