### PR TITLE
Remove CBL data from CTR

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -90,6 +90,21 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.number }}
 
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set kubelogin environment
+        uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Seed role codes
+        shell: bash
+        run: |
+          make ci aks-review get-cluster-credentials PR_NUMBER=123
+          kubectl exec -n tra-development deployment/access-your-teaching-qualifications-pr-${{ github.event.number }} -- /bin/sh -c "cd /app && bundle exec rake db:seed_role_codes"
+
       - name: Post comment to Pull Request ${{ github.event.number }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "bootsnap", require: false
 gem "console1984"
 gem "cssbundling-rails"
 gem "data_migrate", github: "ilyakatz/data-migrate"
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.1"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.2"
 gem "faraday"
 gem "govuk-components", "~> 5.6"
 gem "govuk_design_system_formbuilder", "~> 5.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 79378cc466a40c6a6cba317e232cbf48ec79ab7d
-  tag: v1.14.1
+  revision: 706595e52fed211cee53ad99ceaeaabb47a059cc
+  tag: v1.14.2
   specs:
-    dfe-analytics (1.14.1)
+    dfe-analytics (1.14.2)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -12,7 +12,6 @@ class CheckRecords::TeacherProfileSummaryComponent < ViewComponent::Base
   end
 
   def build_tags
-    append_restriction_tag
     append_teaching_status_tag
     append_induction_tag
   end
@@ -20,16 +19,6 @@ class CheckRecords::TeacherProfileSummaryComponent < ViewComponent::Base
   private
 
   delegate :no_restrictions?, :possible_restrictions?, to: :teacher
-
-  def append_restriction_tag
-    tags << if no_restrictions?
-      { message: 'No restrictions', colour: 'green'}
-    elsif possible_restrictions?
-      { message: 'Possible restrictions', colour: 'blue'}
-    else
-      { message: 'Restriction', colour: 'red'}
-    end
-  end
 
   def append_teaching_status_tag
     tags << if teacher.qts_awarded?

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -41,7 +41,6 @@ module QualificationsApi
 
     def restriction_status
       return 'No restrictions' if no_restrictions?
-      return 'Possible restrictions' if possible_restrictions?
 
       'Restriction'
     end
@@ -50,10 +49,6 @@ module QualificationsApi
       return true if sanctions.blank? || sanctions.all?(&:guilty_but_not_prohibited?)
 
       false
-    end
-
-    def possible_restrictions?
-      sanctions.any?(&:possible_match_on_childrens_barred_list?)
     end
 
     def sanctions

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -165,12 +165,6 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "G1" => {
-      title: "Possible match on the children’s barred list",
-      description: <<~DESCRIPTION.chomp
-        Email the Disclosure and Barring Service (DBS) at [dbscost@dbs.gov.uk](mailto:dbscost@dbs.gov.uk) to check if this person is allowed to work with children.
-      DESCRIPTION
-    },
     "T1" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
@@ -233,10 +227,6 @@ class Sanction
 
   def title
     SANCTIONS[code][:title] if SANCTIONS[code]
-  end
-
-  def possible_match_on_childrens_barred_list?
-    code == "G3"
   end
 
   def guilty_but_not_prohibited?

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -134,45 +134,5 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component do
         end
       end
     end
-
-    describe 'restrictions statuses' do
-      describe "No restrictions tag" do
-        context "teacher#no_restrictions is true" do
-          before { allow(teacher).to receive(:no_restrictions?).and_return(true) }
-
-          it "adds the No restrictions tag" do
-            render_inline described_class.new(teacher)
-
-            expect(page).to have_text("No restrictions")
-          end
-        end
-
-        context "teacher#no_restrictions returns false " do
-          before do
-            allow(teacher).to receive(:no_restrictions?).and_return(false)
-            allow(teacher).to receive(:possible_restrictions?).and_return(true)
-          end
-
-          it "adds the possible restriction tag" do
-            render_inline described_class.new(teacher)
-
-            expect(page).to have_text("Possible restriction")
-          end
-        end
-
-        context "teacher has a restriction" do
-          before do
-            allow(teacher).to receive(:no_restrictions?).and_return(false)
-            allow(teacher).to receive(:possible_restrictions?).and_return(false)
-          end
-
-          it "adds the restriction tag" do
-            render_inline described_class.new(teacher)
-
-            expect(page).to have_text("Restriction")
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/models/sanction_spec.rb
+++ b/spec/models/sanction_spec.rb
@@ -29,12 +29,11 @@ RSpec.describe Sanction, type: :model do
     subject(:description) { sanction.description }
 
     context 'when type exists in SANCTIONS' do
-      let(:code) { "G1" }
+      let(:code) { "A13" }
       
       it "returns the description as markdown" do
         expect(description)
-          .to eq('Email the Disclosure and Barring Service (DBS) at [dbscost@dbs.gov.uk](mailto:dbscost@dbs.gov.uk) ' \
-                 'to check if this person is allowed to work with children.')
+          .to include('Suspended by the General Teaching Council for England.')
       end
     end
 

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Teacher search with restrictions",
     then_i_see_the_restriction_on_the_result
 
     when_i_click_on_the_result
-    then_i_see_the_details_of_the_restriction
+    then_i_see_the_details_of_the_record
   end
 
   private
@@ -35,8 +35,7 @@ RSpec.describe "Teacher search with restrictions",
     click_link "Teacher Restricted"
   end
 
-  def then_i_see_the_details_of_the_restriction
-    expect(page).to have_content("Possible match on the children’s barred list")
+  def then_i_see_the_details_of_the_record
     expect(page).to have_title("Terry Walsh - Check a teacher’s record")
   end
 end


### PR DESCRIPTION
### Context

Remove CBL flags from teacher records. 

In the discussion with policy and TRA ops we agreed that:

the preferred option is still stop displaying DBS barred flags on CTR

the switch to CTR makes implementing this change simpler as it makes no reference to displaying this information anyway.

Making the change will allow  be simpler and clearer in the guidance and we can explicitly signpost users where they should, for example, make full disclose checks

### Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/Uk6PltRr/255-remove-cbl-data-from-ctr)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
