### PR TITLE
2048 aytq migrate domains production

### DIFF
--- a/terraform/application/config/production.yml
+++ b/terraform/application/config/production.yml
@@ -1,1 +1,3 @@
 ---
+ACCESS_EXTERNAL_DOMAIN: access-your-teaching-qualifications.education.gov.uk
+CHECK_EXTERNAL_DOMAIN: check-a-teachers-record.education.gov.uk

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -11,7 +11,7 @@
           "to-domain": "access-your-teaching-qualifications.education.gov.uk"
         }
       ],
-      "origin_hostname": "s165p01-aytq-production-app.azurewebsites.net"
+      "origin_hostname": "access-your-teaching-qualifications-production.teacherservices.cloud"
     },
     "check-a-teachers-record.education.gov.uk": {
       "front_door_name": "s189p01-ctr-dom-fd",
@@ -24,7 +24,7 @@
           "to-domain": "check-a-teachers-record.education.gov.uk"
         }
       ],
-      "origin_hostname": "s165p01-aytq-production-app.azurewebsites.net"
+      "origin_hostname": "check-a-teachers-record-production.teacherservices.cloud"
     }
   }
 }


### PR DESCRIPTION
### Context

Changes to point to external domain for production and using the correct origin hostname.

### Changes proposed in this pull request

Changes to point to external domain for production and using the correct origin hostname.

### Guidance to review

Validate external URLs are working correctly.

https://access-your-teaching-qualifications.education.gov.uk/
https://check-a-teachers-record.education.gov.uk/


### Link to Trello card

https://trello.com/c/kYWAOZTW/2048-aytq-migrate-domains

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
