### PR TITLE
Improve bulk search UI

### DIFF
--- a/app/components/tabbed_pagination_component.rb
+++ b/app/components/tabbed_pagination_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class TabbedPaginationComponent < GovukComponent::PaginationComponent
+  def initialize(fragment: nil, **kwargs)
+    self.fragment = fragment
+    super(**kwargs)
+  end
+
+  private
+
+  attr_accessor :fragment
+
+  def build_items
+    pagy.series.map { |i| with_item(number: i, href: pagy_url_for(pagy, i, fragment:), from_pagy: true) }
+  end
+
+  def build_next
+    return unless pagy&.next
+
+    kwargs = {
+      href: pagy_url_for(pagy, pagy.next, fragment:),
+      text: @next_text,
+    }
+
+    with_next_page(**kwargs.compact)
+  end
+
+  def build_previous
+    return unless pagy&.prev
+
+    kwargs = {
+      href: pagy_url_for(pagy, pagy.prev, fragment:),
+      text: @previous_text,
+    }
+
+    with_previous_page(**kwargs.compact)
+  end
+end

--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -45,6 +45,8 @@ module CheckRecords
       end
       @not_found = data['not_found'].map {|record| Hashie::Mash.new(record) }
       @pagy, @results = pagy_array(@results)
+
+      @bulk_search_response.update!(expires_at: 30.minutes.from_now)
     end
 
     private

--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -44,7 +44,9 @@ module CheckRecords
         QualificationsApi::Teacher.new(teacher['api_data'])
       end
       @not_found = data['not_found'].map {|record| Hashie::Mash.new(record) }
-      @pagy, @results = pagy_array(@results)
+      @pagy, @results = pagy_array(@results, limit: 10)
+      @pagy_not_found, @not_found = 
+        pagy_array(@not_found, limit: 10, page_param: :page_not_found, anchor_string: '#records-not-found')
 
       @bulk_search_response.update!(expires_at: 30.minutes.from_now)
     end

--- a/app/views/check_records/bulk_searches/new.html.erb
+++ b/app/views/check_records/bulk_searches/new.html.erb
@@ -25,7 +25,7 @@
             must be in DD/MM/YYYY format. 
           </p>
           <p class="govuk-body">
-            You can add a maximum of 20 people.
+            You can add a maximum of 100 people.
           </p>
         </li>
         <li>

--- a/app/views/check_records/bulk_searches/show.html.erb
+++ b/app/views/check_records/bulk_searches/show.html.erb
@@ -1,12 +1,15 @@
 <% content_for :page_title, "Bulk Search Results" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Find multiple records" => new_check_records_bulk_search_path, "Results" => nil }) %>
-  <%= render ActionAtComponent.new(action: "searched") %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render ActionAtComponent.new(action: "searched") %>
     <h1 class="govuk-heading-l"><%= pluralize(@total, 'teacher record') %> found</h1>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      We found <%= pluralize(@total, 'teacher record') %> out of the <%= pluralize(@results.count + @not_found.count, 'entry') %> you uploaded.
+    </p>
     <%= govuk_tabs do |tabs|
       if @results.any?
         tabs.with_tab(label: "Records found", id: "records-found") do %>

--- a/app/views/check_records/search/_not_found.html.erb
+++ b/app/views/check_records/search/_not_found.html.erb
@@ -1,6 +1,7 @@
 <div class="no-results--table">
-  <%= govuk_table do |table|
-    table.with_caption(size: 'm', text: 'No records found')
+  <% if not_found.any? %>
+    <%= govuk_table do |table|
+      table.with_caption(size: 'm', text: 'No records found')
 
     table.with_head do |head|
       head.with_row do |row|
@@ -13,9 +14,17 @@
       not_found.each do |record|
         body.with_row do |row|
           row.with_cell(text: record.trn)
-          row.with_cell(text: record.date_of_birth.to_date.to_fs(:long_uk))
+            row.with_cell(text: record.date_of_birth.to_date.to_fs(:long_uk))
+          end
         end
       end
-    end
-  end %>
+    end %>
+  <% end %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="app-pagination">
+        <%= render TabbedPaginationComponent.new(pagy: @pagy_not_found, fragment: '#records-not-found') if @pagy_not_found.pages.positive? %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     when_i_click_find_records
     then_i_see_results
     and_my_search_is_logged
+    when_i_wait_for_the_search_to_expire
+    then_i_see_the_expired_search_message
   end
 
   private
@@ -44,4 +46,19 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     expect(search_log.query_count).to eq 2
     expect(search_log.result_count).to eq 1
   end
+
+  def when_i_wait_for_the_search_to_expire
+    travel 29.minutes
+    page.refresh
+    travel 2.minutes
+    page.refresh
+    expect(page).not_to have_content "Bulk search expired"
+    travel 31.minutes
+    page.refresh
+  end
+
+  def then_i_see_the_expired_search_message
+    expect(page).to have_content "Bulk search expired"
+    travel_back
+  end 
 end


### PR DESCRIPTION
We can improve the UX of the bulk search experience by adding
new copy and pagination for the not found tab.

### Link to Trello card

https://trello.com/c/g08YzsRn/224-bulk-search-stress-test-bulk-search-limits

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
