### PR TITLE
Add annex to terms and conditions

### DIFF
--- a/app/views/check_records/terms_and_conditions/show.html.erb
+++ b/app/views/check_records/terms_and_conditions/show.html.erb
@@ -205,6 +205,70 @@
 
     <p class="govuk-body">Website: <a class="govuk-link" href="https://www.gov.uk/government/organisations/teaching-regulation-agency">https://www.gov.uk/government/organisations/teaching-regulation-agency</a></p>
 
+    <h1 class="govuk-heading-l">Annex</h1>
+    <h2 class ="govuk-heading-m">
+      1. Introduction
+    </h2>
+    <p class="govuk-body">If there is no data sharing agreement or memorandum of understanding (as applicable) in place between DfE and your organisation, the provisions of this Annex together with the Terms set out above shall apply to your access and use of the Service.</p>
+    <h2 class ="govuk-heading-m">
+      2. Data Protection
+    </h2>
+    <p class="govuk-body">2.1 By agreeing to these Terms, You confirm and acknowledge that:</p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body">Your organisation remains responsible for its compliance obligations under the Data Protection Legislation;</li>
+
+      <li class="govuk-body">You are only permitted to access the Service and process the Personal Data for the purposes set out in Clause 1.7, your access is on a strictly need-to-know basis and shall be for no longer than is necessary. If any Personal Data is retained by You or your organisation that retention must at all times comply with Data Protection Legislation;</li>
+
+      <li class="govuk-body">Your organisation has implemented and will maintain appropriate technical and organisational security measures to ensure that all Personal Data are sufficiently protected against any Personal Data Breach (as defined in Data Protection Legislation) and that the requirements of Article 32 of the UK GDPR are met at all times;</li>
+
+      <li class="govuk-body">You will take all necessary precautions to preserve both the integrity and security of the Personal Data You process as well as prevent any corruption or loss of any Personal Data (or any part thereof);</li>
+
+      <li class="govuk-body">You and your organisation will remain responsible for dealing with and responding to:
+        <ol type="i" class="govuk-body">
+          <li class="govuk-body">any Subject Access Request (or purported Subject Access Request, as defined in Data Protection Legislation);</li>
+          <li class="govuk-body">other requests, complaint or communication from a Data Subject (as defined in Data Protection Legislation); </li>
+          <li class="govuk-body">any communication from the Information Commissioner's Office (or such other regulatory authority); </li>
+          <li class="govuk-body">any request from a third party to disclose Personal Data where compliance with such request is required or purported to be required by applicable law</li>
+        </ol>
+        relating to your organisation's obligations under the Data Protection Legislation, unless otherwise agreed with DfE;
+      </li>
+
+      <li class="govuk-body">You shall promptly report to DfE any circumstance of which You become aware which may:
+        <ol type="i" class="govuk-body">
+          <li class="govuk-body">mean that these Terms have not been complied with;</li>
+          <li class="govuk-body">cause DfE to breach the Data Protection Legislation as a result of Processing (as defined in Data Protection Legislation) carried out in connection with these Terms; and</li>
+          <li class="govuk-body">mean that there has been unauthorised Processing of any Personal Data under these Terms.</li>
+        </ol>
+      </li>
+
+      <li class="govuk-body">You are responsible for any digital, downloaded, or saved copies of data or other content You access through the Service; </li>
+
+      <li class="govuk-body">You will ensure that Data Subjects are aware of how You and your organisation use their data through the Service, including but not limited to, making available a privacy notice that details your use of the Service;</li>
+
+      <li class="govuk-body">No transfer of Personal Data outside of the United Kingdom shall take place (or be attempted) without the prior written consent of DfE; </li>
+
+      <li class="govuk-body">You agree that where any Personal Data contains information relating to the racial or ethnic origin, physical or mental health, sexual orientation, gender identity, religion/belief, biometric information, trade union membership, political or philosophical beliefs of an individual these are special categories of personal data (as defined in Data Protection Legislation) or are required to be treated as special categories of personal data under these Terms.</li>
+    </ol>
+    <h2 class ="govuk-heading-m">
+      3. Records
+    </h2>
+
+    <p class="govuk-body">You shall maintain complete and accurate records and information to demonstrate your compliance with these Terms and Data Protection Legislation.</p>
+
+    <h2 class ="govuk-heading-m">
+      4. General
+    </h2>
+
+    <p class="govuk-body">These Terms may not be assigned, varied or otherwise transferred, in whole, or in part, by You without the prior written consent of DfE. </p>
+
+    <p class="govuk-body">These Terms are between You and us and nobody else can enforce them.</p>
+
+    <p class="govuk-body">These Terms contain the whole agreement and understanding between You and DfE and supersede any prior written, or oral, agreement which may have been entered into between us relation to its subject matter.</p>
+
+    <p class="govuk-body">If we delay in enforcing these Terms (or any of them), DfE will still be entitled to enforce them later.</p>
+
+    <p class="govuk-body">If a court decides that any of these Terms are invalid, the remainder of the Terms will still apply.</p>
+
     <% if current_dsi_user %>
       <%= form_with url: check_records_terms_and_conditions_path, method: :patch do |f| %>
         <%= f.govuk_submit "Accept" %>


### PR DESCRIPTION
### Context

As part of the terms and conditions, there should be an annex covering specific information concerning the data protection regulations

### Changes proposed in this pull request

Add annex to terms and conditions. 

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
