### PR TITLE
Remove pagination limit

### DIFF
--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -44,7 +44,7 @@ module CheckRecords
         QualificationsApi::Teacher.new(teacher['api_data'])
       end
       @not_found = data['not_found'].map {|record| Hashie::Mash.new(record) }
-      @pagy, @results = pagy_array(@results, limit: 4)
+      @pagy, @results = pagy_array(@results)
     end
 
     private


### PR DESCRIPTION
The value for the pagination limit was set small for development
purposes.

Now that we want to use this in a production environment, we need it to
be the default, 20 records.