### PR TITLE
Move the timestamp representation to a component

### DIFF
--- a/app/components/action_at_component.html.erb
+++ b/app/components/action_at_component.html.erb
@@ -1,0 +1,3 @@
+<span class="govuk-caption-m">
+  <%= action.titleize %> at <%= at %>
+</span>

--- a/app/components/action_at_component.rb
+++ b/app/components/action_at_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ActionAtComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :action
+
+  def at
+    Time.current.to_fs(:time_and_date)
+  end
+end

--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -31,7 +31,6 @@ module CheckRecords
     end
 
     def trn_result
-      @searched_at = Time.zone.now.strftime("%-I:%M%P on %-d %B %Y")
       @trn_search = TrnSearch.new(trn: search_params[:trn])
       render :trn_search and return if(@trn_search.invalid? && !skipped?)
 
@@ -78,8 +77,7 @@ module CheckRecords
     def build_personal_details_search
       Search.new(
         date_of_birth: date_of_birth_params_to_array,
-        last_name: params[:search][:last_name],
-        searched_at: Time.zone.now
+        last_name: params[:search][:last_name]
       )
     end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -11,7 +11,6 @@ class Search
   attr_accessor :last_name, :searched_at
   attr_reader :date_of_birth
 
-
   validates :last_name, presence: true
   validate :date_of_birth_is_valid
 
@@ -24,10 +23,6 @@ class Search
     date_fields[1] = word_to_month_number(date_fields[1]) if month_is_a_word
 
     @date_of_birth = DateOfBirth.new(*date_fields)
-  end
-
-  def searched_at_to_s
-    searched_at.strftime("%-I:%M%P on %-d %B %Y")
   end
 
   private

--- a/app/views/check_records/search/personal_details_result.html.erb
+++ b/app/views/check_records/search/personal_details_result.html.erb
@@ -2,9 +2,7 @@
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
 
-  <span class="govuk-caption-m">
-    Searched at <%= @search.searched_at_to_s %>
-  </span>
+  <%= render ActionAtComponent.new(action: "Searched") %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -12,7 +10,7 @@
     <% if @total.zero? %>
       <h1 class="govuk-heading-l">No records found</h1>
       <p class="govuk-body">
-        No record found for <%= @search.last_name %> born on <%= @search.date_of_birth.to_s.to_date.strftime("%e %B %Y") %>
+        No record found for <%= @search.last_name %> born on <%= @search.date_of_birth.to_s.to_date.to_fs(:long_uk) %>
       </p>
     <% else %>
       <h1 class="govuk-heading-l"><%= pluralize(@total, 'record') %> found</h1>

--- a/app/views/check_records/search/trn_result.html.erb
+++ b/app/views/check_records/search/trn_result.html.erb
@@ -2,9 +2,7 @@
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
 
-  <span class="govuk-caption-m">
-    Searched at <%= @searched_at %>
-  </span>
+  <%= render ActionAtComponent.new(action: "Searched") %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -19,7 +17,7 @@
     <% elsif @teacher.blank? %>
       <h1 class="govuk-heading-l">No records found</h1>
       <p class="govuk-body">
-        No record found for <%= @search.last_name %> born on <%= @search.date_of_birth.to_s.to_date.strftime("%e %B %Y") %> with TRN <%= @trn_search.trn %>.
+        No record found for <%= @search.last_name %> born on <%= @search.date_of_birth.to_s.to_date.to_fs(:long_uk) %> with TRN <%= @trn_search.trn %>.
       </p>
       <%= render partial: "search_again_link" %>
     <% else %>

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -10,10 +10,7 @@
     </div>
   </div>
 
-  <span class="govuk-caption-m">
-    Viewed at <%= Time.current.strftime("%-I:%M%P on %-d %B %Y") %>
-  </span>
-
+  <%= render ActionAtComponent.new(action: "Viewed") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,3 @@
 Date::DATE_FORMATS[:long_uk] = "%e %B %Y"
+
+Time::DATE_FORMATS[:time_and_date] = "%-I:%M%P on %-d %B %Y"

--- a/spec/components/action_at_component_spec.rb
+++ b/spec/components/action_at_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActionAtComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new(action:)).css(".govuk-caption-m").to_html }
+
+  let(:action) { "Viewed" }
+  let(:frozen_time) { Time.zone.local(2020, 6, 1, 10, 21) }
+
+  it "renders the timestamp" do
+    travel_to(frozen_time) do
+      expect(rendered_component).to include("Viewed at #{frozen_time.to_fs(:time_and_date)}")
+    end
+  end
+
+  context "when the action is 'Created'" do
+    let(:action) { "Created" }
+
+    it "renders the action correctly" do
+      travel_to(frozen_time) do
+        expect(rendered_component).to include("Created at")
+      end
+    end
+  end
+
+  context "when the current timezone is not UTC" do
+    let(:frozen_time) { Time.parse("2020-06-01 10:21:00 UTC") }
+
+    before do
+      Time.zone = "Eastern Time (US & Canada)"
+    end
+
+    after do
+      Time.zone = "UTC"
+    end
+
+    it "renders the timestamp in the correct timezone" do
+      travel_to(frozen_time) do
+        expect(rendered_component).to include("Viewed at 6:21am on 1 June 2020")
+      end
+    end
+  end
+end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -113,11 +113,11 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def and_a_search_timestamp_is_displayed
-    expect(page).to have_content "Searched at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
   end
 
   def and_a_viewed_timestamp_is_displayed
-    expect(page).to have_content "Viewed at #{@frozen_time.strftime("%-I:%M%P on %-d %B %Y")}"
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
   end
 
   def and_a_print_warning_is_displayed


### PR DESCRIPTION
We display the timestamp of when an action was taken in a few places and
the implementation varies slightly in each spot.

I opted to move this to a ViewComponent to make it easier to test this
component in isolation.

Also, we can use the DATE_FORMATS setting to avoid hard-coding date
formats across the code and tests.

### Link to Trello card

https://trello.com/c/ICDKsFk1/245-incorrect-timestamp-on-searched-at-and-viewed-at-in-ctr

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
