### PR TITLE
Implement delete action workflow to delete review

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -15,93 +15,28 @@ on:
 
 jobs:
   delete-review-app:
-    name: Delete Review App ${{ github.event.pull_request.number }}
-    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    name: Delete Review App ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    if: >
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy') || (github.event_name ==
+      'workflow_dispatch')
+
     environment: review
     permissions:
       pull-requests: write
       id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Extract configuration from tfvars
-        run: |
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            PR_NUMBER=${{ github.event.inputs.pr_number }}
-          else
-            PR_NUMBER=${{ github.event.pull_request.number }}
-          fi
-
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          echo "STORAGE_ACCOUNT_NAME=s189t01aytqrvtfsa" >> $GITHUB_ENV
-          echo "TF_RESOURCE_GROUP_NAME=s189t01-aytq-rv-rg" >> $GITHUB_ENV
-        shell: bash
-
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - run: |
-          TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.TF_RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} | jq -r '.[0].value')"
-          echo "::add-mask::$TFSTATE_CONTAINER_ACCESS_KEY"
-          echo "TFSTATE_CONTAINER_ACCESS_KEY=$TFSTATE_CONTAINER_ACCESS_KEY" >> $GITHUB_ENV
-        shell: bash
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.6.4
-          terraform_wrapper: false
-
-      - name: Set Environment variables
-        run: |
-          TF_STATE_FILE=pr-${{ env.PR_NUMBER }}_kubernetes.tfstate
-          echo "TF_STATE_FILE=$TF_STATE_FILE" >> $GITHUB_ENV
-
-          pr_state_file=$(az storage blob list -c terraform-state \
-            --account-key ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }} \
-            --account-name ${{ env.STORAGE_ACCOUNT_NAME }} \
-            --prefix $TF_STATE_FILE --query "[].name" -o tsv)
-          if [ -n "$pr_state_file" ]; then
-            echo "TF_STATE_EXISTS=true" >> $GITHUB_ENV
-          fi
-
-      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      - uses: DFE-Digital/github-actions/delete-review-app@master
         with:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: teaching-qualifications
-          workload_identity_provider: projects/708780292301/locations/global/workloadIdentityPools/access-your-teaching-qualificati/providers/access-your-teaching-qualificati
-
-      - name: Terraform Destroy
-        run: |
-          make ci review terraform-destroy
-        env:
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-
-      - name: Delete tf state file
-        if: env.TF_STATE_EXISTS == 'true'
-        run: |
-          az storage blob delete -c terraform-state --name ${{ env.TF_STATE_FILE }} \
-          --account-key ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }} \
-          --account-name ${{ env.STORAGE_ACCOUNT_NAME }}
-
-      - name: Post Pull Request Comment ${{ github.event.number }}
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: aks
-          message: |
-            The review apps Access Your Teaching Qualifications & Check A Teacher's Record have been deleted.
-            The following domains are not available anymore:
-            - <https://access-your-teaching-qualifications-pr-${{ github.event.number }}.test.teacherservices.cloud>
-            - <https://check-a-teachers-record-pr-${{ github.event.number }}.test.teacherservices.cloud>
+          pr-number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          resource-group-name: s189t01-aytq-rv-rg
+          storage-account-name: s189t01aytqrvtfsa
+          tf-state-file: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}_kubernetes.tfstate
+          gcp-wip: projects/708780292301/locations/global/workloadIdentityPools/access-your-teaching-qualificati/providers/access-your-teaching-qualificati
+          gcp-project-id: teaching-qualifications


### PR DESCRIPTION
# Pull Request: Implement Centralized Delete-Review-App GitHub Action

## Context

We are standardizing our review app deletion process across services by migrating to a centralized GitHub Action (`DFE-Digital/github-actions/delete-review-app@master`). This reduces duplication, improves maintainability, and ensures consistent behavior across all services when cleaning up review app resources.

## Changes proposed in this pull request

- Replaced our custom delete-review-app workflow with the standardized version from `DFE-Digital/github-actions`
- Configured the workflow to maintain all existing functionality including:
  - PR-based and manual triggering
  - Proper authentication with Azure and GCP
  - Terraform state management
  - PR comment notifications
- Set up appropriate parameters to ensure the action works with our current infrastructure naming conventions

The solution uses the existing make target for terraform destroy (`make ci review terraform-destroy`) which ensures compatibility with our current process without requiring changes to other workflows or infrastructure code.

## Guidance to review

- Verify that all required parameters are correctly specified in the workflow file
- Test by creating a PR with the 'deploy' label to create a review app, then close the PR to verify it gets deleted
- Confirm in the Azure portal that all resources are properly cleaned up after the workflow runs
- Check that a comment is posted to the PR confirming deletion
- Working run - https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/runs/14749915666
- Workflow Dispatch run - https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/runs/14784806848/job/41511218300

### Link to Trello card

https://trello.com/c/7M3ZvinR/2323-use-delete-review-app-github-action

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
