### PR TITLE
2143 aytq migrate to gcp wif

### DIFF
--- a/terraform/application/config/preprod.tfvars.json
+++ b/terraform/application/config/preprod.tfvars.json
@@ -1,5 +1,6 @@
 {
   "cluster": "test",
   "namespace": "tra-test",
-  "evidence_container_retention_in_days": 1
+  "evidence_container_retention_in_days": 1,
+  "enable_dfe_analytics_federated_auth": true
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -10,6 +10,7 @@
   "postgres_enable_high_availability": true,
   "send_traffic_to_maintenance_page": false,
   "account_replication_type": "GRS",
+  "enable_dfe_analytics_federated_auth": true,
   "statuscake_alerts": {
     "website_url": [
       "https://access-your-teaching-qualifications.education.gov.uk/health",

--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -2,5 +2,6 @@
   "cluster": "test",
   "namespace": "tra-test",
   "evidence_container_retention_in_days": 1,
-  "enable_postgres_backup_storage": true
+  "enable_postgres_backup_storage": true,
+  "enable_dfe_analytics_federated_auth": true
 }


### PR DESCRIPTION
### Context

To add WIF to all environments

Adding analytics module as well as references to correct workspace for Analytics.

### Guidance to review

You can send an api call via the AYTQ homepage URLs for each environment and validate the activity has been logged in BigQuery via - The table name will need to be changed per environment.

SELECT * FROM `teaching-qualifications.events_preprod.events` WHERE TIMESTAMP_TRUNC(occurred_at, DAY) = TIMESTAMP("2024-12-11") order by occurred_at desc;

<img width="1172" alt="Screenshot 2024-12-11 at 12 11 00" src="https://github.com/user-attachments/assets/e937adea-966c-4913-8f47-fe42481bbf80">


### Link to Trello card

https://trello.com/c/Nxs3UM9M/2143-aytq-migrate-to-gcp-wif

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
