### PR TITLE
Upgrade terraform azurerm providers to 3.116.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ tmp/pids/*
 .env.production.local
 
 .terraform/
-.terraform.lock.hcl
 fetch_config.rb
 terraform/application/vendor
 bin/terrafile

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.27.0"
+  constraints = "~> 3.27.0"
+  hashes = [
+    "h1:38deV9FjTj3C5b2RBJ7rEhrsg7E8GcPmiqgFxiO5uZc=",
+    "zh:02e014e70113c321aca49e76c4c39e7d7ca0f45763f095a063d523f0af1a9327",
+    "zh:17457072dbc2e0cb112dcc246173895f873c5d7d907e2f6883c19a104e053e66",
+    "zh:2f38a5326dbadeba80da45c1c6f4eabe207a7672d3e7c9056df1861433148790",
+    "zh:63f608417196fd88d3a5a20b037de0064302985414f49ff494aa65e00dc5d218",
+    "zh:705d67e00c77181bcc6c50613bb8aa2c77988f86534bc240a300a1826efbc24c",
+    "zh:72f7eca9bd3b7b1e6fffb5bc7b11a9281c1f34319b2073b2c7db1b08b558b2f8",
+    "zh:7579eef7a029f0bb8440f161afd53e59859541a4aa05008d0d88c5ecf2d81c23",
+    "zh:78429d5602a356acadc3c4b2d19bbed3e1a373f8c89e2bb9871527a1c56f51cb",
+    "zh:e0eb79998b61d7d2a4be05cc28f7c2caa8bc50edddd2f0e0bfb99a833982ae6b",
+    "zh:e6b3d8da3e75d6793a21f318937ce3ba81d6267c18cc058a9366ba35d37cf3be",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7905b2ac7e3a71ebbdc6846bbbc417df4be5690e7afd74d2aba48828a21398e",
+  ]
+}
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.0.5"
+  constraints = "2.0.5"
+  hashes = [
+    "h1:8/x0qo4d2j83dbM5RmGW++GJ4gQbz9OgoedLtPyFJIg=",
+    "zh:0d4abab56a77562c8c347e4bec8ec5f9cb74cfa78e14485d1895dbae2d3e46d1",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:1d3a6ad4d42bdf912482ca1b6100883ce6075257b841723c155aef52ffffc7c5",
+    "zh:2a613729fa535c15214029832fd7da54adbe2142b84033ae78509b0fa1db1d5b",
+    "zh:3e8546072054c6f356193d942deab120ef9f5cd861891e4e8b4951a971573de5",
+    "zh:4211f740a066527475e14819ecd3551985b1dd52245de1d9bb2d6db57a37fb70",
+    "zh:45bbce8cebd7ec50d4691081b0f119fc75512e1e306d87584b33ad7cc337939f",
+    "zh:4b514734633ce09d30ea9e7ef0caabd788575bb1b706af0c8ba60b96a923dcba",
+    "zh:6ddc4591d4e52cbd78c2a9473c870287166c1d1c15802257bd1780330f6ad0d8",
+    "zh:79f974a40afe997081410e7e6c2ffa96d7cf51969f2bb8ef930d42f6a857b5c9",
+    "zh:98b155af2ebcbf710febd6263b9f8ad5a79faed1d6177432f081539cebece959",
+    "zh:b0f6f90c02d851740fe1177e807fd32cd17519f57fb0dda9ed3d9f5845d9bbc0",
+    "zh:b39348a178af82ba1d26b93cb2d0cbb375b1c8607554390568e5d603539e8392",
+    "zh:c5a13978a2ddacfc7507d3d149044791408d7075c99eafe2f7daa01eea061213",
+    "zh:dc1e63f106f95591f162cac520e71ed7203c270b9e17eb3b5333e80a02c9905c",
+  ]
+}

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.104.2"
+      version = "3.116.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### Context

Keep providers up-to-date
This is now possible after https://github.com/DFE-Digital/terraform-modules/releases/tag/v0.38.0 was released

Ticket: https://trello.com/c/moH45K2M


### Changes proposed in this pull request

Upgrade in application

### Guidance to review

- make production terraform-plan


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
