### PR TITLE
Upgrade data_migrate gem for Rails 7.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "azure-storage-blob", github: "honeyankit/azure-storage-ruby"
 gem "bootsnap", require: false
 gem "console1984"
 gem "cssbundling-rails"
-gem "data_migrate"
+gem "data_migrate", github: "ilyakatz/data-migrate"
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.1"
 gem "faraday"
 gem "govuk-components", "~> 5.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,14 @@ GIT
       net-http-persistent (~> 4.0)
       nokogiri (~> 1, >= 1.10.8)
 
+GIT
+  remote: https://github.com/ilyakatz/data-migrate.git
+  revision: 5b66f54d10ac221a53ee74b69acdaeb498b49b0a
+  specs:
+    data_migrate (11.0.0.rc3)
+      activerecord (>= 6.1)
+      railties (>= 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -164,9 +172,6 @@ GEM
     cuprite (0.15.1)
       capybara (~> 3.0)
       ferrum (~> 0.15.0)
-    data_migrate (9.4.2)
-      activerecord (>= 6.1)
-      railties (>= 6.1)
     date (3.3.4)
     declarative (0.0.20)
     diff-lcs (1.5.1)
@@ -660,7 +665,7 @@ DEPENDENCIES
   console1984
   cssbundling-rails
   cuprite
-  data_migrate
+  data_migrate!
   dfe-analytics!
   dotenv-rails
   factory_bot_rails

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_230_329_102_114)
+DataMigrate::Data.define(version: 20230329102114)


### PR DESCRIPTION
The version of data_migrate (9.4.2) that is currently installed
references a method on the database connection that is removed in Rails
7.2.

This prevents us from being able to deploy the app as booting fails on
the data migration step.

There is no rubygems version that supports Rails 7.2 yet, so I opted to
switch to referencing the repo on GitHub directly.

We can revisit after a new release is published. This is looking like it
will coincide with the release of v11.