### PR TITLE
Fix oauth bypass system

### DIFF
--- a/app/controllers/check_records/sign_in_controller.rb
+++ b/app/controllers/check_records/sign_in_controller.rb
@@ -7,7 +7,7 @@ module CheckRecords
 
     def new
       if DfESignIn.bypass?
-        redirect_post "/check-records/auth/developer/callback", options: { authenticity_token: :auto }
+        redirect_post "/check-records/auth/developer", options: { authenticity_token: :auto }
       else
         redirect_post "/check-records/auth/dfe", options: { authenticity_token: :auto }
       end

--- a/config/routes/check_records.rb
+++ b/config/routes/check_records.rb
@@ -11,6 +11,7 @@ namespace :check_records, path: "check-records" do
   get "/auth/dfe/sign-out", to: "sign_out#new", as: :dsi_sign_out
 
   get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
+  get "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
   post "/auth/developer/callback" => "omniauth_callbacks#dfe_bypass"
 
   get "/search", to: "search#personal_details_search"


### PR DESCRIPTION
### Context

The auto-redirect was sending you to the wrong page, this corrects it so you’re properly sent to the spoofed information form. The added path also corrects an issue caused by a change in how omniauth-developer works back in 2023.

### Changes proposed in this pull request

- Corrects /check-records/sign-in path redirect when DFE bypass is enabled to direct you to `/check-records/auth/developer` instead of `/check-records/auth/developer/callback`
  The new path takes you to a form that properly lets you spoof the oauth information.
- Adds new path for submission from that form so that the GET based form properly returns. Further information here: https://github.com/omniauth/omniauth/commit/480a2ffaafc0af32dcd6edaad0ab3d7855171292#commitcomment-137751302

### Guidance to review

1. Visit `/check-records/sign-in` locally with `BYPASS_DSI` set to true.
2. Enter desired information into displayed developer form and submit.
3. Confirm you are logged in. 

### Link to Trello card

[Fix AYTQ dev environment DSI bypass feature](https://trello.com/c/fAw1as8l/501-fix-aytq-dev-environment-dsi-bypass-feature)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
