### PR TITLE
Fix issue where trn starts with zero

### DIFF
--- a/app/models/bulk_search.rb
+++ b/app/models/bulk_search.rb
@@ -18,9 +18,9 @@ class BulkSearch
 
   def not_found
     @not_found ||= csv.map { |row|
-      next if results.any? { |teacher| teacher.trn == row["TRN"] }
+      next if results.any? { |teacher| teacher.trn == sanitise_trn(row["TRN"]) }
 
-      Hashie::Mash.new(trn: row["TRN"], date_of_birth: Date.parse(row["Date of birth"]))
+      Hashie::Mash.new(trn: sanitise_trn(row["TRN"]), date_of_birth: Date.parse(row["Date of birth"]))
     }.compact
   end
 
@@ -74,7 +74,8 @@ class BulkSearch
 
   def response
     @response ||= begin
-      queries = csv.map { |row| { trn: row["TRN"], dateOfBirth: Date.parse(row["Date of birth"]) } }.compact
+      queries = csv.map { |row|
+ { trn: sanitise_trn(row["TRN"]), dateOfBirth: Date.parse(row["Date of birth"]) } }.compact
       find_all(queries)
     end
   end
@@ -89,5 +90,10 @@ class BulkSearch
     @search_client ||= QualificationsApi::Client.new(
       token: ENV["QUALIFICATIONS_API_FIXED_TOKEN"]
     )
+  end
+
+  def sanitise_trn(trn)
+    # Ensure the TRN is exactly 7 characters by padding with leading zeros, csv formatting can remove leading zeros
+    trn.to_s.rjust(7, '0')
   end
 end


### PR DESCRIPTION
### Context

If the TRN starts with 0 it doesn’t find the csv removes the preceding zero as it is formatted as a number. 

We should pad trns that are too short with preceding zeros to fix this issue; and we should update the formatting on the example csv so that this doesnt happen.



### Changes proposed in this pull request

Pad trns that are too short with preceding zeros.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
