### PR TITLE
Add delay to deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -157,7 +157,12 @@ jobs:
           image_name_tag: ${{ needs.build_image.outputs.image_name_tag }}
           image_tag: ${{ github.sha }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          site_up_retries: 120
+          site_up_retries: 240
+
+      - run: |
+          echo Sleeping...
+          sleep 600
+          Finished sleeping
 
       - uses: ./.github/actions/smoke-test
         id: smoke-test


### PR DESCRIPTION
### Context
Deployments are failing as the app takes a long time to start

### Changes proposed in this pull request
Adding a long delay to give it a chance to start in time.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
