### PR TITLE
Handle API errors for bulk search

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -139,6 +139,18 @@ module QualificationsApi
       response = client.post("v3/persons/find", { persons: queries }) do |request|
         request.headers["X-Api-Version"] = "20240814"
       end
+      case response.status
+      when 200
+        response.body
+      when 403
+        raise QualificationsApi::ForbiddenError
+      when 401
+        raise QualificationsApi::InvalidTokenError
+      else
+        raise QualificationsApi::UnknownError, "API returned unhandled status #{response.status}"
+      end
+    rescue QualificationsApi::UnknownError => e
+      Sentry.capture_exception(e)
       response.body
     end
 

--- a/app/models/bulk_search.rb
+++ b/app/models/bulk_search.rb
@@ -24,13 +24,13 @@ class BulkSearch
   end
 
   def results
-    @results ||= response["results"].map do |teacher|
+    @results ||= response.fetch("results", []).map do |teacher|
       QualificationsApi::Teacher.new(teacher)
     end
   end
 
   def total
-    @total ||= response["total"]
+    @total ||= response.fetch("total", 0)
   end
 
   private
@@ -68,7 +68,7 @@ class BulkSearch
   end
 
   def find_all(queries)
-    search_client.bulk_teachers(queries:)
+    search_client.bulk_teachers(queries:) || {}
   end
 
   def response

--- a/spec/lib/qualifications_api/client_spec.rb
+++ b/spec/lib/qualifications_api/client_spec.rb
@@ -100,4 +100,50 @@ RSpec.describe QualificationsApi::Client, test: :with_fake_quals_api do
       end
     end
   end
+
+  describe "#bulk_teachers" do
+    subject(:bulk_teachers) do
+      described_class.new(token:).bulk_teachers(queries:)
+    end
+
+    let(:token) { "token" }
+    let(:queries) { [] }
+    
+    it "returns the total count of records found" do
+      expect(bulk_teachers["total"]).to eq(1)
+    end
+
+    it "returns the records found" do
+      expect(bulk_teachers.dig("results", 0, "trn")).to eq("9876543")
+    end
+
+    context "when the API returns a 401" do
+      let(:token) { "invalid-token" }
+
+      it "raises an error" do
+        expect { bulk_teachers }.to raise_error(
+          QualificationsApi::InvalidTokenError
+        )
+      end
+    end
+
+    context "when the API returns a 403" do
+      let(:token) { "forbidden" }
+
+      it "raises an error" do
+        expect { bulk_teachers }.to raise_error(
+          QualificationsApi::ForbiddenError
+        )
+      end
+    end
+
+    context "when the API returns a 500" do
+      let(:token) { "api-error" }
+
+      it "captures the error in Sentry" do
+        expect(Sentry).to receive(:capture_exception)
+        bulk_teachers
+      end
+    end
+  end
 end

--- a/spec/models/bulk_search_spec.rb
+++ b/spec/models/bulk_search_spec.rb
@@ -79,5 +79,20 @@ RSpec.describe BulkSearch, type: :model do
 
       it { is_expected.to be_falsey }
     end
+
+    context 'when the search returns an error' do
+      before do
+        allow_any_instance_of(QualificationsApi::Client).to receive(:bulk_teachers).and_return(nil)
+      end
+
+      it "returns no results" do
+        is_expected.to eq([0, [], 
+          [
+            { "trn" => "3001403", "date_of_birth" => Date.parse("01/01/1990") },
+            { "date_of_birth" => Date.parse("1/1/2000"), "trn" => "9876543" }
+          ]
+        ])
+      end
+    end
   end
 end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -79,10 +79,19 @@ class FakeQualificationsApi < Sinatra::Base
   post "/v3/persons/find" do
     content_type :json
 
-    {
-      results: [quals_data(trn: "9876543")],
-      total: 1
-    }.to_json
+    case bearer_token
+    when "token"
+      {
+        results: [quals_data(trn: "9876543")],
+        total: 1
+      }.to_json
+    when "invalid-token"
+      halt 401
+    when "forbidden"
+      halt 403
+    when "api-error"
+      halt 500
+    end
   end
 
   get "/v3/certificates/npq/:id" do


### PR DESCRIPTION
There are cases when the API throws an error that we can handle better
for the user.

If an error is returned the body of the response is empty, which leads
to an exception due to the expectation of there always being a body
value.

I opted to guard against the nil value to ensure we can always render a
response.

For the error handling, I opted to raise an exception with the error
code and message so we can get insight into the issues during testing.

### Link to Trello card

https://trello.com/c/g08YzsRn/224-bulk-search-create-mvp-to-understand-bulk-search-limits

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
