### PR TITLE
Add support for programme type as an Integer

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -114,7 +114,7 @@ module QualificationsApi
 
     def add_itt(qts: true)
       all_itt_data = api_data.fetch("initial_teacher_training", [])
-      eyts_itt_data, qts_itt_data = all_itt_data.partition { |itt| itt.programme_type&.starts_with?("EYITT") }
+      eyts_itt_data, qts_itt_data = all_itt_data.partition { |itt| itt.programme_type.to_s&.starts_with?("EYITT") }
       itt_data = qts ? qts_itt_data : eyts_itt_data
 
       @qualifications << itt_data

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -213,6 +213,42 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         expect(qualifications.map(&:type)).to eq(%i[qts itt])
       end
     end
+
+    context "when programmeType is an Integer" do
+      let(:api_data) do
+        {
+          "initialTeacherTraining" => [
+            {
+              "qualification" => {
+                "name" => "BA"
+              },
+              "startDate" => "2012-02-28",
+              "endDate" => "2013-01-28",
+              "programmeType" => 1,
+              "programmeTypeDescription" => "Higher Education Institution",
+              "result" => "Pass",
+              "ageRange" => {
+                "description" => "10 to 16 years"
+              },
+              "provider" => {
+                "name" => "Earl Spencer Primary School",
+                "ukprn" => nil
+              },
+              "subjects" => [
+                { "code" => "100079", "name" => "business studies" }
+              ]
+            }
+          ],
+          "qts" => {
+            "awarded" => "2013-01-28",
+          }
+        }
+      end
+
+      it "the QTS gets priority in the sort order" do
+        expect(qualifications.map(&:type)).to eq(%i[qts itt])
+      end
+    end
   end
 
   describe "#name" do


### PR DESCRIPTION
We have a new programme type returned by the DQT API that is an Integer
rather than a String.

This breaks the code that partitions the qualifications as it expects a
String.

We currently have no use for the Integer value so I've opted for the
simplest change of converting it to a String.

https://trello.com/c/bLp2ONEO/211-add-support-for-new-programme-types