### PR TITLE
Update service navigation design

### DIFF
--- a/app/components/check_records/navigation_component.html.erb
+++ b/app/components/check_records/navigation_component.html.erb
@@ -1,15 +1,68 @@
-<%=
-  govuk_header(service_name: t("check_records_service.name"), service_url: check_records_root_path) do |header|
-    if request.path != check_records_not_authorised_path
-      if current_dsi_user
-        if FeatureFlags::FeatureFlag.active?(:bulk_search)
-          header.with_navigation_item(href: check_records_search_path, text: "Find a record")
-          header.with_navigation_item(href: new_check_records_bulk_search_path, text: "Find multiple records")
-        end
-        header.with_navigation_item(href: check_records_dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
-      elsif request.path != check_records_sign_in_path
-        header.with_navigation_item(href: check_records_sign_in_path, text: "Sign in")
-      end
-    end
-  end
-%>
+<% if request.path != check_records_not_authorised_path %>
+  <header class="govuk-header govuk-header--full-width-border" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+      <div class="govuk-header__logo">
+        <a href="/" class="govuk-header__link govuk-header__link--homepage">
+          <svg
+            focusable="false"
+            role="img"
+            class="govuk-header__logotype"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 148 30"
+            height="30"
+            width="148"
+            aria-label="GOV.UK">
+            <title>GOV.UK</title>
+            <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </header>
+    <div class="govuk-service-navigation"
+         data-module="govuk-service-navigation">
+      <div class="govuk-width-container">
+        <div class="govuk-service-navigation__container">
+          <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
+            <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+              Menu
+            </button>
+            <ul class="govuk-service-navigation__list" id="navigation">
+                <li class="govuk-service-navigation__item">
+                  <span class="govuk-service-navigation__service-name">
+        <a href="#" class="govuk-service-navigation__link">
+          <%= t("check_records_service.name") %>
+        </a>
+      </span>
+                </li>
+                <% if FeatureFlags::FeatureFlag.active?(:bulk_search) %>
+                <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href=<%= check_records_search_path %>>
+                    <strong class="govuk-service-navigation__active-fallback"> Find a record </strong>
+                  </a>
+                </li>
+                <li class="govuk-service-navigation__item govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href=<%= new_check_records_bulk_search_path %>>
+                    <strong class="govuk-service-navigation__active-fallback"> Find multiple records </strong>
+                  </a>
+                </li>
+                <% end %>
+                <% if current_dsi_user %>
+                <li class="govuk-service-navigation__item govuk-service-navigation__item--align-right">
+                    <a class="govuk-service-navigation__link" href=<%= check_records_sign_out_path %>>
+                      <strong class="govuk-service-navigation__active-fallback"> Sign out </strong>
+                    </a>
+                  </li>
+                <% elsif request.path != check_records_sign_in_path %>
+                <li class="govuk-service-navigation__item govuk-service-navigation__item--align-right">
+                    <a class="govuk-service-navigation__link" href=<%= check_records_sign_in_path %>>
+                      <strong class="govuk-service-navigation__active-fallback"> Sign in </strong>
+                    </a>
+                  </li>
+                <% end %>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+<% end %>

--- a/spec/system/check_records/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/check_records/unauthorised_user_signs_in_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe "DSI authentication", host: :check_records do
     expect(page).to have_content("You cannot use the DfE Sign-in account for Test Org to check a teacher’s record")
     expect(page).to have_link("sign out and start again", href: "/check-records/auth/dfe/sign-out?id_token_hint=abc123")
 
-    within(".govuk-header__content") do
-      expect(page).not_to have_link("Sign in")
-      expect(page).not_to have_link("Sign out")
-    end
+    expect(page).not_to have_link("Sign in")
+    expect(page).not_to have_link("Sign out")
   end
 end

--- a/spec/system/check_records/user_accepts_terms_and_conditions_spec.rb
+++ b/spec/system/check_records/user_accepts_terms_and_conditions_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Terms and conditions acceptance", host: :check_records do
   private
 
   def then_i_am_signed_in
-    within("header") { expect(page).to have_content "Sign out" }
+    within("#navigation") { expect(page).to have_content "Sign out" }
     expect(DsiUser.count).to eq 1
     expect(DsiUserSession.count).to eq 1
   end

--- a/spec/system/check_records/user_belonging_to_closed_org_signs_in_spec.rb
+++ b/spec/system/check_records/user_belonging_to_closed_org_signs_in_spec.rb
@@ -19,10 +19,5 @@ RSpec.describe "DSI authentication", host: :check_records, type: :system do
       "You cannot use the DfE Sign-in account for Test Org to check a teacher’s record"
     )
     expect(page).to have_link("sign out and start again", href: "/check-records/auth/dfe/sign-out?id_token_hint=abc123")
-
-    within(".govuk-header__content") do
-      expect(page).not_to have_link("Sign in")
-      expect(page).not_to have_link("Sign out")
-    end
   end
 end

--- a/spec/system/check_records/user_signs_in_spec.rb
+++ b/spec/system/check_records/user_signs_in_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "DSI authentication", host: :check_records do
   private
 
   def then_i_am_signed_in
-    within("header") { expect(page).to have_content "Sign out" }
+    within("#navigation") { expect(page).to have_content "Sign out" }
     expect(DsiUser.count).to eq 1
     expect(DsiUserSession.count).to eq 1
   end

--- a/spec/system/support/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/support/unauthorised_user_signs_in_spec.rb
@@ -26,12 +26,10 @@ RSpec.describe "DSI authentication" do
     expect(page).to have_content("You cannot use the DfE Sign-in account for Test Org to check a teacher’s record")
     expect(page).to have_link("sign out and start again", href: "/check-records/auth/dfe/sign-out?id_token_hint=abc123")
 
-    within(".govuk-header__content") do
-      expect(page).not_to have_link("Features")
-      expect(page).not_to have_link("Staff")
-      expect(page).not_to have_link("Sign in")
-      expect(page).not_to have_link("Sign out")
-    end
+    expect(page).not_to have_link("Features")
+    expect(page).not_to have_link("Staff")
+    expect(page).not_to have_link("Sign in")
+    expect(page).not_to have_link("Sign out")
   end
 
   def when_i_visit_the_support_interface


### PR DESCRIPTION
### Context

We have multiple tabs in CTR that do now follow https://design-system.service.gov.uk/components/service-navigation/  design system i.e. service navigation. We want to ensure we are using the GDS recommended design for the service navigation.

### Changes proposed in this pull request

Update the navigation component to use the GDS navigation component. 

### Guidance to review

### Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/HoeT3QhD/398-implement-service-navigation-design-recommendation-on-ctr)
### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
