### PR TITLE
[2048] Remove app service IP restriction

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -110,20 +110,6 @@ resource "azurerm_linux_web_app" "aytq-app" {
     http2_enabled       = true
     minimum_tls_version = "1.2"
     health_check_path   = "/health"
-    ip_restriction = var.domain != null ? [{
-      name     = "FrontDoor"
-      action   = "Allow"
-      priority = 1
-      headers = [{
-        x_azure_fdid      = try([local.infrastructure_secrets.FRONTDOOR_ID], [])
-        x_fd_health_probe = []
-        x_forwarded_for   = []
-        x_forwarded_host  = []
-      }]
-      service_tag               = "AzureFrontDoor.Backend"
-      ip_address                = null
-      virtual_network_subnet_id = null
-    }] : []
   }
 
   app_settings = local.aytq_env_vars


### PR DESCRIPTION
### Context
The app service will be accessed by a new front door in s189 after the domain migration.

### Changes proposed in this pull request
Remove IP restriction to uncouple it from the existing front door.

### Guidance to review
It was removed from preprod manually and https://s165t01-aytq-preprod-app.azurewebsites.net/ does not return 403

### After merge
Rules may have to be removed manually

### Link to Trello card
https://trello.com/c/kYWAOZTW

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
