### PR TITLE
Display a viewed at timestamp on a teacher record

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :page_title, @teacher.name %>
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
+  <span class="govuk-caption-m">
+    Viewed at <%= Time.current.strftime("%-I:%M%P on %-d %B %Y") %>
+  </span>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_npq_details
     then_i_see_mq_details
     then_i_see_previous_last_names
+    and_a_viewed_timestamp_is_displayed
   end
 
   private
@@ -112,5 +113,9 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def and_a_search_timestamp_is_displayed
     expect(page).to have_content "Searched at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
   end
 end


### PR DESCRIPTION
As part of the audit trail for users to be able to prove they performed
a search on a certain day, we want to include a timestamp on the page.

We can simply display the current time and date of when the page was
rendered.

### Link to Trello card

https://trello.com/c/ujHJzEZt/188-replicate-cbls-record-search-timestamp-on-ctr

![capybara-202001011021008626034745](https://github.com/user-attachments/assets/4c044802-6459-45a2-b1bf-56f58867ade3)


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
