### PR TITLE
112 malware scanning of file uploads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.0.0)
@@ -645,6 +647,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/date_of_birth_changes_controller.rb
@@ -50,6 +50,7 @@ module Qualifications
           date_of_birth_change: @date_of_birth_change
         )
         @date_of_birth_change.update!(reference_number:)
+        @date_of_birth_change.malware_scan
 
         redirect_to submitted_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change)
       end

--- a/app/controllers/qualifications/one_login_users/name_changes_controller.rb
+++ b/app/controllers/qualifications/one_login_users/name_changes_controller.rb
@@ -42,6 +42,7 @@ module Qualifications
         @name_change = current_user.name_changes.find(params[:id])
         reference_number = qualifications_api_client.send_name_change(name_change: @name_change)
         @name_change.update!(reference_number:)
+        @name_change.malware_scan
 
         redirect_to submitted_qualifications_one_login_user_name_change_path(@name_change)
       end

--- a/app/jobs/fetch_malware_scan_result_job.rb
+++ b/app/jobs/fetch_malware_scan_result_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FetchMalwareScanResultJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(change_request:)
+    Malware::FetchScanResult.new(change_request:).call
+  end
+end

--- a/app/jobs/remove_malware_file_job.rb
+++ b/app/jobs/remove_malware_file_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveMalwareFileJob < ApplicationJob
+  def perform(change_request:)
+    Malware::RemoveFile.new(change_request:).call
+  end
+end

--- a/app/models/date_of_birth_change.rb
+++ b/app/models/date_of_birth_change.rb
@@ -4,7 +4,21 @@ class DateOfBirthChange < ApplicationRecord
 
   delegate :filename, to: :evidence, prefix: true
 
+  enum malware_scan_result: {
+    clean: "clean",
+    error: "error",
+    pending: "pending",
+    suspect: "suspect"
+  }, _prefix: :scan_result
+
+
   def expiring_evidence_url
     evidence.url(expires_in: 5.minutes.in_seconds)
+  end
+
+  def malware_scan
+    return unless evidence.attached?
+
+    FetchMalwareScanResultJob.set(wait: 30.seconds).perform_later(change_request: self)
   end
 end

--- a/app/models/malware/fetch_scan_result.rb
+++ b/app/models/malware/fetch_scan_result.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Malware
+  class FetchScanResult
+    # Only later versions of the Azure Storage REST API support tags operations.
+    Kernel.silence_warnings { Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02" }
+
+    SCAN_RESULT_TAG_KEY = /Malware Scanning scan result/
+    SCAN_RESULT_TAG_VALUE_CLEAN = /No threats found/
+
+    def initialize(change_request:)
+      @change_request = change_request
+    end
+
+    def call
+      return unless change_request.evidence.attached?
+
+      response = fetch_scan_result
+      if response.success?
+        if response.body =~ SCAN_RESULT_TAG_KEY
+          change_request.update!(malware_scan_result: malware_scan_result_from_response(response))
+          RemoveMalwareFileJob.perform_later(change_request:) if change_request.scan_result_suspect?
+        end
+      else
+        change_request.scan_result_error!
+      end
+    rescue Azure::Core::Http::HTTPError
+      change_request.scan_result_error!
+    end
+
+    private
+
+    attr_reader :change_request
+
+    def blob_service
+      @blob_service ||=
+        Azure::Storage::Blob::BlobService.new(
+          storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
+          storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"]
+        )
+    end
+
+    def fetch_scan_result
+      blob_service.call(:get, get_tags_for_blob_url)
+    end
+
+    def get_tags_for_blob_url
+      @get_tags_for_blob_url ||=
+        blob_service.generate_uri(File.join("evidence", change_request.evidence.key), { comp: "tags" })
+    end
+
+    def malware_scan_result_from_response(response)
+      response.body =~ SCAN_RESULT_TAG_VALUE_CLEAN ? "clean" : "suspect"
+    end
+  end
+end

--- a/app/models/malware/remove_file.rb
+++ b/app/models/malware/remove_file.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Malware
+  class RemoveFile
+    attr_reader :change_request
+
+    def initialize(change_request:)
+      @change_request = change_request
+    end
+
+    def call
+      return unless change_request.scan_result_suspect?
+
+      change_request.evidence.purge
+    end
+  end
+end

--- a/app/models/name_change.rb
+++ b/app/models/name_change.rb
@@ -2,6 +2,15 @@ class NameChange < ApplicationRecord
   belongs_to :user
   has_one_attached :evidence
 
+  enum malware_scan_result: {
+    clean: "clean",
+    error: "error",
+    pending: "pending",
+    suspect: "suspect"
+  },
+  _prefix: :scan_result
+
+
   def expiring_evidence_url
     evidence.url(expires_in: 5.minutes.in_seconds)
   end
@@ -10,5 +19,11 @@ class NameChange < ApplicationRecord
 
   def full_name
     "#{first_name} #{middle_name} #{last_name}".squish
+  end
+
+  def malware_scan
+    return unless evidence.attached?
+
+    FetchMalwareScanResultJob.set(wait: 30.seconds).perform_later(change_request: self)
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -28,6 +28,7 @@ shared:
     - created_at
     - updated_at
     - reference_number
+    - malware_scan_result
   :dsi_users:
     - id
     - email
@@ -62,6 +63,7 @@ shared:
     - middle_name
     - last_name
     - reference_number
+    - malware_scan_result
   :users:
     - id
     - email

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -36,3 +36,6 @@ feature_flags:
     author: Malcolm Baig
     description: Reduce number of search results shown to users of CTR by prompting
       them for a TRN when last name and date of birth return multiple results.
+  malware_scan:
+    author: Richard Pattinson
+    description: Enable malware scanning

--- a/db/migrate/20240717113527_add_malware_scan_result_to_change_requests.rb
+++ b/db/migrate/20240717113527_add_malware_scan_result_to_change_requests.rb
@@ -1,0 +1,6 @@
+class AddMalwareScanResultToChangeRequests < ActiveRecord::Migration[7.1]
+  def change
+    add_column :date_of_birth_changes, :malware_scan_result, :string, null: false, default: "pending"
+    add_column :name_changes, :malware_scan_result, :string, null: false, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_10_162148) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_17_113527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_10_162148) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "reference_number"
+    t.string "malware_scan_result", default: "pending", null: false
     t.index ["user_id"], name: "index_date_of_birth_changes_on_user_id"
   end
 
@@ -148,6 +149,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_10_162148) do
     t.string "middle_name"
     t.string "last_name"
     t.string "reference_number"
+    t.string "malware_scan_result", default: "pending", null: false
     t.index ["user_id"], name: "index_name_changes_on_user_id"
   end
 

--- a/spec/support/system/malware_scan_helpers.rb
+++ b/spec/support/system/malware_scan_helpers.rb
@@ -1,0 +1,19 @@
+module MalwareScanHelpers
+  def given_malware_scanning_is_enabled(scan_result: "No threats found")
+    FeatureFlags::FeatureFlag.activate(:malware_scan)
+    tags_url = "https://example.com/uploads/abc987xyz123?comp=tags"
+    response_body = <<-XML.squish
+      <Tags>
+        <Tag>
+          <Key>Malware Scanning scan result</Key>
+          <Value>#{scan_result}</Value>
+        </Tag>
+      </Tags>
+    XML
+    stubbed_service = instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+    stubbed_response =
+      instance_double(Azure::Core::Http::HttpResponse, success?: true, body: response_body)
+    allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(stubbed_service)
+    allow(stubbed_service).to receive(:call).and_return(stubbed_response)
+  end
+end

--- a/spec/system/qualifications/user_uploads_a_suspect_file.rb
+++ b/spec/system/qualifications/user_uploads_a_suspect_file.rb
@@ -6,14 +6,16 @@ RSpec.feature "Account page", type: :system do
   include QualificationAuthenticationSteps
   include MalwareScanHelpers
 
-  scenario "User submits a request to change name", test: %i[with_stubbed_auth with_fake_quals_api] do
+  scenario "User submits a request to change date of birth", test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_qualifications_service_is_open
     given_i_am_signed_in_via_one_login
-    given_malware_scanning_is_enabled
+    given_malware_scanning_is_enabled(scan_result: "Malicious")
     when_i_click_through_to_update_my_details
-    and_click_change_name
-    then_i_am_on_the_name_change_form
+
+    and_click_change_date_of_birth
+    then_i_am_on_the_date_of_birth_change_form
     and_i_can_see_a_list_of_valid_evidence
+
     when_i_submit_the_form
     then_i_see_validation_errors
 
@@ -21,7 +23,7 @@ RSpec.feature "Account page", type: :system do
     and_i_submit_the_form
     then_i_see_the_confirmation_page
 
-    when_i_edit_my_name
+    when_i_edit_the_date_of_birth
     and_i_submit_the_form
     and_i_confirm_my_changes
 
@@ -29,7 +31,10 @@ RSpec.feature "Account page", type: :system do
     and_my_evidence_is_uploaded
 
     when_the_pending_scan_result_is_fetched_after_a_delay
-    then_the_evidence_is_updated
+    then_the_evidence_is_flagged_as_suspicious
+
+    when_the_remove_file_job_runs_after_a_delay
+    then_the_evidence_is_removed
   end
 
   private
@@ -45,18 +50,18 @@ RSpec.feature "Account page", type: :system do
     click_link "View and update details"
   end
 
-  def and_click_change_name
+  def and_click_change_date_of_birth
     change_links = all('a', text: 'Change')
-    change_links[0].click
+    change_links[1].click
   end
 
-  def then_i_am_on_the_name_change_form
-    expect(page).to have_content "Change your name on teaching certificates"
+  def then_i_am_on_the_date_of_birth_change_form
+    expect(page).to have_content "Change your date of birth"
   end
 
   def and_i_can_see_a_list_of_valid_evidence
     within(".govuk-details") do
-      expect(page).to have_selector(:css, "li", text: "deed poll", visible: :all)
+      expect(page).to have_selector(:css, "li", text: "driving license", visible: :all)
     end
   end
 
@@ -66,31 +71,28 @@ RSpec.feature "Account page", type: :system do
   alias_method :and_i_submit_the_form, :when_i_submit_the_form
 
   def then_i_see_validation_errors
-    expect(page).to have_content "Enter your first name"
-    expect(page).to have_content "Enter your last name"
+    expect(page).to have_content "Enter a date of birth"
     expect(page).to have_content "Select a file"
   end
 
   def when_i_complete_the_form
-    fill_in "First name", with: " Steven"
-    fill_in "Middle name", with: " Gonville "
-    fill_in "Last name", with: "Toast"
+    fill_in("Day", with: 5)
+    fill_in("Month", with: 12)
+    fill_in("Year", with: 1990)
 
     attach_file "Upload evidence", Rails.root.join("spec/fixtures/test-upload.pdf")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_content "Confirm change"
-    expect(page).to have_content "Steven Gonville Toast"
+    expect(page).to have_content "5 December 1990"
     expect(page).to have_content "test-upload.pdf"
   end
 
-  def when_i_edit_my_name
+  def when_i_edit_the_date_of_birth
     change_links = all('a', text: 'Change')
     change_links[0].click
-    fill_in "First name", with: "Ray"
-    fill_in "Middle name", with: ""
-    fill_in "Last name", with: "Purchase"
+    fill_in "Month", with: 3
 
     attach_file "Upload evidence", Rails.root.join("spec/fixtures/test-upload.pdf")
   end
@@ -100,15 +102,15 @@ RSpec.feature "Account page", type: :system do
   end
 
   def then_my_request_is_submitted
-    expect(NameChange.last.full_name).to eq "Ray Purchase"
-    expect(NameChange.last.reference_number).to eq "CASE-TEST-123"
-    expect(page).to have_content "Name change request submitted"
+    expect(page).to have_content "Date of birth change request submitted"
     expect(page).to have_content "CASE-TEST-123"
+    expect(DateOfBirthChange.last.date_of_birth.to_s).to eq "1990-03-05"
+    expect(DateOfBirthChange.last.reference_number).to eq "CASE-TEST-123"
   end
 
   def and_my_evidence_is_uploaded
-    expect(NameChange.last.evidence.attached?).to be true
-    expect(NameChange.last.malware_scan_result).to eq "pending"
+    expect(DateOfBirthChange.last.evidence.attached?).to be true
+    expect(DateOfBirthChange.last.malware_scan_result).to eq "pending"
   end
 
   def when_the_pending_scan_result_is_fetched_after_a_delay
@@ -116,7 +118,16 @@ RSpec.feature "Account page", type: :system do
     travel_to(time) { perform_enqueued_jobs(only: FetchMalwareScanResultJob) }
   end
 
-  def then_the_evidence_is_updated
-    expect(NameChange.last.malware_scan_result).to eq "clean"
+  def then_the_evidence_is_flagged_as_suspicious
+    expect(DateOfBirthChange.last.malware_scan_result).to eq "suspect"
+  end
+
+  def when_the_remove_file_job_runs_after_a_delay
+    time = Time.zone.now + 1.minute
+    travel_to(time) { perform_enqueued_jobs(only: RemoveMalwareFileJob) }
+  end
+
+  def then_the_evidence_is_removed
+    expect(DateOfBirthChange.last.evidence.attached?).to be false
   end
 end


### PR DESCRIPTION
### Context

Add malware scanning to AYTQ as per the Refer Serious MIsconduct service. Ensure that no evidence uploaded to the service  via the change name or date of birth flows contains malicious content. This will be handled using azures defender for cloud, which will need configuring as per refer serious misconduct. 

### Changes proposed in this pull request

- Add malware_scan_result field to name_change and date_of_birth_change models
- Add logic to scan defenders output for malicious content warning and update the flag asynchronysly
- test that the correct values of malware_scan_result are applied

### Requires further input

- When a malicious result is found, what should the user experience be like? Should the user be prompted to restart the whole journey and the previous data be removed? Should there be a link sent via email to reupload evidence? 

### Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/POYT7qzl/112-malware-scanning-of-file-uploads)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
