### PR TITLE
Add more specific response logic to CTR TeachersController

### DIFF
--- a/app/controllers/check_records/teachers_controller.rb
+++ b/app/controllers/check_records/teachers_controller.rb
@@ -10,7 +10,10 @@ module CheckRecords
         qualification.npq? || qualification.mq?
       end
     rescue QualificationsApi::TeacherNotFoundError
-      render "not_found"
+      respond_to do |format|
+        format.html { render "not_found" }
+        format.any { head :not_found }
+      end
     end
   end
 end


### PR DESCRIPTION


### Context
https://dfe-teacher-services.sentry.io/issues/5449239596/?project=4505227155996672&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1

The existing code simply renders a not_found template if a teacher wasn't returned by the API. If this action receives an oddly-formed request (eg - a request for .css format), the action errors as it can't find an appropriate template in that format.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Handle these sporadic errors by being more explicit about how to respond to html requests vs all other formats. Specifically, render the not_found template for html requests, return a head 404 for everything else.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
na
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
