### PR TITLE
Remove induction history from show page

### DIFF
--- a/app/components/induction_summary_component.html.erb
+++ b/app/components/induction_summary_component.html.erb
@@ -4,8 +4,5 @@
   </div>
   <div class="govuk-summary-card__content">
     <%= render GovukComponent::SummaryListComponent.new(rows:) if rows.any? %>
-    <%= render GovukComponent::DetailsComponent.new(classes: detail_classes, summary_text: "Induction history") do %>
-      <%= render GovukComponent::SummaryListComponent.new(classes: list_classes, rows: history) if history.any? %>
-    <% end %>
   </div>
 </div>

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -36,18 +36,6 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
 
       expect(rows[2].css(".govuk-summary-list__key").text).to eq("Certificate")
       expect(rows[2].css(".govuk-summary-list__value").text).to eq("Download Induction certificate")
-
-      expect(rows[3].css(".govuk-summary-list__key").text).to eq("Appropriate body")
-      expect(rows[3].css(".govuk-summary-list__value").text).to eq("Induction body")
-
-      expect(rows[4].css(".govuk-summary-list__key").text).to eq("Start date")
-      expect(rows[4].css(".govuk-summary-list__value").text).to eq(" 1 September 2022")
-
-      expect(rows[5].css(".govuk-summary-list__key").text).to eq("End date")
-      expect(rows[5].css(".govuk-summary-list__value").text).to eq(" 1 October 2022")
-
-      expect(rows[6].css(".govuk-summary-list__key").text).to eq("Number of terms")
-      expect(rows[6].css(".govuk-summary-list__value").text).to eq("1")
     end
 
     it "renders does not render empty component rows" do

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -34,10 +34,6 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Pass")
     expect(page).to have_content("1 October 2022")
     expect(page).to have_link("Download Induction certificate")
-    find("span", text: "Induction history").click
-    expect(page).to have_content("Induction body")
-    expect(page).to have_content("1 September 2022")
-    expect(page).to have_content("Number of terms\t1")
   end
 
   def and_my_induction_certificate_is_downloadable


### PR DESCRIPTION
### Context

As we are no longer consuming induction history from the Qualifications API; we should remove the component that renders them.

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
