### PR TITLE
Add a maintenance window for BigQuery

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -10,4 +10,6 @@ DfE::Analytics.configure do |config|
       disabled_by_default = Rails.env.development?
       ENV.fetch("BIGQUERY_DISABLE", disabled_by_default.to_s) != "true"
     end
+
+  config.bigquery_maintenance_window = "08-09-2024 18:00..08-09-2024 19:00"
 end


### PR DESCRIPTION
We are doing some maintenance work on BigQuery and need to ensure that
we queue up events for sending after the maintenance is complete.