### PR TITLE
Explicitly set the timezone

### DIFF
--- a/app/components/action_at_component.rb
+++ b/app/components/action_at_component.rb
@@ -6,6 +6,6 @@ class ActionAtComponent < ViewComponent::Base
   attr_accessor :action
 
   def at
-    Time.current.to_fs(:time_and_date)
+    Time.use_zone("London") { Time.current.to_fs(:time_and_date) }
   end
 end

--- a/spec/components/action_at_component_spec.rb
+++ b/spec/components/action_at_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActionAtComponent, type: :component do
 
   it "renders the timestamp" do
     travel_to(frozen_time) do
-      expect(rendered_component).to include("Viewed at #{frozen_time.to_fs(:time_and_date)}")
+      expect(rendered_component).to include("Viewed at 10:21am on 1 June 2020")
     end
   end
 
@@ -35,9 +35,9 @@ RSpec.describe ActionAtComponent, type: :component do
       Time.zone = "UTC"
     end
 
-    it "renders the timestamp in the correct timezone" do
+    it "renders the timestamp in the London timezone" do
       travel_to(frozen_time) do
-        expect(rendered_component).to include("Viewed at 6:21am on 1 June 2020")
+        expect(rendered_component).to include("Viewed at 11:21am on 1 June 2020")
       end
     end
   end


### PR DESCRIPTION
When display the time an action was performed, it is consistently being
rendered in UTC.

Previous efforts have included setting the Time.zone in the application
configuration but this hasn't worked.

Given that we have a single place where we calculate the timestamp, we
can explicitly set the time zone to London to ensure it displays
correctly.