### PR TITLE
Send a custom event on validation errors

### DIFF
--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,2 @@
+shared:
+  - bulk_search_validation_error

--- a/spec/system/check_records/user_searches_with_an_invalid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_an_invalid_csv_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
 
     when_i_search_with_a_csv_missing_a_value
     then_i_see_the_missing_value_error_message
+    and_i_see_the_analytics_event
   end
 
   private
@@ -34,6 +35,10 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
 
   def then_i_see_the_missing_value_error_message
     expect(page).to have_content "The selected file does not have a TRN in row 1"
+  end
+
+  def and_i_see_the_analytics_event
+    expect(:bulk_search_validation_error).to have_been_enqueued_as_analytics_events
   end
 end
 


### PR DESCRIPTION
When a user sees a validation error while trying to perform a bulk
search there is no corresponding event tracked in BigQuery. This makes
it hard to analyse how the service is used and how we could improve it.

Adding a custom event that contains the validation error message is a
first step in being able to bring some observability to this particular
experience.

The event simply contains the full validation error message. We will
launch the feature with this and can iterate on it as needed.