### PR TITLE
2048 Origin change and s165 test removals

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,8 +21,6 @@ on:
         type: choice
         options:
           - dev
-          - test
-          - preprod
           - production
 
 jobs:
@@ -174,7 +172,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             DEPLOYMENT_MATRIX="{ 'environment': ['${{ github.event.inputs.environment }}'] }"
           else
-            DEPLOYMENT_MATRIX="{ 'environment': ['dev', 'test', 'preprod'] }"
+            DEPLOYMENT_MATRIX="{ 'environment': ['dev'] }"
           fi
           echo "deployment_matrix=$DEPLOYMENT_MATRIX" >> $GITHUB_OUTPUT
 
@@ -222,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_prod
-    needs: [build_image, deploy_non_prod]
+    needs: [build_image, deploy_aks]
     environment:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,10 @@ aks-production: production-cluster
 domains:
 	$(eval include global_config/domains.sh)
 
+bin/konduit.sh:
+	curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/main/scripts/konduit.sh -o bin/konduit.sh \
+		&& chmod +x bin/konduit.sh
+
 composed-variables: ## Compose variables needed for deployments
 	$(eval RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg)
 	$(eval KEYVAULT_NAMES='("${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv", "${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-inf-kv")')

--- a/terraform/application/config/preprod.yml
+++ b/terraform/application/config/preprod.yml
@@ -1,1 +1,3 @@
 ---
+ACCESS_EXTERNAL_DOMAIN: preprod.access-your-teaching-qualifications.education.gov.uk
+CHECK_EXTERNAL_DOMAIN: preprod.check-a-teachers-record.education.gov.uk

--- a/terraform/application/config/test.yml
+++ b/terraform/application/config/test.yml
@@ -1,1 +1,3 @@
 ---
+ACCESS_EXTERNAL_DOMAIN: test.access-your-teaching-qualifications.education.gov.uk
+CHECK_EXTERNAL_DOMAIN: test.check-a-teachers-record.education.gov.uk

--- a/terraform/domains/environment_domains/config/preprod.tfvars.json
+++ b/terraform/domains/environment_domains/config/preprod.tfvars.json
@@ -5,14 +5,14 @@
       "resource_group_name": "s189p01-aytq-dom-rg",
       "domains": ["preprod"],
       "environment_short": "pp",
-      "origin_hostname": "s165t01-aytq-preprod-app.azurewebsites.net"
+      "origin_hostname": "access-your-teaching-qualifications-preprod.test.teacherservices.cloud"
     },
     "check-a-teachers-record.education.gov.uk": {
       "front_door_name": "s189p01-ctr-dom-fd",
       "resource_group_name": "s189p01-aytq-dom-rg",
       "domains": ["preprod"],
       "environment_short": "pp",
-      "origin_hostname": "s165t01-aytq-preprod-app.azurewebsites.net"
+      "origin_hostname": "check-a-teachers-record-preprod.test.teacherservices.cloud"
     }
   }
 }

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -5,14 +5,14 @@
       "resource_group_name": "s189p01-aytq-dom-rg",
       "domains": ["test"],
       "environment_short": "test",
-      "origin_hostname": "s165t01-aytq-test-app.azurewebsites.net"
+      "origin_hostname": "access-your-teaching-qualifications-test.test.teacherservices.cloud"
     },
     "check-a-teachers-record.education.gov.uk": {
       "front_door_name": "s189p01-ctr-dom-fd",
       "resource_group_name": "s189p01-aytq-dom-rg",
       "domains": ["test"],
       "environment_short": "test",
-      "origin_hostname": "s165t01-aytq-test-app.azurewebsites.net"
+      "origin_hostname": "check-a-teachers-record-test.test.teacherservices.cloud"
     }
   }
 }


### PR DESCRIPTION
### Context

To point the origin towards the correct external domains

### Changes proposed in this pull request

To point the origin towards the correct external domains aswell as remove the old tfvars and make targets/

### Guidance to review

Check that the app service has been migrated to AKS and remove redundant test references

### Link to Trello card

https://trello.com/c/kYWAOZTW/2048-aytq-migrate-domains

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
