### PR TITLE
Display warning text related to printing

### DIFF
--- a/app/assets/stylesheets/check_records.scss
+++ b/app/assets/stylesheets/check_records.scss
@@ -112,3 +112,9 @@ h1 .govuk-tag {
     max-width: 100%;
   }
 }
+
+@media print {
+  .app__no-print {
+    display: none;
+  }
+}

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -39,6 +39,12 @@
     <% @other_qualifications.each do |qualification| %>
       <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
     <% end %>
+
+    <%= govuk_inset_text classes: "govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0 app__no-print" do %>
+      <div class="govuk-!-margin-bottom-1">
+        You should review the terms and conditions before printing this page. You should dispose of the offline records you maintain once they have served their purpose.
+      </div>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">
@@ -60,12 +66,12 @@
       <% end %>
 
       <% if @teacher.date_of_birth.present? %>
-          <li>
-            <h4>Date of birth</h4>
-          </li>
-          <li>
-            <p><%= Date.parse(@teacher.date_of_birth).to_fs(:long) %></p>
-          </li>
+        <li>
+          <h4>Date of birth</h4>
+        </li>
+        <li>
+          <p><%= Date.parse(@teacher.date_of_birth).to_fs(:long) %></p>
+        </li>
       <% end %>
 
       <% if @teacher.previous_names.present? %>

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_mq_details
     then_i_see_previous_last_names
     and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
   end
 
   private
@@ -117,5 +118,9 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def and_a_viewed_timestamp_is_displayed
     expect(page).to have_content "Viewed at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
   end
 end


### PR DESCRIPTION
We want to make the user aware of their responsibilities relating to
printing information they have searched for.

This introduces a warning that is visible only when viewed in a browser
and not on the printed version of the page.

### Link to Trello card

https://trello.com/c/sZ5JxLJF/189-add-a-warning-text-or-print-button-that-informs-users-that-they-can-download-or-print-the-pages-on-ctr-and-cbl

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally

<img width="1013" alt="Screenshot 2024-07-26 at 10 50 53 am" src="https://github.com/user-attachments/assets/47b59a89-f398-4190-959d-466e01ea2989">

Printed version: [James Gunn - Check a teacher’s record.pdf](https://github.com/user-attachments/files/16390088/James.Gunn.-.Check.a.teacher.s.record.pdf)
