### PR TITLE
Add better messaging for session expiry

### DIFF
--- a/app/controllers/check_records/sign_out_controller.rb
+++ b/app/controllers/check_records/sign_out_controller.rb
@@ -2,9 +2,9 @@ module CheckRecords
   class SignOutController < CheckRecordsController
     skip_before_action :handle_expired_session!
     skip_before_action :enforce_terms_and_conditions_acceptance!
-    before_action :reset_session
 
     def new
+      session.delete(:dsi_user_id)
       redirect_to check_records_sign_in_path
     end
   end

--- a/app/controllers/concerns/dsi_authenticatable.rb
+++ b/app/controllers/concerns/dsi_authenticatable.rb
@@ -22,14 +22,10 @@ module DsiAuthenticatable
   end
 
   def handle_expired_session!
-    if session[:dsi_user_session_expiry].nil?
-      redirect_to check_records_sign_out_path
-      return
-    end
+    return unless Time.zone.at(session.fetch(:dsi_user_session_expiry, 1.minute.ago)).past?
 
-    if Time.zone.at(session[:dsi_user_session_expiry]).past?
-      redirect_to check_records_sign_out_path
-    end
+    flash[:warning] = I18n.t("validation_errors.session_expired")
+    redirect_to check_records_sign_out_path
   end
 
   def failed_sign_in_message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     generic_oauth_failure: There was a problem with your previous request. Please try again.
     generic_sign_in_failure: You need to sign in to continue.
     feedback_auth_failure: You must be signed in to give feedback.
+    session_expired: Your session has expired. Please sign in again.
 
   activemodel:
     errors:

--- a/spec/system/check_records/user_session_expires_spec.rb
+++ b/spec/system/check_records/user_session_expires_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "DSI session expiry", host: :check_records, type: :system do
 
   def then_i_am_required_to_sign_in_again
     expect(page).to have_current_path check_records_sign_in_path
+    expect(page).to have_content("Your session has expired. Please sign in again.")
   end
 
   def when_i_refresh_the_page


### PR DESCRIPTION
When a session expires, we sign the user out and redirect them to the
start page with no explanation.

This change introduces a flash message with a small explanation in an
attempt to make the scenario clearer.

I also modified the session reset to only remove the user information
rather than clobbering the whole session. This ensures that flash
messages are persisted across redirects.