### PR TITLE
Adjust induction check to work on the find API

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -89,11 +89,11 @@ module QualificationsApi
     end
 
     def passed_induction?
-      api_data.induction&.status_description == "Pass"
+      api_data.induction&.status == "Pass" || api_data.induction_status&.status == "Pass"
     end
 
     def exempt_from_induction?
-      api_data.induction&.status == "Exempt"
+      api_data.induction&.status == "Exempt" || api_data.induction_status&.status == "Exempt"
     end
 
     def no_induction?

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component do
     end
 
     context "when teacher has passed induction" do
-      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status_description' => 'Pass' }}) }
+      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status' => 'Pass' }}) }
 
       it { is_expected.to have_text("Passed induction") }
     end
 
     context "when teacher has failed induction" do
-      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status_description' => 'Fail' }}) }
+      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status' => 'Fail' }}) }
 
       it { is_expected.not_to have_text("Passed induction") }
     end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     let(:teacher) { described_class.new(api_data) }
 
     context "induction status is 'Pass'" do
-      let(:api_data) { { "induction" => { "status_description" => "Pass", } } }
+      let(:api_data) { { "induction" => { "status" => "Pass", } } }
 
       it "returns true" do
         expect(teacher.passed_induction?).to eq true


### PR DESCRIPTION
### Context

Induction check on the bulk upload component hits the find API rather than the Qualifications API . Due to differences in naming between the two API's ('induction' on qualifications and 'induction_status' on find) the call was succeeding in the Quals case and failing in the find case. A new "FindAPI" module should be created moving forward in order to handle the different API layouts. This fix will resolve the issue in the meantime.

### Changes proposed in this pull request

Permit both 'induction' and 'induction_status' for the induction check.

### Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/7hbGCIHY/391-ctr-bulk-search-summary-tag-information-isnt-pulling-through-accurately)
### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
