### PR TITLE
Fix redirects from name and date of birth change controllers

### DIFF
--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -8,7 +8,7 @@ module Qualifications
       }.freeze
 
       before_action :redirect_to_root_unless_one_login_enabled
-      before_action :redirect_if_change_pending, only: [:create, :update]
+      before_action :redirect_if_change_pending
 
       def new
         @date_of_birth_change_form = DateOfBirthChangeForm.new
@@ -79,7 +79,7 @@ module Qualifications
         if teacher.pending_date_of_birth_change?
           flash[:warning] =
             "You have a date of birth change request pending. \
-          Please wait until that is complete before submitting another."
+          Please wait until it’s complete before submitting another."
           redirect_to qualifications_one_login_user_path
         end
       end

--- a/app/controllers/qualifications/one_login_users/name_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/name_changes_controller.rb
@@ -2,7 +2,7 @@ module Qualifications
   module OneLoginUsers
     class NameChangesController < QualificationsInterfaceController
       before_action :redirect_to_root_unless_one_login_enabled
-      before_action :redirect_if_change_pending, only: [:create, :update]
+      before_action :redirect_if_change_pending
 
       def new
         @name_change_form = NameChangeForm.new
@@ -68,7 +68,7 @@ module Qualifications
         if teacher.pending_name_change?
           flash[:warning] =
             "You have a name change request pending. \
-          Please wait until that is complete before submitting another."
+          Please wait until it’s complete before submitting another."
           redirect_to qualifications_one_login_user_path
         end
       end


### PR DESCRIPTION


### Context
We have before filters in these controllers that redirect the user back to the account page if they attempt to resubmit a name or date of birth change form. These filters were applying only to the create/update actions, meaning that a user could still resubmit a request from the confirmation page.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Remove the whitelist on these filters so that all controller actions are inaccessible if a request is pending.

Amend the error message wording slightly while we're at it.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Code review should be sufficient, will be tested in prod review.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/1OaL0MRj/111-handling-one-login-name-dob-change-multiple-requests
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
