### PR TITLE
Restrict feedback to authenticated users

### DIFF
--- a/app/controllers/check_records/feedbacks_controller.rb
+++ b/app/controllers/check_records/feedbacks_controller.rb
@@ -1,8 +1,5 @@
 module CheckRecords
   class FeedbacksController < CheckRecordsController
-    skip_before_action :authenticate_dsi_user!
-    skip_before_action :handle_expired_session!
-
     def new
       @feedback = Feedback.new
     end
@@ -27,6 +24,10 @@ module CheckRecords
         :contact_permission_given,
         :email
       )
+    end
+
+    def failed_sign_in_message
+      I18n.t("validation_errors.feedback_auth_failure")
     end
   end
 end

--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -3,7 +3,6 @@ module CheckRecords
     skip_before_action :authenticate_dsi_user!
     skip_before_action :handle_expired_session!
     skip_before_action :enforce_terms_and_conditions_acceptance!
-    before_action :reset_session, except: :not_authorised
     before_action :handle_failed_sign_in, only: :new, if: -> { params[:oauth_failure] == "true" }
 
     def new

--- a/app/controllers/concerns/dsi_authenticatable.rb
+++ b/app/controllers/concerns/dsi_authenticatable.rb
@@ -12,6 +12,7 @@ module DsiAuthenticatable
 
   def authenticate_dsi_user!
     if current_dsi_user.blank?
+      flash[:warning] = failed_sign_in_message
       redirect_to check_records_sign_in_path
     end
   end
@@ -29,6 +30,10 @@ module DsiAuthenticatable
     if Time.zone.at(session[:dsi_user_session_expiry]).past?
       redirect_to check_records_sign_out_path
     end
+  end
+
+  def failed_sign_in_message
+    I18n.t("validation_errors.generic_sign_in_failure")
   end
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,8 @@ en:
 
   validation_errors:
     generic_oauth_failure: There was a problem with your previous request. Please try again.
+    generic_sign_in_failure: You need to sign in to continue.
+    feedback_auth_failure: You must be signed in to give feedback.
 
   activemodel:
     errors:

--- a/spec/system/check_records/user_gives_feedback_spec.rb
+++ b/spec/system/check_records/user_gives_feedback_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature "Feedback", host: :check_records, type: :system do
 
   scenario "User gives feedback", test: :with_stubbed_auth do
     given_the_check_service_is_open
+    when_i_visit_the_sign_in_page
+    and_i_click_on_feedback
+    then_i_am_prompted_to_sign_in
     when_i_sign_in_via_dsi
     and_i_click_on_feedback
     then_i_see_the_feedback_form
@@ -31,6 +34,11 @@ RSpec.feature "Feedback", host: :check_records, type: :system do
 
   def and_i_click_on_feedback
     click_on "feedback"
+  end
+
+  def then_i_am_prompted_to_sign_in
+    expect(page).to have_current_path("/check-records/sign-in")
+    expect(page).to have_content("You must be signed in to give feedback.")
   end
 
   def then_i_see_the_feedback_form


### PR DESCRIPTION
We are getting spam in the feedback form and want to reduce this.

The proposal is to restrict access to the feedback form using the
authentication system.

In this first iteration, we are redirecting to the start page of the
service and showing a flash message with instructions about needing to
sign in to give feedback.

### Link to Trello card

https://trello.com/c/xBCi45yt/172-remove-feedback-form-link-from-the-start-pages-of-ctr-cbl-aytq

<img width="1028" alt="Screenshot 2024-07-17 at 10 53 45 am" src="https://github.com/user-attachments/assets/f7ba6bf2-1962-4e48-b034-3e0f42dba94f">


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
