### PR TITLE
Redirect to feedback form after sign in

### DIFF
--- a/app/controllers/check_records/omniauth_callbacks_controller.rb
+++ b/app/controllers/check_records/omniauth_callbacks_controller.rb
@@ -15,7 +15,8 @@ class CheckRecords::OmniauthCallbacksController < ApplicationController
 
     create_or_update_dsi_user
 
-    redirect_to dsi_user&.internal? ? support_interface_root_path : check_records_root_path
+    redirect_location = session.delete(:return_to) || check_records_root_path
+    redirect_to dsi_user&.internal? ? support_interface_root_path : redirect_location
   end
   alias_method :dfe_bypass, :dfe
 

--- a/app/controllers/concerns/dsi_authenticatable.rb
+++ b/app/controllers/concerns/dsi_authenticatable.rb
@@ -13,6 +13,7 @@ module DsiAuthenticatable
   def authenticate_dsi_user!
     if current_dsi_user.blank?
       flash[:warning] = failed_sign_in_message
+      session[:return_to] = request.fullpath
       redirect_to check_records_sign_in_path
     end
   end

--- a/spec/system/check_records/user_gives_feedback_spec.rb
+++ b/spec/system/check_records/user_gives_feedback_spec.rb
@@ -7,11 +7,11 @@ RSpec.feature "Feedback", host: :check_records, type: :system do
 
   scenario "User gives feedback", test: :with_stubbed_auth do
     given_the_check_service_is_open
+    and_i_am_an_existing_dsi_user
     when_i_visit_the_sign_in_page
     and_i_click_on_feedback
     then_i_am_prompted_to_sign_in
-    when_i_sign_in_via_dsi
-    and_i_click_on_feedback
+    when_i_sign_in_via_dsi(accept_terms_and_conditions: false)
     then_i_see_the_feedback_form
     when_i_press_send_feedback
     then_i_see_validation_errors
@@ -27,6 +27,15 @@ RSpec.feature "Feedback", host: :check_records, type: :system do
   end
 
   private
+
+  def and_i_am_an_existing_dsi_user
+    create(
+      :dsi_user, 
+      email: "test@example.com", 
+      terms_and_conditions_accepted_at: Date.yesterday, 
+      terms_and_conditions_version_accepted: '1.0'
+    )
+  end
 
   def and_i_visit_the_search_page
     visit search_path


### PR DESCRIPTION
We want to make the flow of signing in to provide feedback easier.

Currently, if you click the feedback link while signed out, you are
returned to the start page and prompted to sign in. If you then proceed
to sign in, you need to click the feedback link again after successfully
authenticating.

As a first step to making this flow have less steps for the user, I
opted to store the intention of providing feedback as a `return_to`
value in the session.

The user is still prompted to sign in but automatically gets redirected
to the feedback form if that's what they were attempting to do
previously.

### Link to Trello card

https://trello.com/c/lLJaXWWP/173-redirect-back-to-feedback-form-after-sign-in

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
