### PR TITLE
Adjust whitelist on name/DoB change before filters

### DIFF
--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -8,7 +8,7 @@ module Qualifications
       }.freeze
 
       before_action :redirect_to_root_unless_one_login_enabled
-      before_action :redirect_if_change_pending
+      before_action :redirect_if_change_pending, except: [:submitted]
 
       def new
         @date_of_birth_change_form = DateOfBirthChangeForm.new

--- a/app/controllers/qualifications/one_login_users/name_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/name_changes_controller.rb
@@ -2,7 +2,7 @@ module Qualifications
   module OneLoginUsers
     class NameChangesController < QualificationsInterfaceController
       before_action :redirect_to_root_unless_one_login_enabled
-      before_action :redirect_if_change_pending
+      before_action :redirect_if_change_pending, except: [:submitted]
 
       def new
         @name_change_form = NameChangeForm.new


### PR DESCRIPTION
We need to whitelist this action so the page is visible to the user after submitting their change request.
