### PR TITLE
Update downtime banner with next scheduled maintenance window

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -35,7 +35,7 @@
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
-          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 7th October between 6pm and 7pm while we carry out essential maintenance" %>
         <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>

--- a/app/views/layouts/check_records_layout.html.erb
+++ b/app/views/layouts/check_records_layout.html.erb
@@ -35,7 +35,7 @@
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if FeatureFlags::FeatureFlag.active?(:downtime_banner) %>
-          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 30th September between 6pm and 7pm while we carry out essential maintenance" %>
+          <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Monday 7th October between 6pm and 7pm while we carry out essential maintenance" %>
         <% end %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
 


### PR DESCRIPTION
### Context

Update notification banner to reflect downtime on thursday the 3rd

### Changes proposed in this pull request

Update the notification banner text.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
