### PR TITLE
Display the current organisation for this session

### DIFF
--- a/app/controllers/check_records/search_controller.rb
+++ b/app/controllers/check_records/search_controller.rb
@@ -6,6 +6,7 @@ module CheckRecords
 
     def personal_details_search
       @search = Search.new
+      @organisation_name = current_dsi_user.dsi_user_sessions.last&.organisation_name
     end
 
     def personal_details_result

--- a/app/views/check_records/search/personal_details_search.html.erb
+++ b/app/views/check_records/search/personal_details_search.html.erb
@@ -2,6 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @organisation_name %>
+      <div class="govuk-caption-m govuk-!-margin-bottom-4">
+        You're signed in as <%= @organisation_name %>
+      </div>
+    <% end %>
+
     <%= form_with model: @search, url: check_records_result_path, method: :get do |f| %>
       <%= f.govuk_error_summary %>
 


### PR DESCRIPTION
A user can select which organisation to use when signing in. We
currently don't make that choice visible anywhere in Check.

As an improvement for the user, we want to display their chosen
organisation at the point where they start their search.

### Link to Trello card

https://trello.com/c/bFw4IC5t/156-enhance-ui-to-display-signed-in-organization-for-multi-affiliated-users

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1005" alt="Screenshot 2024-08-09 at 9 51 09 am" src="https://github.com/user-attachments/assets/600ed1e0-e107-4efb-a651-50441fa0fa08">
