### PR TITLE
Correct TRN search behaviour

### DIFF
--- a/app/models/trn_search.rb
+++ b/app/models/trn_search.rb
@@ -4,4 +4,9 @@ class TrnSearch
   attr_accessor :trn
 
   validates :trn, presence: true
+
+  def find_teacher(teachers:)
+    return unless valid?
+    teachers.find { |t| t.trn == trn }
+  end
 end

--- a/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_a_teacher_record_in_the_results
-    expect(page).to have_content "Terry Walsh"
+    expect(page).to have_content "Terry John Walsh"
   end
 
   def when_i_click_on_the_teacher_record
-    click_on "Terry Walsh"
+    click_on "Terry John Walsh"
   end
 
   def then_i_see_this_teachers_details


### PR DESCRIPTION

### Context
Currently the TRN search in CTR does an API call for a teacher with the submitted TRN value. This isn't the desired behaviour. We should be doing a last name / date of birth search, and then filtering on this result set.

<!-- Why are you making this change? -->


### Changes proposed in this pull request
Alter the logic of CheckRecords::SearchController#trn_result to reflect the behaviour outlined above.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be manually tested by searching for `Baig` / `1/1/1990` and:

- keeping a copy of Baig's TRN
- searching for `Test` / `1/1/1990`
- using one of the returned TRNs to carry out a TRN search (should filter the result set)
- going back and using Baig's TRN instead (no results should be returned)

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/YB7UbzQm/169-correct-trn-search-logic
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
