### PR TITLE
Add an entity to record a bulk search

### DIFF
--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -8,9 +8,18 @@ module CheckRecords
     def create
       @bulk_search = BulkSearch.new(file: bulk_search_params[:file])
       @total, @results, @not_found = @bulk_search.call
-      unless @results
+
+      if @results
+        BulkSearchLog.create!(
+          csv: @bulk_search.csv,
+          dsi_user_id: current_dsi_user.id,
+          query_count: @bulk_search.csv.count,
+          result_count: @total
+        )
+      else
         render :new
       end
+
     end
 
     private

--- a/app/models/bulk_search.rb
+++ b/app/models/bulk_search.rb
@@ -33,6 +33,10 @@ class BulkSearch
     @total ||= response["total"]
   end
 
+  def csv
+    @csv ||= CSV.parse(file.read, headers: true)
+  end
+
   private
 
   def all_rows_have_data
@@ -54,10 +58,6 @@ class BulkSearch
         errors.add(:file, "The selected file does not have a TRN in row #{index + 1}")
       end
     end
-  end
-
-  def csv
-    @csv ||= CSV.parse(file.read, headers: true)
   end
 
   def header_row_present?

--- a/app/models/bulk_search_log.rb
+++ b/app/models/bulk_search_log.rb
@@ -1,0 +1,7 @@
+class BulkSearchLog < ApplicationRecord
+  belongs_to :dsi_user
+
+  validates :csv, presence: true
+  validates :query_count, presence: true
+  validates :result_count, presence: true
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -128,3 +128,11 @@ shared:
     - created_at
     - updated_at
     - service
+  :bulk_search_logs:
+    - id
+    - csv
+    - dsi_user_id
+    - query_count
+    - result_count
+    - created_at
+    - updated_at

--- a/db/migrate/20240829103510_create_bulk_search_logs.rb
+++ b/db/migrate/20240829103510_create_bulk_search_logs.rb
@@ -1,0 +1,12 @@
+class CreateBulkSearchLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bulk_search_logs do |t|
+      t.references :dsi_user, null: false, foreign_key: true
+      t.integer :query_count
+      t.integer :result_count
+      t.text :csv
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_22_092519) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_29_103510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_092519) do
     t.datetime "updated_at", null: false
     t.index ["auditor_id"], name: "index_audits1984_audits_on_auditor_id"
     t.index ["session_id"], name: "index_audits1984_audits_on_session_id"
+  end
+
+  create_table "bulk_search_logs", force: :cascade do |t|
+    t.bigint "dsi_user_id", null: false
+    t.integer "query_count"
+    t.integer "result_count"
+    t.text "csv"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dsi_user_id"], name: "index_bulk_search_logs_on_dsi_user_id"
   end
 
   create_table "console1984_commands", force: :cascade do |t|
@@ -200,6 +210,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_092519) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bulk_search_logs", "dsi_users"
   add_foreign_key "date_of_birth_changes", "users"
   add_foreign_key "search_logs", "dsi_users"
 end

--- a/spec/factories/bulk_search_logs.rb
+++ b/spec/factories/bulk_search_logs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :bulk_search_log do
+    dsi_user { nil }
+    query_count { 1 }
+    result_count { 1 }
+    csv { "MyText" }
+  end
+end

--- a/spec/models/bulk_search_log_spec.rb
+++ b/spec/models/bulk_search_log_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe BulkSearchLog, type: :model do
+  it { is_expected.to validate_presence_of(:csv) }
+  it { is_expected.to validate_presence_of(:query_count) }
+  it { is_expected.to validate_presence_of(:result_count) }
+end

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     when_i_sign_in_via_dsi
     and_search_with_a_valid_csv
     then_i_see_the_results_summary
+    and_my_search_is_logged
   end
 
   private
@@ -22,5 +23,12 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
 
   def then_i_see_the_results_summary
     expect(page).to have_content "1 teacher record found"
+  end
+
+  def and_my_search_is_logged
+    search_log = BulkSearchLog.last
+    expect(search_log.csv).to eq "TRN,Date of birth\n3001403,1990-01-01\n9876543,2000-01-01\n"
+    expect(search_log.query_count).to eq 2
+    expect(search_log.result_count).to eq 1
   end
 end


### PR DESCRIPTION
We want a way of tracking how the bulk search is used.

`BulkSearchLog` has a similar structure to `SearchLog` and is intended
to be used in a similar way.

### Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/c5M6Qqyz/254-analytics-set-up-to-understand-how-users-perform-bulk-searches