### PR TITLE
Add SearchLog entries wherever we do a search in CTR

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -18,13 +18,7 @@ module CheckRecords
         render :personal_details_search
       else
         @total, @teachers = search_qualifications_api_with_personal_details(@search)
-        SearchLog.create!(
-          dsi_user: current_dsi_user,
-          last_name: @search.last_name,
-          date_of_birth: @search.date_of_birth.to_s,
-          result_count: @total,
-          search_type: :personal_details
-        )
+        log_search(:personal_details, @search.last_name, @search.date_of_birth, @total)
 
         if @total > 1 && FeatureFlags::FeatureFlag.active?(:trn_search)
           redirect_to check_records_trn_search_path(search: search_params) and return
@@ -42,12 +36,11 @@ module CheckRecords
 
       if skipped?
         @total, @teachers = search_qualifications_api_with_personal_details(personal_details_search)
-        SearchLog.create!(
-          dsi_user: current_dsi_user,
-          last_name: personal_details_search.last_name,
-          date_of_birth: personal_details_search.date_of_birth.to_s,
-          result_count: @total,
-          search_type: :skip_trn_use_personal_details
+        log_search(
+          :skip_trn_use_personal_details,
+          personal_details_search.last_name,
+          personal_details_search.date_of_birth,
+          @total
         )
         return
       end
@@ -58,24 +51,12 @@ module CheckRecords
         render :trn_search and return
       else
         @teacher = search_qualifications_api_with_trn(@trn_search.trn)
-        SearchLog.create!(
-          dsi_user: current_dsi_user,
-          last_name: personal_details_search.last_name,
-          date_of_birth: personal_details_search.date_of_birth.to_s,
-          result_count: 1,
-          search_type: :trn
-        )
+        log_search(:trn, personal_details_search.last_name, personal_details_search.date_of_birth, 1)
       end
 
     rescue QualificationsApi::TeacherNotFoundError
-      SearchLog.create!(
-        dsi_user: current_dsi_user,
-        last_name: personal_details_search.last_name,
-        date_of_birth: personal_details_search.date_of_birth.to_s,
-        result_count: 0,
-        search_type: :trn
-      )
-      @search = build_personal_details_search
+      log_search(:trn, personal_details_search.last_name, personal_details_search.date_of_birth, 0)
+      @search = personal_details_search
       @teacher = nil
     end
 
@@ -141,6 +122,16 @@ module CheckRecords
       unless FeatureFlags::FeatureFlag.active?(:trn_search)
         redirect_to check_records_root_path
       end
+    end
+
+    def log_search(type, last_name, date_of_birth, total)
+      SearchLog.create!(
+        dsi_user: current_dsi_user,
+        last_name:,
+        date_of_birth: date_of_birth.to_s,
+        result_count: total,
+        search_type: type,
+      )
     end
   end
 end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,3 +1,9 @@
 class SearchLog < ApplicationRecord
+  enum search_type: {
+    personal_details: 'personal_details',
+    trn: 'trn',
+    skip_trn_use_personal_details: 'skip_trn_use_personal_details'
+  }
+
   belongs_to :dsi_user
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -80,6 +80,7 @@ shared:
     - last_name
     - date_of_birth
     - result_count
+    - search_type
     - created_at
     - updated_at
   :console1984_users:

--- a/db/migrate/20240620134804_add_search_type_to_search_log.rb
+++ b/db/migrate/20240620134804_add_search_type_to_search_log.rb
@@ -1,0 +1,5 @@
+class AddSearchTypeToSearchLog < ActiveRecord::Migration[7.1]
+  def change
+    add_column :search_logs, :search_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_122038) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_20_134804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_122038) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "result_count"
+    t.string "search_type"
     t.index ["dsi_user_id"], name: "index_search_logs_on_dsi_user_id"
   end
 

--- a/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_i_see_this_teachers_details
+    and_search_logs_are_created
   end
 
   private
@@ -70,5 +71,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     expect(page).to have_content "1234567"
     expect(page).to have_content "January 01, 2000"
     expect(page).to have_content "QTS"
+  end
+
+  def and_search_logs_are_created
+    expect(SearchLog.order(created_at: :asc).pluck(:search_type)).to eq %w[personal_details trn]
+    expect(SearchLog.last.result_count).to eq 1
   end
 end

--- a/spec/system/check_records/user_searches_and_skips_trn_search_spec.rb
+++ b/spec/system/check_records/user_searches_and_skips_trn_search_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
     when_i_skip_the_trn_search
     then_i_see_multiple_search_results
+    and_search_logs_are_created
   end
 
   private
@@ -52,5 +53,11 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   def then_i_see_multiple_search_results
     expect(page).to have_content "2 records found"
     expect(page).to have_content "you must only view the teacher record you need"
+  end
+
+  def and_search_logs_are_created
+    expect(SearchLog.order(created_at: :asc).pluck(:search_type)).to eq(
+      %w[personal_details skip_trn_use_personal_details]
+    )
   end
 end

--- a/spec/system/check_records/user_searches_and_uses_an_invalid_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_uses_an_invalid_trn_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
     when_i_enter_an_invalid_trn
     then_i_see_no_records
+    and_search_logs_are_created
   end
 
   private
@@ -45,5 +46,10 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   def then_i_see_no_records
     expect(page).to have_content("No record found for Multiple_results born on 5 April 1992 with TRN bad-trn")
     expect(page).to have_link("Search again")
+  end
+
+  def and_search_logs_are_created
+    expect(SearchLog.order(created_at: :asc).pluck(:search_type)).to eq %w[personal_details trn]
+    expect(SearchLog.last.result_count).to eq 0
   end
 end


### PR DESCRIPTION
### Context

The search flow has been modified to [prompt users for a TRN](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/712) if multiple results are returned. We need to ensure we're capturing analytics data so we can see how this functionality is being used.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Add SearchLog creation whenever we do a search
- Capture the search_type each time
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/b/0BiY9LG4/tra-digital-sprint-board
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
