### PR TITLE
Remove trs lookup for npq data

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -98,7 +98,7 @@ module QualificationsApi
     end
 
     def npq_awarded?
-      api_data.npq_qualifications.first&.awarded.present?
+      npq_data.body["data"]["qualifications"] != []
     end
 
     def eyps_awarded?


### PR DESCRIPTION
### Context

Npq data from TRS was being requested to render certificates. As NPQ data is no longer served by the TRS API, we should instead request data from the NPQ API.

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
