### PR TITLE
Modify the error event data

### DIFF
--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -59,7 +59,7 @@ module CheckRecords
         .with_user(current_dsi_user)
         .with_request_details(request)
         .with_namespace(current_namespace)
-        .with_data(errors: @bulk_search.errors.to_hash)
+        .with_data(data: { errors: @bulk_search.errors.to_hash })
 
       DfE::Analytics::SendEvents.do([event])
     end


### PR DESCRIPTION
When we send the validation error event, the details of the error aren't
available to view in BigQuery.

I believe that in order for them to be visible they need to be passed
using the `data` key.