### PR TITLE
Display QTLS Flag for SET records

### DIFF
--- a/app/components/induction_summary_component.html.erb
+++ b/app/components/induction_summary_component.html.erb
@@ -1,8 +1,14 @@
-<div class="govuk-summary-card">
-  <div class="govuk-summary-card__title-wrapper">
-    <h2 class="govuk-summary-card__title"><%= title %></h2>
-  </div>
-  <div class="govuk-summary-card__content">
-    <%= render GovukComponent::SummaryListComponent.new(rows:) if rows.any? %>
-  </div>
-</div>
+<% if rows.any?%>
+  <%= govuk_summary_card(title:) do |card| %>
+      <%= govuk_summary_list(rows:)%>
+      <% if qualification.qtls_applicable && qualification.set_membership_active %>
+          <hr class="govuk-section-break govuk-section-break--visible">
+          <p> </p>
+          <p>You will no longer be exempt from induction if your Society for Education and Training (SET) membership expires</p>
+      <% elsif qualification.qtls_applicable && !qualification.set_membership_active %>
+          <hr class="govuk-section-break govuk-section-break--visible">
+          <p> </p>
+          <%= govuk_warning_text(text: "You are no longer exempt from induction because your Society for Education and Training (SET) membership expired") %>
+      <% end %>
+  <% end %>
+<% end %>

--- a/app/components/qualification_summary_component.html.erb
+++ b/app/components/qualification_summary_component.html.erb
@@ -1,1 +1,14 @@
-<%= render GovukComponent::SummaryListComponent.new(rows:, card: { title: }) if rows.any? %>
+<% if rows.any? %>
+    <%= govuk_summary_card(title:) do |card| %>
+        <%= govuk_summary_list(rows:)%>
+        <% if qualification.qtls_applicable && qualification.set_membership_active %>
+          <hr class="govuk-section-break govuk-section-break--visible">
+            <p> </p>
+            <p>You will no longer have QTS via QTLS status if your Society for Education and Training (SET) membership expires</p>
+        <% elsif qualification.qtls_applicable && !qualification.set_membership_active %>
+          <hr class="govuk-section-break govuk-section-break--visible">
+            <p> </p>
+            <%= govuk_warning_text(text: "You no longer have QTS via QTLS status because your Society for Education and Training (SET) membership expired") %>
+        <% end %>
+    <% end %>
+<% end %>

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -7,24 +7,29 @@ class QualificationSummaryComponent < ViewComponent::Base
 
   delegate :awarded_at,
            :certificate_type,
+           :qtls_applicable,
            :details,
            :id,
            :itt?,
+           :qts?,
+           :passed_induction,
+           :set_membership_active,
            :name,
            :type,
+           :qts_and_qtls,
            to: :qualification
 
   alias_method :title, :name
 
   def rows
     return itt_rows if itt?
+    if qts? && qtls_applicable
+      return qtls_rows
+    end
 
     @rows = [
-      { key: { text: "Awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } }
-    ]
-
-    if qualification.certificate_url
-      @rows << {
+      { key: { text: "Awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
+      {
         key: {
           text: "Certificate"
         },
@@ -37,7 +42,7 @@ class QualificationSummaryComponent < ViewComponent::Base
             )
         }
       }
-    end
+    ]
 
     if qualification.status_description
       @rows << {
@@ -67,7 +72,7 @@ class QualificationSummaryComponent < ViewComponent::Base
   def itt_rows
     return [] if details.end_date.blank?
 
-    [
+    @rows = [
       {
         key: {
           text: "Qualification"
@@ -134,5 +139,45 @@ class QualificationSummaryComponent < ViewComponent::Base
         }
       }
     ]
+  end
+
+  def qtls_rows
+    if set_membership_active || qts_and_qtls
+      [
+        {
+          key: { 
+            text: "Awarded"
+          }, 
+          value: {
+            text: qtls_awarded_at_text
+          }
+        },
+        {
+          key: {
+            text: "Certificate"
+          },
+          value: {
+            text:
+            link_to(
+              "Download #{type.to_s.upcase} certificate",
+              qualifications_certificate_path(type, format: :pdf),
+              class: "govuk-link"
+              )
+          }
+        }
+      ]
+    elsif !set_membership_active
+      [
+        { key: { text: "Status" }, value: { text: "No QTS" } },
+      ]
+    end
+  end
+
+  def qtls_awarded_at_text
+    if set_membership_active
+      "#{awarded_at&.to_fs(:long_uk)} via qualified teacher learning and skills (QTLS) status"
+    else 
+      awarded_at&.to_fs(:long_uk).to_s
+    end
   end
 end

--- a/app/controllers/check_records/teachers_controller.rb
+++ b/app/controllers/check_records/teachers_controller.rb
@@ -11,7 +11,7 @@ module CheckRecords
       end
     rescue QualificationsApi::TeacherNotFoundError
       respond_to do |format|
-        format.html { render "not_found" }
+        format.html { render "not_found", locals: { trn: SecureIdentifier.decode(params[:id]) } } 
         format.any { head :not_found }
       end
     end

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -81,9 +81,10 @@ module QualificationsApi
     end
 
     def teacher(trn: nil)
+      client.headers["X-Api-Version"] = "20250327"
       # If TRN is provided, we use an endpoint which expects a fixed Bearer token.
       # If TRN is blank, the token needs to come from an authenticated Identity user.
-      endpoint = (trn ? "v3/teachers/#{trn}" : "v3/teacher")
+      endpoint = (trn ? "v3/persons/#{trn}" : "v3/person")
       response =
         get(
           endpoint,
@@ -92,7 +93,7 @@ module QualificationsApi
               Induction
               InitialTeacherTraining
               MandatoryQualifications
-              Sanctions
+              Alerts
               PreviousNames
               PendingDetailChanges
             ].join(",")

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,7 +1,8 @@
 class Qualification
   include ActiveModel::Model
 
-  attr_accessor :awarded_at, :certificate_url, :name, :status_description, :type
+  attr_accessor :awarded_at, :name, :status_description, :type, :qtls_applicable, 
+:set_membership_active, :passed_induction, :qts_and_qtls
   attr_writer :details
 
   FORMATTED_QUALIFICATION_TEXT = {
@@ -28,12 +29,6 @@ class Qualification
     @details ||= Hashie::Mash.new({})
   end
 
-  def id
-    # QTS and EYTS certificate URLs don't contain an id
-    return nil if qts? || eyts?
-    @certificate_url&.split("/")&.last
-  end
-
   def induction?
     type == :induction
   end
@@ -56,6 +51,10 @@ class Qualification
 
   def eyts?
     type == :eyts
+  end
+
+  def qts_and_qtls?
+    false
   end
 
   def formatted_qualification_name

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -1,13 +1,13 @@
 class Sanction
-  attr_accessor :code, :start_date
+  attr_accessor :alert_type_id, :start_date
 
   def initialize(api_data)
-    @code = api_data[:code]
+    @alert_type_id = api_data[:alert_type][:alert_type_id]
     @start_date = api_data[:start_date].present? ? Date.parse(api_data[:start_date]) : nil
   end
 
   SANCTIONS = {
-    "A13" => {
+    "1a2b06ae-7e9f-4761-b95d-397ca5da4b13" => {
       title: "Suspension order with conditions",
       description: <<~DESCRIPTION.chomp
         Suspended by the General Teaching Council for England.
@@ -17,7 +17,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "A14" => {
+    "50508749-7a6b-4175-8538-9a1e55692efd" => {
       title: "Suspension order with conditions",
       description: <<~DESCRIPTION.chomp
         Suspended by the General Teaching Council for England.
@@ -27,7 +27,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "A18" => {
+    "a6fc9f2e-8923-4163-978e-93bd901d146f" => {
       title: "Registration order with conditions",
       description: <<~DESCRIPTION.chomp
         Given a registration order by the General Teaching Council for England.
@@ -37,7 +37,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "A1A" => {
+    "fa6bd220-61b0-41fc-9066-421b3b9d7885" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of unacceptable professional conduct.
@@ -47,7 +47,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A1B" => {
+    "e3658a61-bee2-4df1-9a26-e010681ee310" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of unacceptable professional conduct.
@@ -57,7 +57,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A20" => {
+    "d372fcfa-1c4a-4fed-84c8-4c7885575681" => {
       title: "Suspension order with conditions",
       description: <<~DESCRIPTION.chomp
         Suspended by the General Teaching Council for England.
@@ -67,7 +67,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "A21A" => {
+    "950d3eed-bef5-448a-b0f0-bf9c54f2103b" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of a criminal offence which is relevant to fitness to teach.
@@ -77,7 +77,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A21B" => {
+    "72e48b6a-e781-4bf3-910b-91f2d28f2eaa" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of a criminal offence which is relevant to their fitness to teach.
@@ -87,7 +87,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A3" => {
+    "3499860a-a0fb-43e3-878e-c226d14150b0" => {
       title: "Registration order with conditions",
       description: <<~DESCRIPTION.chomp
         Given a registration order by the General Teaching Council.
@@ -97,7 +97,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "A5A" => {
+    "c02bdc3a-7a19-4034-aa23-3a23c54e1d34" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of serious professional incompetence.
@@ -107,7 +107,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A5B" => {
+    "cac68337-3f95-4475-97cf-1381e6b74700" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the General Teaching Council for England because of serious professional incompetence.
@@ -117,7 +117,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "A7" => {
+    "1ebd1620-293d-4169-ba78-0b41a6413ad9" => {
       title: "Registration order with conditions",
       description: <<~DESCRIPTION.chomp
         Given a registration order by the General Teaching Council for England.
@@ -127,7 +127,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
       DESCRIPTION
     },
-    "B3" => {
+    "8ef92c14-4b1f-4530-9189-779ad9f3cefd" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching by the Secretary of State or an independent schools tribunal.
@@ -137,7 +137,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "C1" => {
+    "651e1f56-3135-4961-bd7e-3f7b2c75cb04" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching because they failed probation.
@@ -147,7 +147,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "C2" => {
+    "9fafaa80-f9f8-44a0-b7b3-cffedcbe0298" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching because they failed induction.
@@ -157,7 +157,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "C3" => {
+    "5ea8bb68-4774-4ad8-b635-213a0cdda4c3" => {
       title: "Restriction",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching because they failed probation.
@@ -165,7 +165,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "T1" => {
+    "ed0cd700-3fb2-4db0-9403-ba57126090ed	" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Found guilty of of serious misconduct.
@@ -175,7 +175,7 @@ class Sanction
         Check the [list of published decisions on GOV.UK](https://www.gov.uk/search/all?parent=&keywords=panel+outcome+misconduct&level_one_taxon=&manual=&organisations%5B%5D=teaching-regulation-agency&organisations%5B%5D=national-college-for-teaching-and-leadership&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest) for more details.
       DESCRIPTION
     },
-    "T2" => {
+    "a414283f-7d5b-4587-83bf-f6da8c05b8d5" => {
       title: "Interim prohibition order",
       description: <<~DESCRIPTION.chomp
         Prevented from teaching during an investigation for serious misconduct.
@@ -185,7 +185,7 @@ class Sanction
         Call the Teaching Regulation Agency (TRA) on 0207 593 5393 for more information.
       DESCRIPTION
     },
-    "T3" => {
+    "50feafbc-5124-4189-b06c-6463c7ebb8a8" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Deregistered by the General Teaching Council for Scotland because of serious misconduct.
@@ -193,7 +193,7 @@ class Sanction
         Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.
       DESCRIPTION
     },
-    "T4" => {
+    "a5bd4352-2cec-4417-87a1-4b6b79d033c2" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Deregistered by the Education Workforce Council, Wales because of serious misconduct.
@@ -203,7 +203,7 @@ class Sanction
         Email [registration@ewc.wales](mailto:registration@ewc.wales) for more information.
       DESCRIPTION
     },
-    "T5" => {
+    "5aa21b8f-2069-43c9-8afd-05b34b02505f" => {
       title: "Prohibition order",
       description: <<~DESCRIPTION.chomp
         Found guilty of serious misconduct by the General Teaching Council for Northern Ireland.
@@ -213,7 +213,7 @@ class Sanction
         Email [registration@gtcni.org.uk](mailto:registration@gtcni.org.uk) for more information.
       DESCRIPTION
     },
-    "T6" => {
+    "7924fe90-483c-49f8-84fc-674feddba848" => {
       title: "Found guilty of serious misconduct but not prevented from teaching",
       description: <<~DESCRIPTION.chomp
         Check the [list of published decisions on GOV.UK](https://www.gov.uk/search/all?parent=&keywords=panel+outcome+misconduct&level_one_taxon=&manual=&organisations%5B%5D=teaching-regulation-agency&organisations%5B%5D=national-college-for-teaching-and-leadership&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest) for more details.
@@ -222,14 +222,14 @@ class Sanction
   }.freeze
 
   def description
-    SANCTIONS[code][:description] if SANCTIONS[code]
+    SANCTIONS[alert_type_id][:description] if SANCTIONS[alert_type_id]
   end
 
   def title
-    SANCTIONS[code][:title] if SANCTIONS[code]
+    SANCTIONS[alert_type_id][:title] if SANCTIONS[alert_type_id]
   end
 
   def guilty_but_not_prohibited?
-    code == "T6"
+    alert_type_id == "7924fe90-483c-49f8-84fc-674feddba848"
   end
 end

--- a/app/views/qualifications/certificates/_qts.html.erb
+++ b/app/views/qualifications/certificates/_qts.html.erb
@@ -5,7 +5,16 @@
   <p class="text">This is to certify that: <strong><%= teacher.name %></strong></p>
   <p class="text">Teacher Reference Number: <strong><%= teacher.trn %></strong></p>
   <p>&#160;</p>
-  <% if teacher.exempt_from_induction? %>
+  <% if @qualification.set_membership_active %>
+    <p class="text">has attained qualified teacher status (QTS) via qualified teacher learning and <br/>
+    skills (QTLS) status, meets the requirements for employment in maintained schools and <br/> 
+    non-maintained special schools in England and is exempt from the requirements to serve a  <br/>
+    statutory induction period.</p>
+
+    <p class="text">You will lose QTS and your exemption from the requirement to serve induction if your <br/>
+      Society for Education and Training (SET) membership expires.
+    </p>
+  <% elsif teacher.exempt_from_induction? %>
   <p class="text">has attained qualified teacher status (QTS), meets the requirements for employment in <br/>
     maintained schools and non-maintained special schools in England and is exempt from the <br/>
     requirements to serve a statutory induction period.</p>

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
         name: "Induction summary",
         awarded_at: induction.end_date&.to_date,
         type: :itt,
+        qtls_applicable: false,
+        qts_and_qtls: false,
+        set_membership_active: false,
         details: induction
       )
     end

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.awarded&.to_date,
         name: "QTS",
+        passed_induction: true,
+        qtls_applicable: false,
+        qts_and_qtls: false,
+        set_membership_active: false,
         status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
@@ -94,7 +98,120 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
 
     it "renders the status description" do
-      expect(rows[1].text).to include(qualification.status_description)
+      expect(rows[1].text).to include("Certificate")
+    end
+
+    it "renders the status description" do
+      expect(rows[2].text).to include(qualification.status_description)
+    end
+  end
+
+  describe "rendering QTLS with Set membership active" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        name: "QTS",
+        passed_induction: true,
+        qtls_applicable: true,
+        qts_and_qtls: false,
+        set_membership_active: true,
+        status_description: "Qualified (trained in the UK)",
+        type: :qts,
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the awarded at date" do
+      expect(rows[0].text).to include(
+        "#{qualification.awarded_at.to_fs(:long_uk)} via qualified teacher learning and skills (QTLS) status"
+        )
+    end
+
+    it "renders the certificate link" do
+      expect(rows[1].text).to include("Download")
+    end
+  end
+
+  describe "rendering QTLS with Set membership expired" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        name: "QTS",
+        passed_induction: true,
+        qtls_applicable: true,
+        qts_and_qtls: false,
+        set_membership_active: false,
+        status_description: "Qualified (trained in the UK)",
+        type: :qts,
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the awarded at date" do
+      expect(rows[0].text).to include("No QTS")
+    end
+  end
+
+  describe "rendering QTS with QTLS" do
+    let(:fake_quals_data) do
+      Hashie::Mash.new(
+        quals_data(trn: "1234567")
+          .deep_transform_keys(&:to_s)
+          .deep_transform_keys(&:underscore)
+      )
+    end
+    let(:qualification) do
+      Qualification.new(
+        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        name: "QTS",
+        passed_induction: false,
+        qtls_applicable: true,
+        qts_and_qtls: false,
+        set_membership_active: true,
+        status_description: "Qualified (trained in the UK)",
+        type: :qts,
+      )
+    end
+    let(:component) { described_class.new(qualification:) }
+    let(:rendered) { render_inline(component) }
+    let(:rows) { rendered.css(".govuk-summary-list__row") }
+
+    it "renders the qualification name" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the awarded at date" do
+      expect(rows[0].text).to include(qualification.awarded_at.to_fs(:long_uk))
+    end
+
+    it "renders the certificate link" do
+      expect(rows[1].text).to include("Download QTS certificate")
     end
   end
 end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -405,24 +405,14 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     it { is_expected.to be_truthy }
 
-    context 'when there are possible restrictions' do
-      let(:api_data) do
-        {
-          "sanctions" => [
-            { "code" => "T6", "start_date" => "2024-01-01" },
-            { "possibleMatchOnChildrensBarredList" => true }
-          ]
-        }
-      end
-
-      it { is_expected.to be_falsey }
-    end
-
     context "when there are sanctions that are not prohibited" do
       let(:api_data) do
         {
-          "sanctions" => [
-            { "code" => "T6", "start_date" => "2024-01-01" },
+          "alerts" => [
+            "alert_type" => {
+              "alert_type_id" => "7924fe90-483c-49f8-84fc-674feddba848"
+            }, 
+            "start_date" => "2024-01-01" 
           ]
         }
       end
@@ -433,8 +423,10 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     context "when there are sanctions not listed in the Sanction model" do
       let(:api_data) do
         {
-          "sanctions" => [
-            { "code" => "T7", "start_date" => "2024-01-01" },
+          "alerts" => [
+            "alert_type" => {
+            "alert_type_id" => "241eeb78-fac7-4c77-8059-c12e93dc2fae", "start_date" => "2024-01-01" 
+          }
           ]
         }
       end
@@ -445,8 +437,11 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     context "when there are sanctions that are prohibited" do
       let(:api_data) do
         {
-          "sanctions" => [
-            { "code" => "A13", "start_date" => "2024-01-01" },
+          "alerts" => [
+            "alert_type" =>  {
+              "alert_type_id" => "1a2b06ae-7e9f-4761-b95d-397ca5da4b13"
+            },
+            "start_date" => "2024-01-01" 
           ]
         }
       end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -16,28 +16,6 @@ RSpec.describe Qualification, type: :model do
     end
   end
 
-  describe "#id" do
-    let(:type) { :npq }
-    subject { qualification.id }
-
-    let(:qualification) { described_class.new(certificate_url:, type:) }
-    let(:certificate_url) { "https://example.com/1234" }
-
-    it { is_expected.to eq("1234") }
-
-    context "when certificate url is not present" do
-      let(:certificate_url) { nil }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when certificate type is qts" do
-      let(:type) { :qts }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
   describe "#induction?" do
     subject { qualification.induction? }
 

--- a/spec/models/sanction_spec.rb
+++ b/spec/models/sanction_spec.rb
@@ -3,33 +3,35 @@ require 'rails_helper'
 RSpec.describe Sanction, type: :model do
   let(:api_data) do
     {
-      code:,
+      alert_type: {
+        alert_type_id:,
+      },
       start_date:
     }
   end
-  let(:code) { "A13" }
+  let(:alert_type_id) { "1a2b06ae-7e9f-4761-b95d-397ca5da4b13" }
   let(:start_date) { "2020-10-25" }
-  let(:sanction) { described_class.new(api_data) }
+  let(:alert) { described_class.new(api_data) }
 
   describe '#title' do
-    subject { sanction.title }
+    subject { alert.title }
 
     context 'when type exists in SANCTIONS' do
       it { is_expected.to eq('Suspension order with conditions') }
     end
 
     context 'when type does not exist in SANCTIONS' do
-      let(:code) { "Z99" }
+      let(:alert_type_id) { "Z99" }
 
       it { is_expected.to be_nil }
     end
   end
 
   describe '#description' do
-    subject(:description) { sanction.description }
+    subject(:description) { alert.description }
 
     context 'when type exists in SANCTIONS' do
-      let(:code) { "A13" }
+      let(:alert_type_id) { "1a2b06ae-7e9f-4761-b95d-397ca5da4b13" }
       
       it "returns the description as markdown" do
         expect(description)
@@ -38,7 +40,7 @@ RSpec.describe Sanction, type: :model do
     end
 
     context 'when type does not exist in SANCTIONS' do
-      let(:code) { "Z99" }
+      let(:alert_type_id) { "0000000-7e9f-4761-b95d-0000000000" }
 
       it { is_expected.to be_nil }
     end
@@ -46,7 +48,7 @@ RSpec.describe Sanction, type: :model do
 
 
   describe "start_date" do
-    subject { sanction.start_date }
+    subject { alert.start_date }
 
     it { is_expected.to eq(Date.parse(start_date)) }
 

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -4,7 +4,7 @@ require_relative "fake_qualifications_data_with_nulling"
 class FakeQualificationsApi < Sinatra::Base
   include FakeQualificationsData
 
-  get "/v3/teacher" do
+  get "/v3/person" do
     content_type :json
 
     case bearer_token
@@ -55,7 +55,7 @@ class FakeQualificationsApi < Sinatra::Base
     end
   end
 
-  get "/v3/teachers/:trn" do
+  get "/v3/persons/:trn" do
     content_type :json
 
     trn = params[:trn]
@@ -154,7 +154,7 @@ class FakeQualificationsApi < Sinatra::Base
         { first_name: "Terry", last_name: "Jones", middle_name: "" },
         { first_name: "Terry", last_name: "Smith", middle_name: "" }
       ],
-      sanctions: [],
+      alerts: [],
       trn:
     }
   end
@@ -168,7 +168,7 @@ class FakeQualificationsApi < Sinatra::Base
       previousNames: [
         { first_name: "Stephen", last_name: "Toast", middle_name: "" },
       ],
-      sanctions: [],
+      alerts: [],
       trn: "987654321"
     }
   end
@@ -183,13 +183,17 @@ class FakeQualificationsApi < Sinatra::Base
         { first_name: "Terry", last_name: "Jones", middle_name: "" },
         { first_name: "Terry", last_name: "Smith", middle_name: "" }
       ],
-      sanctions: [
+      alerts: [
         {
-          code: "G1",
+          alert_type: {
+            alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99",
+          },
           startDate: "2019-10-25"
         },
         {
-          code: "A1A",
+          alert_type: {
+            alert_type_id: "fa6bd220-61b0-41fc-9066-421b3b9d7885"
+          },
           startDate: "2018-9-20"
         }
       ],

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -11,20 +11,20 @@ module FakeQualificationsData
       ],
       eyts: {
         awarded: "2022-04-01",
-        certificateUrl: "/v3/certificates/eyts",
         statusDescription: "Qualified (trained in the UK)",
       },
       qts: {
         awarded: "2023-02-27",
-        certificateUrl: "/v3/certificates/qts",
         statusDescription: "Qualified (trained in the UK)",
+        routes: {
+          awarded_approved_count: "1"
+        }
       },
       induction: {
         startDate: "2022-09-01",
         endDate: "2022-10-01",
         status: "Pass",
         statusDescription: "Passed Induction",
-        certificateUrl: "/v3/certificates/induction",
         periods: [
           {
             startDate: "2022-09-01",
@@ -85,7 +85,13 @@ module FakeQualificationsData
           }
         }
       ],
-      sanctions: trn == "9876543" ? [ { code: "G1", startDate: "2020-10-25" } ] : []
+      alerts: if trn == "9876543"
+  [ { alert_type: {alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99"}, 
+startDate: "2020-10-25" } ]
+else
+  []
+end,
+      qtlsStatus: "None"
     }
   end
 
@@ -102,7 +108,8 @@ module FakeQualificationsData
       initialTeacherTraining: nil,
       mandatoryQualifications: [],
       npqQualifications: [],
-      sanctions: []
+      alerts: [],
+      qtlsStatus: nil,
     }
   end
 end

--- a/spec/support/fake_qualifications_data_with_nulling.rb
+++ b/spec/support/fake_qualifications_data_with_nulling.rb
@@ -76,6 +76,6 @@ class FakeQualificationsDataWithNulling
   end
 
   def minimal_sanctions!
-    @data[:sanctions] = [ { code: "G1", startDate: nil } ]
+    @data[:alerts] = [ { alert_type: { alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99"}, startDate: nil } ]
   end
 end


### PR DESCRIPTION
### Context

TRN allocation for SET/EwC members with QTLS will be taken over by TRA/DfE moving forward. We have also started reconciliation of the existing TRNs to ensure we have a teaching record for each of the SET members and are displaying valid professional status on their records.

We want to make changes to the front-end services so that the teachers with QTLS can view and download relevant information from AYTQ


### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
