### PR TITLE
Add a link to print the page

### DIFF
--- a/app/javascript/check_records.js
+++ b/app/javascript/check_records.js
@@ -1,3 +1,15 @@
 import { initAll } from "govuk-frontend";
 
 initAll();
+
+function printPage() {
+  window.print();
+}
+
+// Add event listener to the print button
+document.addEventListener("DOMContentLoaded", () => {
+  const printButton = document.querySelector("[data-print-button]");
+  if (printButton) {
+    printButton.addEventListener("click", printPage);
+  }
+});

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -1,9 +1,19 @@
 <% content_for :page_title, @teacher.name %>
 <% content_for :breadcrumbs do %>
-  <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-3 govuk-!-margin-bottom-2">
+      <a href="#" data-print-button class="app__no-print">Print this page</a>
+    </div>
+  </div>
+
   <span class="govuk-caption-m">
     Viewed at <%= Time.current.strftime("%-I:%M%P on %-d %B %Y") %>
   </span>
+
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
We want to make it easier for a user to print the page.

Adding a link that triggers the browser print functionality will make it
clearer that this is a printable page.

### Link to Trello card

https://trello.com/c/sZ5JxLJF/189-add-a-warning-text-or-print-button-that-informs-users-that-they-can-download-or-print-the-pages-on-ctr-and-cbl

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally

<img width="1017" alt="Screenshot 2024-07-26 at 11 53 48 am" src="https://github.com/user-attachments/assets/15fbac38-59bc-4225-9e6b-551146cedd30">
