### PR TITLE
Check alert exposable and has an end date

### DIFF
--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -69,7 +69,9 @@ module QualificationsApi
     end
 
     def sanctions
-      api_data.alerts&.map { |alert| Sanction.new(alert) }
+      api_data.alerts&.filter_map do |alert| 
+        Sanction.new(alert) if alert_showable?(alert) 
+      end
     end
 
     def teaching_status
@@ -262,6 +264,10 @@ module QualificationsApi
           type: :mandatory
         )
       end
+    end
+
+    def alert_showable?(alert)
+      alert.end_date.blank? && Sanction::SANCTIONS.key?(alert.alert_type.alert_type_id)
     end
   end
 

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -218,8 +218,49 @@ class Sanction
       description: <<~DESCRIPTION.chomp
         Check the [list of published decisions on GOV.UK](https://www.gov.uk/search/all?parent=&keywords=panel+outcome+misconduct&level_one_taxon=&manual=&organisations%5B%5D=teaching-regulation-agency&organisations%5B%5D=national-college-for-teaching-and-leadership&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest) for more details.
       DESCRIPTION
-    }
+    },
+    "af65c236-47a6-427b-8e4b-930de6d256f0" => {
+      title: "Suspension order without conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "872d7700-aa6f-435e-b5f9-821fb087962a" => {
+      title: "Suspension order without conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "3c5fc83b-10e1-4a15-83e6-794fce3e0b45" => {
+      title: "Suspension order without conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "17b4fe26-7468-4702-92e5-785b861cf0fa" => {
+      title: "Suspension order with conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+  
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
+    "a6f51ccc-a19c-4dc2-ba80-ffb7a95ff2ee" => {
+      title: "Suspension order without conditions",
+      description: <<~DESCRIPTION.chomp
+        Suspended by the General Teaching Council for England.
+
+        Call the Teaching Regulation Agency (TRA) on 0207 593 5393 to check the conditions.
+      DESCRIPTION
+    },
   }.freeze
+
 
   def description
     SANCTIONS[alert_type_id][:description] if SANCTIONS[alert_type_id]

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -425,8 +425,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         {
           "alerts" => [
             "alert_type" => {
-            "alert_type_id" => "241eeb78-fac7-4c77-8059-c12e93dc2fae", "start_date" => "2024-01-01" 
-          }
+            "alert_type_id" => "Nonsense", "start_date" => "2024-01-01" 
+          },
           ]
         }
       end
@@ -447,6 +447,22 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it { is_expected.to be_falsey }
+    end
+
+    context "when there are sanctions that have an end date" do
+      let(:api_data) do
+        {
+          "alerts" => [
+            "alert_type" =>  {
+              "alert_type_id" => "1a2b06ae-7e9f-4761-b95d-397ca5da4b13"
+            },
+            "start_date" => "2024-01-01",
+            "end_date" => "2025-01-02",
+          ]
+        }
+      end
+
+      it { is_expected.to be_truthy }
     end
   end
 end


### PR DESCRIPTION
### Context

Alerts were rendering that we do not expose in CTR. This was showing restrictions tags in places they were not appropriate. 

Add alert_type_ids for 5 alert types we should be serving. 

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
