### PR TITLE
Bump test app service plan to B2

### DIFF
--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -3,6 +3,7 @@
   "key_vault_name": "s165t01-aytq-ts-kv",
   "resource_group_name": "s165t01-aytq-ts-rg",
   "storage_account_name": "s165t01aytqtfstatets",
+  "app_service_plan_sku": "B2",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165t01-aytq",


### PR DESCRIPTION
### Context

Upgrade service plan of test environment from B1-> B2. This is to ensure smoke tests pass. Under the current plan we were maxing out the CPU, meaning that fresh deployments would fail at the deploy to test step of the pipeline. 

### Changes proposed in this pull request

Upgrade the service plan B1-> B2.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
