### PR TITLE
2070 Enabling monitoring

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -2,7 +2,7 @@
   "cluster": "production",
   "namespace": "tra-production",
   "evidence_container_retention_in_days": 30,
-  "enable_monitoring": false,
+  "enable_monitoring": true,
   "app_replicas": 2,
   "worker_replicas": 1,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",


### PR DESCRIPTION
### Context

Enabling monitoring for different components of AYTQ deployment, including postgres and redis.

### Changes proposed in this pull request

Set enable monitoring flag to true for production environment to enable azure monitor to scrape metrics from production level components.

### Guidance to review

Check azure monitor for action group related to aytq.

### Link to Trello card

https://trello.com/c/WvAbNtPA/2070-aytq-azure-monitoring

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
