### PR TITLE
344 review and add fields to ctr for regulatory organisations gtcni ewc wales

### DIFF
--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -60,6 +60,14 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
       { key: { text: "Age range" }, value: { text: details.age_range&.description } },
       {
         key: {
+          text: "Course start date"
+        },
+        value: {
+          text: details.start_date&.to_date&.to_fs(:long_uk)
+        }
+      },
+      {
+        key: {
           text: "Course end date"
         },
         value: {

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -45,12 +45,16 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows[4].text).to include(qualification.details.age_range&.description)
     end
 
+    it "renders the qualification status" do
+      expect(rows[5].text).to include(Date.parse(qualification.details.start_date).to_fs(:long_uk))
+    end
+
     it "renders the qualification course end date" do
-      expect(rows[5].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
+      expect(rows[6].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
     end
 
     it "renders the qualification status" do
-      expect(rows[6].text).to include(qualification.details.result)
+      expect(rows[7].text).to include(qualification.details.result)
     end
 
     it "omits rows with no value" do


### PR DESCRIPTION
### Context

For GTCNI,

Assess adding ITT course length and/or course start date as a required data field → We will add to qual_show_component.

Assess adding Class and Division for the qualification as a nice-to-have data field. → Not doing this

For EWC Wales, they require:

Induction start date → Not doing this right now because induction period will be moved to CPD post migration. We dont to surface something we will remove in a few months.

Induction Pass date. → Already exists

QTS Award Route is needed as DfE recognise Overseas awards but EWC do not. → Appears as programme_type and is a flat field so cannot be broken down further

Net outcome: Add ITT course start date to the show component

### Changes proposed in this pull request

Add ITT course start date to qualifications show component

### Link to Trello card
[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/4Fomh6K9/344-review-and-add-fields-to-ctr-for-regulatory-organisations-gtcni-ewc-wales)
### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
