### PR TITLE
Parse the date of birth field for a bulk search

### DIFF
--- a/app/models/bulk_search.rb
+++ b/app/models/bulk_search.rb
@@ -73,7 +73,7 @@ class BulkSearch
 
   def response
     @response ||= begin
-      queries = csv.map { |row| { trn: row["TRN"], dateOfBirth: row["Date of birth"] } }.compact
+      queries = csv.map { |row| { trn: row["TRN"], dateOfBirth: Date.parse(row["Date of birth"]) } }.compact
       find_all(queries)
     end
   end

--- a/spec/models/bulk_search_spec.rb
+++ b/spec/models/bulk_search_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe BulkSearch, type: :model do
       expect(call.third).to eq(["trn" => '3001403', "date_of_birth" => Date.parse('01/01/1990')])
     end
 
+    it 'parses the date of birth correctly in the queries' do
+      expect_any_instance_of(QualificationsApi::Client).to receive(:bulk_teachers) do |_, queries:|
+        expect(queries).to include(
+          hash_including(
+            trn: '3001403',
+            dateOfBirth: Date.parse('01/01/1990')
+          )
+        )
+        { "results" => [], "total" => 0 }
+      end
+
+      call
+    end
+
     context 'when the bulk search is not valid' do
       let(:file) { nil }
 
@@ -94,5 +108,7 @@ RSpec.describe BulkSearch, type: :model do
         ])
       end
     end
+
+
   end
 end


### PR DESCRIPTION
The API endpoint we use for the bulk search expects the date of birth
field to be a date object.

This change ensures we pass the value in the correct format.