### PR TITLE
Update induction end date to completed date

### DIFF
--- a/app/components/check_records/qualification_summary_component.html.erb
+++ b/app/components/check_records/qualification_summary_component.html.erb
@@ -6,7 +6,7 @@
         <%= govuk_inset_text do %>
           <p>Exempt from induction via qualified teacher learning and skills (QTLS) status and an active membership with the <a href="https://set.et-foundation.co.uk/your-career/qtls">Society for Education and Training (SET)</a></p>
 
-          <p>They will need to complete induciton if their SET membership expires.</p>
+          <p>They will need to complete induction if their SET membership expires.</p>
         <% end %>
     <% elsif render_qts_induction_exemption_message %>
       <%= govuk_inset_text do %>

--- a/app/views/qualifications/certificates/_induction.html.erb
+++ b/app/views/qualifications/certificates/_induction.html.erb
@@ -11,7 +11,7 @@
     institution. The holder of this certificate is a qualified teacher and has obtained the required<br/>
     qualifications and completed the necessary training for the profession of school teacher in England.</p>
   <p>&#160;</p>
-  <p class="text">Date Induction Completed:&#160;<strong><%= qualification.details.end_date.to_date.to_fs(:long_uk) %></strong></p>
+  <p class="text">Date Induction Completed:&#160;<strong><%= qualification.awarded_at.to_date.to_fs(:long_uk) %></strong></p>
   <p>&#160;</p>
   <p class="text">Congratulations and best wishes for your future career.</p>
   <p>&#160;</p>

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         name: "Initial teacher training (ITT)",
         awarded_at: fake_quals_data.end_date&.to_date,
         type: :itt,
-        details: fake_quals_data.fetch("initial_teacher_training").first
+        details: QualificationsApi::CoercedDetails.new(fake_quals_data.fetch("initial_teacher_training").first)
       )
     end
     let(:component) { described_class.new(qualification:) }
@@ -34,11 +34,11 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
 
     it "renders the qualification" do
-      expect(rows[0].text).to include(qualification.details.dig(:qualification, :name))
+      expect(rows[0].text).to include(qualification.details.dig("qualification", "name"))
     end
 
     it "renders the qualification provider" do
-      expect(rows[1].text).to include(qualification.details.dig(:provider, :name))
+      expect(rows[1].text).to include(qualification.details.dig("provider", "name"))
     end
 
     it "renders the qualification programme type" do

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
     let(:qualification) do
       Qualification.new(
         name: "Induction summary",
-        awarded_at: induction.end_date&.to_date,
+        awarded_at: induction.completed_date&.to_date,
         type: :itt,
         qtls_only: false,
         qts_and_qtls: false,
@@ -43,7 +43,6 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
 
     it "renders does not render empty component rows" do
       component.qualification.awarded_at = nil
-      component.qualification.details.periods.first.end_date = nil
 
       expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("Completed")
       expect(rendered.css(".govuk-summary-list__key").map(&:text)).not_to include("End date")

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         name: "Initial teacher training (ITT)",
-        awarded_at: fake_quals_data.end_date&.to_date,
+        awarded_at: fake_quals_data.initial_teacher_training.first.end_date.value,
         type: :itt,
-        details: fake_quals_data.fetch("initial_teacher_training").first
+        details: QualificationsApi::CoercedDetails.new(fake_quals_data.fetch("initial_teacher_training").first)
       )
     end
     let(:component) { described_class.new(qualification:) }
@@ -26,11 +26,11 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
 
     it "renders the qualification" do
-      expect(rows[0].text).to include(qualification.details.dig(:qualification, :name))
+      expect(rows[0].text).to include(qualification.details.dig("qualification", "name"))
     end
 
     it "renders the qualification provider" do
-      expect(rows[1].text).to include(qualification.details.dig(:provider, :name))
+      expect(rows[1].text).to include(qualification.details.dig("provider", "name"))
     end
 
     it "renders the qualification programme type" do

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -20,19 +20,8 @@ module FakeQualificationsData
       },
       induction: {
         startDate: "2022-09-01",
-        endDate: "2022-10-01",
+        completedDate: "2022-10-01",
         status: "Passed",
-        statusDescription: "Passed",
-        periods: [
-          {
-            startDate: "2022-09-01",
-            endDate: "2022-10-01",
-            terms: 1,
-            appropriateBody: {
-              name: "Induction body"
-            }
-          }
-        ]
       },
       initialTeacherTraining:
         (
@@ -44,11 +33,23 @@ module FakeQualificationsData
                 qualification: {
                   name: "BA"
                 },
-                startDate: "2022-02-28",
-                endDate: "2023-01-28",
-                programmeType: "HEI",
+                startDate: {
+                  value: "2022-02-28",
+                  hasValue: true,
+                },
+                endDate: {
+                  value: "2023-01-28",
+                  hasValue: true,
+                },
+                programmeType: {
+                  hasValue: true,
+                  value: "HEI",
+                },
                 programmeTypeDescription: "Higher education institution",
-                result: "Passed",
+                result: {
+                  hasValue: true,
+                  value: "Passed",
+                },
                 ageRange: {
                   description: "10 to 16 years"
                 },

--- a/spec/support/fake_qualifications_data_with_nulling.rb
+++ b/spec/support/fake_qualifications_data_with_nulling.rb
@@ -44,12 +44,6 @@ class FakeQualificationsDataWithNulling
     @data[:induction][:status] = "None"
     @data[:induction][:statusDescription] = nil
     @data[:induction][:certificateUrl] = nil
-    @data[:induction][:periods].each do |period|
-      period[:startDate] = nil
-      period[:endDate] = nil
-      period[:terms] = nil
-      period[:appropriateBody] = nil
-    end
   end
 
   def minimal_itt!


### PR DESCRIPTION
### Context

As part of the API version update; the TRS API serves completed_date rather than end date. We should reconcile our service so that we consume completed date. 

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
