### PR TITLE
Add redirect to sign out complete page

### DIFF
--- a/app/controllers/qualifications/users/sign_out_controller.rb
+++ b/app/controllers/qualifications/users/sign_out_controller.rb
@@ -28,6 +28,7 @@ module Qualifications
       end
 
       def complete
+        redirect_to qualifications_root_path
       end
     end
   end

--- a/spec/system/qualifications/user_signs_out_spec.rb
+++ b/spec/system/qualifications/user_signs_out_spec.rb
@@ -11,9 +11,7 @@ RSpec.feature "Identity auth", type: :system do
     and_i_am_signed_in_via_identity
     when_i_click_the_sign_out_link
     and_confirm_my_sign_out
-    then_i_see_the_confirmation_page
-    when_i_click_the_button_to_take_me_back_to_the_service
-    then_i_am_on_service_start_page
+    then_i_am_on_service_sign_in_page
   end
 
   private
@@ -30,8 +28,8 @@ RSpec.feature "Identity auth", type: :system do
     click_button "Confirm"
   end
 
-  def then_i_see_the_confirmation_page
-    expect(page).to have_content "You are now signed out"
+  def then_i_am_on_service_sign_in_page
+    expect(page).to have_current_path qualifications_sign_in_path
   end
 
   def when_i_click_the_button_to_take_me_back_to_the_service

--- a/spec/system/qualifications/user_signs_out_via_onelogin_spec.rb
+++ b/spec/system/qualifications/user_signs_out_via_onelogin_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "GOVUK One Login auth", type: :system do
     and_i_am_signed_in_via_onelogin
     when_i_click_the_sign_out_link
     and_confirm_my_sign_out
-    then_i_see_the_confirmation_page
-    when_i_click_the_button_to_take_me_back_to_the_service
-    then_i_am_on_service_start_page
+    then_i_see_the_sign_in_page
   end
 
   private
@@ -31,16 +29,8 @@ RSpec.feature "GOVUK One Login auth", type: :system do
     click_button "Confirm"
   end
 
-  def then_i_see_the_confirmation_page
-    expect(page).to have_content "You are now signed out"
-  end
-
-  def when_i_click_the_button_to_take_me_back_to_the_service
-   click_link "Back to GOV.UK"
-  end
-
-  def then_i_am_on_service_start_page
-    expect(page).to have_current_path qualifications_start_path
+  def then_i_see_the_sign_in_page
+    expect(page).to have_current_path qualifications_sign_in_path
   end
 end
 


### PR DESCRIPTION
### Context

Following conversations with Tejas around onelogin guidance; we don't need to add the one login header. Instead we are going to remove the sign out complete page.

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
