### PR TITLE
Update count and restrictions

### DIFF
--- a/app/controllers/check_records/bulk_searches_controller.rb
+++ b/app/controllers/check_records/bulk_searches_controller.rb
@@ -40,6 +40,8 @@ module CheckRecords
 
       data = @bulk_search_response.body
       @total = @bulk_search_response.total
+      @total_not_found = data['not_found'].count
+      @total_results = data['results'].count
       @results ||= data.fetch("results", []).map do |teacher|
         QualificationsApi::Teacher.new(teacher['api_data'])
       end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -46,7 +46,9 @@ module QualificationsApi
     end
 
     def no_restrictions?
-      return true if sanctions.blank? || sanctions.all?(&:guilty_but_not_prohibited?)
+      return true if sanctions.blank? || 
+        sanctions.all?(&:guilty_but_not_prohibited?) || 
+        sanctions.map(&:title).join.blank?
 
       false
     end

--- a/app/views/check_records/bulk_searches/show.html.erb
+++ b/app/views/check_records/bulk_searches/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, "Bulk Search Results" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Find multiple records" => new_check_records_bulk_search_path, "Results" => nil }) %>
+  <%= render ActionAtComponent.new(action: "searched") %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render ActionAtComponent.new(action: "searched") %>
     <h1 class="govuk-heading-l"><%= pluralize(@total, 'teacher record') %> found</h1>
     <p class="govuk-body govuk-!-margin-bottom-6">
-      We found <%= pluralize(@total, 'teacher record') %> out of the <%= pluralize(@results.count + @not_found.count, 'entry') %> you uploaded.
+      We found <%= pluralize(@total, 'teacher record') %> out of the <%= pluralize(@total_results + @total_not_found, 'entry') %> you uploaded.
     </p>
     <%= govuk_tabs do |tabs|
       if @results.any?

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       let(:api_data) do
         {
           "sanctions" => [
-            { "guiltyButNotProhibited" => true },
+            { "code" => "T6", "start_date" => "2024-01-01" },
             { "possibleMatchOnChildrensBarredList" => true }
           ]
         }
@@ -434,11 +434,35 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       it { is_expected.to be_falsey }
     end
 
-    context "when there are sanctions" do
+    context "when there are sanctions that are not prohibited" do
       let(:api_data) do
         {
           "sanctions" => [
-            { "guiltyButNotProhibited" => true },
+            { "code" => "T6", "start_date" => "2024-01-01" },
+          ]
+        }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there are sanctions not listed in the Sanction model" do
+      let(:api_data) do
+        {
+          "sanctions" => [
+            { "code" => "T7", "start_date" => "2024-01-01" },
+          ]
+        }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there are sanctions that are prohibited" do
+      let(:api_data) do
+        {
+          "sanctions" => [
+            { "code" => "A13", "start_date" => "2024-01-01" },
           ]
         }
       end


### PR DESCRIPTION
QA highlighted a couple of issues with the bulk search feature around
the way we count the returned results and also with the restrictions tag.

- **Fix the count of records**
- **Only highlight known restrictions**

### Link to Trello card

https://trello.com/c/g08YzsRn/224-bulk-search-stress-test-bulk-search-limits

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
