### PR TITLE
2048 aytq migrate production infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ storage/
 
 # Redis snapshots
 dump.rdb
+
+bin/konduit.sh

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -40,9 +40,30 @@ module "web_application" {
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
 
+  replicas     = var.app_replicas
   docker_image = var.docker_image
+  enable_logit = true
 
   send_traffic_to_maintenance_page = var.send_traffic_to_maintenance_page
 
   web_external_hostnames = [local.check_domain]
+}
+
+module "worker_application" {
+  source = "./vendor/modules/aks//aks/application"
+
+  name    = "worker"
+  is_web  = false
+  command = ["bundle", "exec", "sidekiq", "-C", "./config/sidekiq.yml"]
+
+  namespace    = var.namespace
+  environment  = var.environment
+  service_name = var.service_name
+
+  cluster_configuration_map  = module.cluster_data.configuration_map
+  kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
+  kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
+  replicas                   = var.worker_replicas
+  docker_image               = var.docker_image
+  enable_logit               = true
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -5,11 +5,11 @@
   "enable_monitoring": false,
   "external_url": "https://access-your-teaching-qualifications.education.gov.uk/healthcheck",
   "statuscake_contact_groups": [282453],
-  "replicas": 2,
-  "azure_enable_high_availability": true,
-  "azure_enable_monitoring": false,
-  "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
+  "app_replicas": 2,
+  "worker_replicas": 1,
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "enable_postgres_backup_storage": true,
+  "postgres_enable_high_availability": true,
   "send_traffic_to_maintenance_page": false,
   "account_replication_type": "GRS"
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -1,17 +1,19 @@
 module "postgres" {
   source = "./vendor/modules/aks//aks/postgres"
 
-  namespace                   = var.namespace
-  environment                 = var.environment
-  azure_resource_prefix       = var.azure_resource_prefix
-  service_name                = var.service_name
-  service_short               = var.service_short
-  config_short                = var.config_short
-  cluster_configuration_map   = module.cluster_data.configuration_map
-  use_azure                   = var.deploy_azure_backing_services
-  azure_enable_monitoring     = var.enable_monitoring
-  azure_enable_backup_storage = var.enable_postgres_backup_storage
-  server_version              = "16"
+  namespace                      = var.namespace
+  environment                    = var.environment
+  azure_resource_prefix          = var.azure_resource_prefix
+  service_name                   = var.service_name
+  service_short                  = var.service_short
+  config_short                   = var.config_short
+  cluster_configuration_map      = module.cluster_data.configuration_map
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_monitoring        = var.enable_monitoring
+  azure_enable_backup_storage    = var.enable_postgres_backup_storage
+  azure_sku_name                 = var.postgres_flexible_server_sku
+  azure_enable_high_availability = var.postgres_enable_high_availability
+  server_version                 = "16"
 }
 
 module "redis-cache" {

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -66,6 +66,20 @@ variable "evidence_container_retention_in_days" {
   default     = 7
   type        = number
 }
+variable "postgres_flexible_server_sku" {
+  default = "B_Standard_B1ms"
+}
+variable "app_replicas" {
+  description = "number of replicas of the web app"
+  default     = 1
+}
+variable "worker_replicas" {
+  description = "number of replicas of the workers"
+  default     = 1
+}
+variable "postgres_enable_high_availability" {
+  default = false
+}
 
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"


### PR DESCRIPTION
### Context

Adding additional infra necessary for production environment, including HA for Postgres, added replicas for web app deployment and worker application deployment.

### Changes proposed in this pull request

Adding additional infra necessary for production environment, including HA for Postgres, added replicas for web app deployment and worker application deployment.

### Guidance to review

Dev team to validate production infra and test worker functionality.

### Link to Trello card

https://trello.com/c/S5we2pWZ/2027-aytq-production-environment

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
