### PR TITLE
Update notification banenr to use title_text instead of title

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -35,7 +35,7 @@
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
-          <%= govuk_notification_banner title: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
         <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -35,7 +35,7 @@
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
-          <%= govuk_notification_banner title: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
         <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
 


### PR DESCRIPTION
### Context

Notification banner should use title_text rather than title as an argument. 

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
