### PR TITLE
Remove Npq from TRS api call

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -91,7 +91,6 @@ module QualificationsApi
             include: %w[
               Induction
               InitialTeacherTraining
-              NpqQualifications
               MandatoryQualifications
               Sanctions
               PreviousNames


### PR DESCRIPTION
### Context

Now that the NPQ API is being used to render certificates we should deprecate pulling them from the TRS API.
### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
