### PR TITLE
Add notification banner to inform users of service outage

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -34,6 +34,9 @@
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
+          <%= govuk_notification_banner title: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+        <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>
       </main>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -34,6 +34,9 @@
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
+          <%= govuk_notification_banner title: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+        <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
 
         <% if content_for?(:two_thirds) %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -42,3 +42,6 @@ feature_flags:
   bulk_search:
     author: Felix Clack
     description: Enable bulk search in Check the record
+  downtime_banner:
+    author: Richard Pattinson
+    description: Display banner informing users of service downtime


### PR DESCRIPTION
### Context

As part of the scheduled upgrade to AKS we will need to take the AYTQ/CTR down for an hour. This has been scheduled for monday 30th. A notification banner should be raised to notify users.

### Changes proposed in this pull request

<img width="1009" alt="Screenshot 2024-09-26 at 21 26 23" src="https://github.com/user-attachments/assets/674b8b93-9954-443a-b694-119728b6583a">

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
