### PR TITLE
Add ruby/puppeteer upgrading documentation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -31,3 +31,4 @@ public/assets
 storage
 tmp
 vendor
+docs/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@
 # production: runs the actual app
 
 # Build builder image
+# WHEN WE UPDATE THIS WE HAVE TO KEEP PUPPETEER IN SYNC WITH THE VERSION OF CHROMIUM THAT GETS INSTALLED
+# Get the version `apk list chromium` in the running image and then update package.json https://pptr.dev/chromium-support#
+# This is used for rendering PDFs
+# We are specifically using ruby:3.4.4-alpine3.20 rather than ruby:3.4.4 as later versions of alpine don't come with a
+# version of chromium that is on the list of supported versions for puppeteer.
+# See docs/updating_ruby.md and docs/puppeteer.md for more details on how to update this image.
 FROM ruby:3.4.4-alpine3.20 AS builder
 
 # RUN apk -U upgrade && \

--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -1,0 +1,37 @@
+# Puppeteer 
+
+Puppeteer requires some specific configuration to work on Alpine, official documentation can be found on the [Puppeteer troubleshooting page](https://pptr.dev/troubleshooting#running-on-alpine).
+
+Information gathered on the specific set up we have is available below.
+
+## Updating Puppeteer
+
+To find the version of puppeteer you need to upgrade to you need to:
+
+1. Locate the version of Chromium that is available to the version of alpine your ruby image is using, this can be found by looking at the `chromium` package version in the Alpine package repository for the version of Alpine you are using. You can find this by going to [this page](https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=x86_64&origin=&flagged=&maintainer=) and selecting the version of Alpine your ruby image was built off of.
+2. Compare this version of Chromium to the available versions of puppeteer listed on the [supported browsers page](https://pptr.dev/supported-browsers) for puppeteer.
+3. Update the version of puppeteer in your `package.json` file to match the version that supports the version of Chromium you found in step 1.
+4. Run `npm install` to update your `package-lock.json` file with the new version of puppeteer.
+5. Update the version of Chromium in the `Dockerfile` to match the version you found in step 1.
+6. Rebuild your Docker image to ensure that the new version of Chromium is installed.
+7. Test the updated application on a review app to ensure that everything is working correctly with the new version of puppeteer and Chromium by downloading a certificate PDF.
+
+#### What if the version of Chromium available to the Alpine version you are using is not listed on the supported browsers page?
+
+You may need to move to an alternative version of Alpine that has a version of Chromium that is supported by puppeteer. This may involve updating the base image in your Dockerfile to a newer version of Ruby that uses a newer version of Alpine, or switching to a different version of your ruby image that is built off an older version of Alpine that has a supported version of Chromium.
+
+For example, as of writing the Dockerfile is using `ruby:3.4.4-alpine3.20` as alpine 3.20 has a version of Chromium that is supported by puppeteer where as the image `ruby:3.4.4` uses alpine 3.22 which does not have a version of Chromium that is supported by puppeteer.
+
+## Other things to note
+
+### The `--disable-gpu` flag
+
+Right now the setup for puppeteer is being set up with the flag `--disable-gpu`, this is not a core requirement for using puppeteer for our purposes. It is currently in place as workaround to timeout issues beign raised by needing to use alpine 3.20. 
+
+Details on this can be found at the below links:
+- https://pptr.dev/troubleshooting#running-on-alpine
+- https://github.com/puppeteer/puppeteer/issues/11640
+- https://github.com/puppeteer/puppeteer/issues/12637
+- https://github.com/puppeteer/puppeteer/issues/12189
+
+

--- a/docs/updating_ruby.md
+++ b/docs/updating_ruby.md
@@ -1,0 +1,16 @@
+# Updating Ruby
+
+## Places you need to update
+
+- The Ruby version in the `Gemfile` (remember to run `bundle install`)
+- The base image being used for both the builder and production steps in `Dockerfile`
+- The Ruby version in `.ruby-version`
+- The Ruby version in `.tool-versions`
+
+## Other dependencies that need upgrading
+
+### Puppeteer
+
+Puppeteer requires that the version of Chromium being installed matches to the version of puppeteer being installed, this means that when you upgrade the base image of the Dockerfile, which will most likely upgrade your base alpine image, you will also need to update the version of puppeteer in the `package.json` file.
+
+See [docs/puppeteer.md](docs/puppeteer.md) for more information on how to do this.


### PR DESCRIPTION
### Context

Missing documentation on upgrading Ruby and the complexities of Puppeteer.

### Changes proposed in this pull request

- Adds docs/updating-ruby.md
- Adds docs/puppeteer.md