### PR TITLE
Define the API Error class

### DIFF
--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
         end
       end
     end
+
+    context "when the API times out" do
+      before do
+        stub_request(:get, %r{.*}).to_timeout
+      end
+
+      it "raises an error" do
+        client = described_class.new(token: "token")
+
+        expect { client.teacher }.to raise_error(QualificationsApi::ApiError)
+      end
+    end
   end
 
   describe "#certificate" do


### PR DESCRIPTION
There are a few different error messages that are all related to errors
on the API side.

To make error reporting clearer, we want to merge these errors together
into a single error class.

This will allow us to more easily track the errors related to the DQT
API.