### PR TITLE
Adding GCloud federated authentication for teaching-qualifications

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -33,6 +33,11 @@ runs:
       with:
         azure-credentials: ${{ inputs.azure-credentials }}
 
+    - uses: google-github-actions/auth@v2
+      with:
+        project_id: teaching-qualifications
+        workload_identity_provider: projects/708780292301/locations/global/workloadIdentityPools/access-your-teaching-qualificati/providers/access-your-teaching-qualificati
+
     - name: Terraform Apply
       shell: bash
       run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -46,6 +46,9 @@ jobs:
     needs: [build_image]
     environment:
       name: review
+    permissions:
+      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +102,8 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +124,8 @@ jobs:
     environment:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     environment: review
+    permissions:
+      pull-requests: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,6 +72,11 @@ jobs:
       - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: teaching-qualifications
+          workload_identity_provider: projects/708780292301/locations/global/workloadIdentityPools/access-your-teaching-qualificati/providers/access-your-teaching-qualificati
 
       - name: Terraform Destroy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ fetch_config.rb
 terraform/application/vendor
 terraform/domains/infrastructure/vendor
 terraform/domains/environment_domains/vendor
+bin/terrafile
 
 # Active Storage folder
 storage/

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -4,6 +4,7 @@ DfE::Analytics.configure do |config|
   config.queue = :analytics
   config.environment = HostingEnvironment.environment_name
   config.entity_table_checks_enabled = true
+  config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 
   config.enable_analytics =
     proc do

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,21 +1,21 @@
 locals {
   aytq_env_vars = merge(try(local.infrastructure_secrets, null),
     {
-      AZURE_STORAGE_ACCOUNT_NAME            = azurerm_storage_account.evidence.name,
-      AZURE_STORAGE_ACCESS_KEY              = azurerm_storage_account.evidence.primary_access_key,
-      AZURE_STORAGE_CONTAINER               = azurerm_storage_container.uploads.name
-      BIGQUERY_DATASET                      = "events_${var.environment_name}",
-      BIGQUERY_PROJECT_ID                   = "teaching-qualifications",
-      BIGQUERY_TABLE_NAME                   = "events",
-      CHECK_RECORDS_DOMAIN                  = var.check_domain != null ? "https://${var.check_domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
-      ConnectionStrings__Redis              = azurerm_redis_cache.redis.primary_connection_string
-      DATABASE_PASSWORD                     = local.infrastructure_secrets.POSTGRES_ADMIN_PASSWORD
-      DATABASE_URL                          = "postgres://postgres@${local.postgres_server_name}.postgres.database.azure.com:5432"
-      DOCKER_REGISTRY_SERVER_URL            = "https://ghcr.io",
-      HOSTING_DOMAIN                        = var.domain != null ? "https://${var.domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
-      HOSTING_ENVIRONMENT_NAME              = local.hosting_environment
-      RAILS_SERVE_STATIC_FILES              = "true"
-      REDIS_URL                             = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:${azurerm_redis_cache.redis.ssl_port}/0"
+      AZURE_STORAGE_ACCOUNT_NAME = azurerm_storage_account.evidence.name,
+      AZURE_STORAGE_ACCESS_KEY   = azurerm_storage_account.evidence.primary_access_key,
+      AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
+      BIGQUERY_DATASET           = "events_${var.environment_name}",
+      BIGQUERY_PROJECT_ID        = "teaching-qualifications",
+      BIGQUERY_TABLE_NAME        = "events",
+      CHECK_RECORDS_DOMAIN       = var.check_domain != null ? "https://${var.check_domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
+      ConnectionStrings__Redis   = azurerm_redis_cache.redis.primary_connection_string
+      DATABASE_PASSWORD          = local.infrastructure_secrets.POSTGRES_ADMIN_PASSWORD
+      DATABASE_URL               = "postgres://postgres@${local.postgres_server_name}.postgres.database.azure.com:5432"
+      DOCKER_REGISTRY_SERVER_URL = "https://ghcr.io",
+      HOSTING_DOMAIN             = var.domain != null ? "https://${var.domain}" : "https://${local.aytq_web_app_name}.azurewebsites.net"
+      HOSTING_ENVIRONMENT_NAME   = local.hosting_environment
+      RAILS_SERVE_STATIC_FILES   = "true"
+      REDIS_URL                  = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:${azurerm_redis_cache.redis.ssl_port}/0"
     }
   )
 }

--- a/terraform/application/.terraform.lock.hcl
+++ b/terraform/application/.terraform.lock.hcl
@@ -44,6 +44,26 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.6.0"
+  constraints = "6.6.0"
+  hashes = [
+    "h1:BOwY9eXbFeMU+DC1L8RW1CfcGPIiF1rMxNAxjssqNgk=",
+    "zh:0c181f9b9f0ab81731e5c4c2d20b6d342244506687437dad94e279ef2a588f68",
+    "zh:12a4c333fc0ba670e87f09eb574e4b7da90381f9929ef7c866048b6841cc8a6a",
+    "zh:15c277c2052df89429051350df4bccabe4cf46068433d4d8c673820d9756fc00",
+    "zh:35d1663c81b81cd98d768fa7b80874b48c51b27c036a3c598a597f653374d3c8",
+    "zh:56b268389758d544722a342da4174c486a40ffa2a49b45a06111fe31c6c9c867",
+    "zh:abd3ea8c3a62928ba09ba7eb42b52f53e682bd65e92d573f1739596b5a9a67b1",
+    "zh:be55a328d61d9db58690db74ed43614111e1105e5e52cee15acaa062df4e233e",
+    "zh:ce2317ce9fd02cf14323f9e061c43a415b4ae9b3f96046460d0e6b6529a5aa6c",
+    "zh:d54a6d8e031c824f1de21b93c3e01ed7fec134b4ae55223d08868c6168c98e47",
+    "zh:d8c6e33b5467c6eb5a970adb251c4c8194af12db5388cff9d4b250294eae4daa",
+    "zh:f49e4cc9c0b55b3bec7da64dd698298345634a5df372228ee12aa45e57982f64",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.32.0"
   constraints = "2.32.0"

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -23,11 +23,11 @@ module "application_configuration" {
     BIGQUERY_TABLE_NAME        = "events"
     RAILS_SERVE_STATIC_FILES   = "true"
   }
-  secret_variables = {
+  secret_variables = merge({
     DATABASE_URL             = module.postgres.url
     REDIS_URL                = module.redis-cache.url
     AZURE_STORAGE_ACCESS_KEY = azurerm_storage_account.evidence.primary_access_key
-  }
+  }, local.federated_auth_secrets)
 }
 
 module "web_application" {
@@ -70,4 +70,5 @@ module "worker_application" {
   replicas                   = var.worker_replicas
   docker_image               = var.docker_image
   enable_logit               = true
+  enable_gcp_wif             = var.enable_dfe_analytics_federated_auth
 }

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -3,5 +3,6 @@
   "namespace": "tra-development",
   "deploy_azure_backing_services": false,
   "enable_postgres_ssl": false,
-  "evidence_container_retention_in_days": 1
+  "evidence_container_retention_in_days": 1,
+  "enable_dfe_analytics_federated_auth": true
 }

--- a/terraform/application/dfe_analytics.tf
+++ b/terraform/application/dfe_analytics.tf
@@ -1,0 +1,15 @@
+provider "google" {
+  project = "teaching-qualifications"
+}
+
+module "dfe_analytics" {
+  count  = var.enable_dfe_analytics_federated_auth ? 1 : 0
+  source = "./vendor/modules/aks//aks/dfe_analytics"
+
+  azure_resource_prefix = var.azure_resource_prefix
+  cluster               = var.cluster
+  namespace             = var.namespace
+  service_short         = var.service_short
+  environment           = var.environment
+  gcp_dataset           = "events_${var.config}"
+}

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -10,8 +10,8 @@ terraform {
       version = "2.32.0"
     }
     statuscake = {
-     source  = "StatusCakeDev/statuscake"
-     version = "2.2.2"
+      source  = "StatusCakeDev/statuscake"
+      version = "2.2.2"
     }
   }
   backend "azurerm" {
@@ -42,5 +42,5 @@ provider "kubernetes" {
 }
 
 provider "statuscake" {
- api_token = module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN
+  api_token = module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -89,6 +89,11 @@ variable "postgres_enable_high_availability" {
   default = false
 }
 
+variable "enable_dfe_analytics_federated_auth" {
+  description = "Create the resources in Google cloud for federated authentication and enable in application"
+  default     = false
+}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 
@@ -105,4 +110,8 @@ locals {
   # s189paytqevidpdsa vs s189daytqevidpr12345sa
   storage_account_environment   = var.config == var.environment ? var.config_short : replace(var.environment, "-", "")
   evidence_storage_account_name = "${local.azure_resource_prefix_short}aytqevid${local.storage_account_environment}sa"
+
+  federated_auth_secrets = var.enable_dfe_analytics_federated_auth ? {
+    GOOGLE_CLOUD_CREDENTIALS = module.dfe_analytics[0].google_cloud_credentials
+  } : {}
 }


### PR DESCRIPTION
### Context

This change is to implement the dfe analytics module which will connect the service worker deployment using workload identity federation.

### Changes proposed in this pull request

Adding the dfe_analytics module to the Terraform repo. Adding id-token write permissions to the repo aswell as adding a secret config maps to fetch the google credentials from the dfe analytics module, with dfe analytics enabled in the review environment.

### Guidance to review

Developer to validate via the Google Cloud BigQuery workspace project that they can run BigQuery against the service app.

https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/runs/12164162777/job/33925228943

### Link to Trello card

https://trello.com/c/Nxs3UM9M/2143-aytq-migrate-to-gcp-wif

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
