### PR TITLE
Add a warning message for when there are no details

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -71,6 +71,14 @@ module QualificationsApi
       api_data.pending_date_of_birth_change == true
     end
 
+    def no_details?
+      qualifications.empty? && 
+        api_data.induction.blank? && 
+        api_data.eyps.blank? && 
+        api_data.qts.blank? && 
+        api_data.eyts.blank?
+    end
+
     private
 
     def add_qts

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -27,7 +27,9 @@
       <% end %>
     <% end %>
 
-
+    <% if @teacher.no_details? %>
+      <%= govuk_warning_text(text: "We have no details of this person's qualifications, teacher status or induction status. Please contact them directly for this information.") %>
+    <% end %>
     <% if @mqs.present? %>
       <%= render CheckRecords::MqSummaryComponent.new(mqs: @mqs) %>
     <% end %>

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -39,6 +39,11 @@ class FakeQualificationsApi < Sinatra::Base
           total: 2,
           results: [teacher_data, additional_teacher]
         }.to_json
+      when "No_data"
+        {
+          total: 1,
+          results: [no_data]
+        }.to_json
       else
         {
           total: 1,
@@ -56,10 +61,13 @@ class FakeQualificationsApi < Sinatra::Base
     trn = params[:trn]
     case bearer_token
     when "token"
-      if trn == "1234567"
+      case trn
+      when "1234567"
         quals_data(trn: "1234567").to_json
-      elsif trn == "987654321"
+      when "987654321"
         quals_data(trn:).to_json
+      when "1212121"
+        no_data.to_json
       else
         halt 404
       end
@@ -112,6 +120,10 @@ class FakeQualificationsApi < Sinatra::Base
 
   def teacher_data(sanctions: false, trn: "1234567")
     sanctions ? sanctions_data : no_sanctions_data(trn:)
+  end
+
+  def no_data
+    no_sanctions_data(trn: "1212121")
   end
 
   def no_sanctions_data(trn:)

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -88,4 +88,21 @@ module FakeQualificationsData
       sanctions: trn == "987654321" ? [ { code: "G1", startDate: "2020-10-25" } ] : []
     }
   end
+
+  def no_data(trn:)
+    {
+      trn:,
+      dateOfBirth: "2000-01-01",
+      firstName: "Terry",
+      lastName: "Walsh",
+      previousNames: [],
+      eyts: nil,
+      qts: nil,
+      induction: nil,
+      initialTeacherTraining: nil,
+      mandatoryQualifications: [],
+      npqQualifications: [],
+      sanctions: []
+    }
+  end
 end

--- a/spec/support/system/activate_features_steps.rb
+++ b/spec/support/system/activate_features_steps.rb
@@ -14,4 +14,8 @@ module ActivateFeaturesSteps
   def given_onelogin_authentication_is_active
     FeatureFlags::FeatureFlag.activate(:one_login)
   end
+
+  def given_the_trn_search_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:trn_search)
+  end
 end

--- a/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   private
 
-  def given_the_trn_search_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:trn_search)
-  end
-
   def and_search_with_a_valid_name_and_dob
     fill_in "Last name", with: "Multiple_results"
     fill_in "Day", with: "5"

--- a/spec/system/check_records/user_searches_no_details_spec.rb
+++ b/spec/system/check_records/user_searches_no_details_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Teacher search", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  scenario "User searches for someone that has a record but no details",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+
+    when_i_click_on_the_teacher_record
+    then_i_see_this_teacher_has_no_details
+  end
+  
+  private
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "No_data"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_this_teacher_has_no_details
+    expect(page).to have_content(
+      "We have no details of this person's qualifications, teacher status or induction status."
+    )
+  end
+end


### PR DESCRIPTION
There are occasions when we don't have any details on a person even
though we have a record of them.

In these scenarios, to make it clear to users that there was a match, we
want to present the warning text that there are no details on record for
the matched person.


### Link to Trello card

https://trello.com/c/HnWbDqE3/176-design-a-message-for-records-that-do-not-contain-any-information

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1013" alt="Screenshot 2024-07-26 at 12 36 04 pm" src="https://github.com/user-attachments/assets/1de03c32-6fb3-4c08-a358-14ab4c0dbec3">
