### PR TITLE
[2049] Upgrade postgres to version 16

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -11,7 +11,7 @@ module "postgres" {
   use_azure                   = var.deploy_azure_backing_services
   azure_enable_monitoring     = var.enable_monitoring
   azure_enable_backup_storage = var.enable_postgres_backup_storage
-  server_version              = "14"
+  server_version              = "16"
 }
 
 module "redis-cache" {


### PR DESCRIPTION
### Context
Upgrade postgres in new environments from 14 to 16. Upgrading requires downtime so it makes sense to do it now rather than when the application is live in the new environments.

### Changes proposed in this pull request

Update postgres to 16 in the new terraform

### Guidance to review
Validate review app

### Link to Trello card
https://trello.com/c/YYO4pwqb

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
