### PR TITLE
Update to use api-version 20250627 of v3/persons/#{trn}

### DIFF
--- a/app/components/check_records/mq_summary_component.rb
+++ b/app/components/check_records/mq_summary_component.rb
@@ -6,21 +6,25 @@ class CheckRecords::MqSummaryComponent < ViewComponent::Base
   attr_accessor :mqs
 
   def rows
-    mqs.map do |mq|
-      {
-        key: {
-          text: key_text(mq)
+    @rows ||= mqs.flat_map do |mandatory_qualification|
+      [
+        {
+          key: {
+            text: "MQ Specialism"
+          },
+          value: {
+            text: mandatory_qualification.details.specialism.humanize
+          }
         },
-        value: {
-          text: mq.awarded_at.to_fs(:long_uk)
+        {
+          key: {
+            text: "Date Awarded",
+          },
+          value: {
+            text: mandatory_qualification.awarded_at&.to_fs(:long_uk)
+          }
         }
-      }
+      ]
     end
-  end
-
-  private
-
-  def key_text(mandatory_qualification)
-    "Date #{mandatory_qualification.details.specialism.downcase} MQ awarded"
   end
 end

--- a/app/components/check_records/npq_summary_component.rb
+++ b/app/components/check_records/npq_summary_component.rb
@@ -6,7 +6,7 @@ class CheckRecords::NpqSummaryComponent < ViewComponent::Base
   attr_accessor :npqs
 
   def rows
-    npqs.map do |npq|
+    @rows ||= npqs.map do |npq|
       {
         key: {
           text: key_text(npq)

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -27,23 +27,24 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
   alias_method :title, :name
 
   def rows
-    @rows = (
-      if itt?
-        itt_rows
-      elsif mq?
-        mq_rows
-      elsif induction?
-        induction_rows
-      elsif qts?
-        qts_rows
-      else
-        [
-          { key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
-          { key: { text: "Status" }, value: { text: status_description } },
-        ]
-      end
-    )
-    @rows.select { |row| row[:value][:text].present? }
+    @rows ||= build_rows.select { |row| row[:value][:text].present? }
+  end
+
+  def build_rows
+    if itt?
+      itt_rows
+    elsif mq?
+      mq_rows
+    elsif induction?
+      induction_rows
+    elsif qts?
+      qts_rows
+    else
+      [
+        { key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
+        { key: { text: "Status" }, value: { text: status_description } },
+      ]
+    end
   end
 
   def induction_rows

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -25,8 +25,7 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
            to: :qualification
 
   def title
-    return "Professional Status" if qts? || eyts?
-    return "Route to Professional Status" if rtps?
+    return [name, rtps_route_type].compact.join(": ") if rtps?
 
     name
   end
@@ -77,7 +76,6 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
 
   def rtps_rows
     [
-      { key: { text: "Route Type" }, value: { text: details.route_to_professional_status_type&.name } },
       { key: { text: "Qualification" }, value: { text: details.degree_type&.name } },
       { key: { text: "Provider" }, value: { text: details.training_provider&.name } },
       {
@@ -108,8 +106,12 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
           text: details.training_end_date&.to_date&.to_fs(:long_uk)
         }
       },
-      { key: { text: "Course result" }, value: { text: details.status&.to_s&.underscore&.humanize } }
+      { key: { text: "Result" }, value: { text: details.status&.to_s&.underscore&.humanize } }
     ]
+  end
+
+  def rtps_route_type
+    details.route_to_professional_status_type&.name
   end
 
   def age_range_from_training_age_specialism(training_age_specialism)
@@ -145,27 +147,15 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
     rows
   end
 
-  def eyts_rows
-    [
-      { key: { text: "Status" }, value: { text: "Early years teacher status (EYTS)" } },
-      { key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } }
-    ]
-  end
-
   def qts_status_text
-    if qtls_only && !set_membership_active
-      "No QTS"
-    else
-      qts_status_description_text
-    end
+    return "Qualified Teacher Status (QTS)" unless qtls_only
+    return "Qualified via qualified teacher learning and skills (QTLS) status" if set_membership_active
+
+    "No QTS"
   end
 
-  def qts_status_description_text
-    if qtls_only
-      "Qualified via qualified teacher learning and skills (QTLS) status"
-    else
-      "Qualified teacher status (QTS)"
-    end
+  def eyts_rows
+    [{ key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } }]
   end
 
   def failed_induction?

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -10,107 +10,146 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
            :details,
            :id,
            :induction?,
-           :itt?,
+           :rtps?,
            :qtls_only,
            :set_membership_active,
            :set_membership_expired,
            :mq?,
            :name,
-           :status_description,
            :type,
            :qts?,
+           :eyts?,
            :passed_induction,
            :failed_induction,
            :qts_and_qtls,
            to: :qualification
 
-  alias_method :title, :name
+  def title
+    return "Professional Status" if qts? || eyts?
+    return "Route to Professional Status" if rtps?
+
+    name
+  end
 
   def rows
     @rows ||= build_rows.select { |row| row[:value][:text].present? }
   end
 
   def build_rows
-    if itt?
-      itt_rows
+    if rtps?
+      rtps_rows
     elsif mq?
       mq_rows
     elsif induction?
       induction_rows
     elsif qts?
       qts_rows
+    elsif eyts?
+      eyts_rows
     else
       [
-        { key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
-        { key: { text: "Status" }, value: { text: status_description } },
+        { key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } },
       ]
     end
   end
 
   def induction_rows
     if qtls_only && !passed_induction && !failed_induction?
-      if set_membership_active 
-        return [{ key: { text: "Induction status" }, value: { text: "Exempt"} }]
-      else 
+      if set_membership_active
+        return [
+          { key: { text: "Induction status" }, value: { text: "Exempt" } },
+          { key: { text: "Reason for exemption" },
+            value: { text: details[:exemption_reasons]&.map(&:name)&.join(", ") } }
+        ]
+      else
         return [{ key: { text: "Induction status" }, value: { text: "No induction"} }]
       end
     end
+
     [
-      { 
-        key: { text: "Induction status" }, 
-        value: { text: description_text(details&.status) } 
+      {
+        key: { text: "Induction status" },
+        value: { text: description_text(details&.status) }
       },
       { key: { text: "Date completed" }, value: { text: awarded_at&.to_fs(:long_uk) } }
     ]
   end
 
-  def itt_rows
+  def rtps_rows
     [
-      { key: { text: "Qualification" }, value: { text: details.qualification&.name } },
-      { key: { text: "ITT provider" }, value: { text: details.provider&.name } },
-      { key: { text: "Programme type" }, value: { text: details.programme_type_description } },
+      { key: { text: "Route Type" }, value: { text: details.route_to_professional_status_type&.name } },
+      { key: { text: "Qualification" }, value: { text: details.degree_type&.name } },
+      { key: { text: "Provider" }, value: { text: details.training_provider&.name } },
       {
         key: {
           text: "Subject"
         },
         value: {
-          text: details.subjects.map { |subject| subject.name.titleize }.join(", ")
-        }
-      },
-      { key: { text: "Age range" }, value: { text: details.age_range&.description } },
-      {
-        key: {
-          text: "Course start date"
-        },
-        value: {
-          text: details.start_date&.to_date&.to_fs(:long_uk)
+          text: details.training_subjects&.map { |subject| subject.name.titleize }&.join(", ")
         }
       },
       {
+        key: { text: "Age range" },
+        value: { text: age_range_from_training_age_specialism(details.training_age_specialism) }
+      },
+      {
         key: {
-          text: "Course end date"
+          text: "Start date"
         },
         value: {
-          text: details.end_date&.to_date&.to_fs(:long_uk)
+          text: details.training_start_date&.to_date&.to_fs(:long_uk)
         }
       },
-      { key: { text: "Course result" }, value: { text: details.result&.to_s&.humanize } }
+      {
+        key: {
+          text: "End date"
+        },
+        value: {
+          text: details.training_end_date&.to_date&.to_fs(:long_uk)
+        }
+      },
+      { key: { text: "Course result" }, value: { text: details.status&.to_s&.underscore&.humanize } }
     ]
+  end
+
+  def age_range_from_training_age_specialism(training_age_specialism)
+    case training_age_specialism&.type
+    when "Range"
+      "#{training_age_specialism.from} to #{training_age_specialism.to} years"
+    else
+      # Easier to use a hash lookup for the known types
+      # Rather than .underscore.humanize, especially since that tactic just results in "Key stage1"
+      {
+        'FoundationStage' => "Foundation stage",
+        'FurtherEducation' =>  "Further education",
+        'KeyStage1' =>  "Key stage 1",
+        'KeyStage2' =>  "Key stage 2",
+        'KeyStage3' =>  "Key stage 3",
+        'KeyStage4' =>  "Key stage 4"
+      }[training_age_specialism&.type]
+    end
   end
 
   def mq_rows
     [
       { key: { text: "Specialism" }, value: { text: details.specialism } },
-      { key: { text: "Date awarded" }, value: { text: awarded_at.to_fs(:long_uk) } }
+      { key: { text: "Held since" }, value: { text: awarded_at.to_fs(:long_uk) } }
     ]
   end
 
   def qts_rows
-    rows = [{ key: { text: "QTS status" }, value: { text: qts_status_text } }]
+    rows = [{ key: { text: "Status" }, value: { text: qts_status_text } }]
     unless qtls_only && !set_membership_active
-      rows.append( { key: { text: "Date awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } } )
+      rows.append( { key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } } )
     end
     rows
+  end
+
+  def eyts_rows
+    [
+      { key: { text: "Status" }, value: { text: "Early years teacher status (EYTS)" } },
+      { key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } }
+    ]
   end
 
   def qts_status_text
@@ -124,8 +163,8 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
   def qts_status_description_text
     if qtls_only
       "Qualified via qualified teacher learning and skills (QTLS) status"
-    else 
-      status_description
+    else
+      "Qualified teacher status (QTS)"
     end
   end
 

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -175,7 +175,7 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
   end
 
   def render_induction_exemption_warning?
-    induction? && set_membership_expired && !passed_induction && details&.status != "Failed"
+    induction? && set_membership_expired && !passed_induction && details&.status != "Failed" && details&.status != "Exempt"
   end
 
   def render_qtls_warning_message?

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -175,7 +175,11 @@ class CheckRecords::QualificationSummaryComponent < ViewComponent::Base
   end
 
   def render_induction_exemption_warning?
-    induction? && set_membership_expired && !passed_induction && details&.status != "Failed" && details&.status != "Exempt"
+    induction? &&
+      set_membership_expired &&
+      !passed_induction &&
+      details&.status != "Failed" &&
+      details&.status != "Exempt"
   end
 
   def render_qtls_warning_message?

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -142,7 +142,7 @@ class InductionSummaryComponent < ViewComponent::Base
   end
 
   def render_induction_exemption_warning?
-    set_membership_expired && !passed_induction && details&.status != "Failed"
+    set_membership_expired && !passed_induction && details&.status != "Failed" && details&.status != "Exempt"
   end
 
   def description_text(status)

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -41,7 +41,7 @@ class QualificationSummaryComponent < ViewComponent::Base
 
   def qualification_rows
     [
-      { key: { text: "Awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
+      { key: { text: "Held since" }, value: { text: awarded_at&.to_fs(:long_uk) } },
       type_supports_certificates? ? certificate_rows : nil,
       details.specialism.present? ? specialism_rows : nil,
     ].flatten.compact
@@ -180,7 +180,7 @@ class QualificationSummaryComponent < ViewComponent::Base
       [
         {
           key: {
-            text: "Awarded"
+            text: "Held since"
           },
           value: {
             text: qtls_awarded_at_text

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -24,10 +24,14 @@ class QualificationSummaryComponent < ViewComponent::Base
   alias_method :title, :name
 
   def rows
+    @rows ||= build_rows.select { |row| row[:value][:text].present? }
+  end
+
+  def build_rows
     return itt_rows if itt?
     return qtls_rows if qts? && qtls_only
       
-    @rows = [
+    qualification_rows = [
       { key: { text: "Awarded" }, value: { text: awarded_at&.to_fs(:long_uk) } },
       {
         key: {
@@ -45,7 +49,7 @@ class QualificationSummaryComponent < ViewComponent::Base
     ]
 
     if qualification.status_description
-      @rows << {
+      qualification_rows << {
         key: {
           text: "Status"
         },
@@ -56,7 +60,7 @@ class QualificationSummaryComponent < ViewComponent::Base
     end
 
     if details.specialism
-      @rows << {
+      qualification_rows << {
         key: {
           text: "Specialism"
         },
@@ -66,13 +70,13 @@ class QualificationSummaryComponent < ViewComponent::Base
       }
     end
 
-    @rows.select { |row| row[:value][:text].present? }
+    qualification_rows
   end
 
   def itt_rows
     return [] if details.end_date.blank?
 
-    @rows = [
+    [
       {
         key: {
           text: "Qualification"

--- a/app/lib/qualifications_api/certificate.rb
+++ b/app/lib/qualifications_api/certificate.rb
@@ -2,7 +2,7 @@ module QualificationsApi
   class Certificate
     include ActiveModel::Model
 
-    VALID_TYPES = %i[eyts induction itt NPQEL NPQLTD NPQLT NPQH NPQML NPQLL NPQEYL NPQSL NPQLBC NPQSENCO NPQLPM 
+    VALID_TYPES = %i[eyts induction rtps NPQEL NPQLTD NPQLT NPQH NPQML NPQLL NPQEYL NPQSL NPQLBC NPQSENCO NPQLPM
 qts].freeze
 
     attr_accessor :name, :type, :file_data

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -81,7 +81,7 @@ module QualificationsApi
     end
 
     def teacher(trn: nil)
-      client.headers["X-Api-Version"] = "20250327"
+      client.headers["X-Api-Version"] = "20250627"
       # If TRN is provided, we use an endpoint which expects a fixed Bearer token.
       # If TRN is blank, the token needs to come from an authenticated Identity user.
       endpoint = (trn ? "v3/persons/#{trn}" : "v3/person")
@@ -91,7 +91,6 @@ module QualificationsApi
           {
             include: %w[
               Induction
-              InitialTeacherTraining
               MandatoryQualifications
               Alerts
               PreviousNames

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -95,6 +95,7 @@ module QualificationsApi
               Alerts
               PreviousNames
               PendingDetailChanges
+              RoutesToProfessionalStatuses
             ].join(",")
           }
         )

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -42,17 +42,15 @@ module QualificationsApi
     end
 
     def qualifications
-      @qualifications = []
-
-      add_npq
-      add_mandatory_qualifications
-      add_induction
-      add_qts
-      add_itt
-      add_eyts
-      add_itt(qts: false)
-
-      @qualifications.flatten!
+      @qualifications ||= [
+        npq_qualifications,
+        mq_qualifications,
+        induction_qualification,
+        qts_qualification,
+        itt_qualifications,
+        eyts_qualification,
+        itt_qualifications(qts: false),
+      ].flatten.compact
     end
 
     def restriction_status
@@ -172,10 +170,10 @@ module QualificationsApi
 
     private
 
-    def add_qts
+    def qts_qualification
       return if api_data.qts.blank? && !qtls_only?
 
-      @qualifications << Qualification.new(
+      Qualification.new(
         awarded_at: api_data.qts&.awarded&.to_date,
         name: "Qualified teacher status (QTS)",
         qtls_only: qtls_only?,
@@ -189,10 +187,10 @@ module QualificationsApi
       )
     end
 
-    def add_eyts
+    def eyts_qualification
       return if api_data.eyts.blank?
 
-      @qualifications << Qualification.new(
+      Qualification.new(
         awarded_at: api_data.eyts.awarded&.to_date,
         name: "Early years teacher status (EYTS)",
         status_description: api_data.eyts.status_description,
@@ -200,65 +198,64 @@ module QualificationsApi
       )
     end
 
-    def add_npq
-      unless @npq_data == []
-        @npq_data.body["data"]["qualifications"]
-          .sort_by { |npq| npq["award_date"]&.to_date }
-          .reverse
-          .each do |npq|
-            @qualifications << Qualification.new(
-              awarded_at: npq["award_date"]&.to_date,
-              name: NPQ_QUALIFICATION_NAME[npq["npq_type"].to_sym],
-              type: npq["npq_type"]&.to_sym
-            )
-        end
+    def npq_qualifications
+      return [] if @npq_data == []
+
+      @npq_data.body["data"]["qualifications"]
+        .sort_by { |npq| npq["award_date"]&.to_date }
+        .reverse
+        .each do |npq|
+        @qualifications << Qualification.new(
+          awarded_at: npq["award_date"]&.to_date,
+          name: NPQ_QUALIFICATION_NAME[npq["npq_type"].to_sym],
+          type: npq["npq_type"]&.to_sym
+        )
       end
     end
 
-    def add_itt(qts: true)
+    def itt_qualifications(qts: true)
       all_itt_data = api_data.fetch("initial_teacher_training", [])
       eyts_itt_data, qts_itt_data = all_itt_data.partition { |itt| itt.programme_type.to_s&.starts_with?("EYITT") }
       itt_data = qts ? qts_itt_data : eyts_itt_data
 
-      @qualifications << itt_data
-        .sort_by { |itt| itt.awarded&.to_date }
-        .reverse
-        .map do |itt_response|
-          Qualification.new(
-            awarded_at: itt_response.end_date&.to_date,
-            details: CoercedDetails.new(itt_response),
-            name: "Initial teacher training (ITT)",
-            type: :itt
-          )
-        end
+      itt_data.sort_by { |itt| itt.awarded&.to_date }
+              .reverse
+              .map do |itt_response|
+        Qualification.new(
+          awarded_at: itt_response.end_date&.to_date,
+          details: CoercedDetails.new(itt_response),
+          name: "Initial teacher training (ITT)",
+          type: :itt
+        )
+      end
     end
 
-    def add_induction
+    def induction_qualification
       return if api_data.induction.blank?
       return if api_data.induction.status == "None" && !qtls_only?
 
-      @qualifications << Qualification.new(
+      Qualification.new(
         awarded_at: api_data.induction&.completed_date&.to_date,
         details: CoercedDetails.new(api_data.induction),
         qtls_only: qtls_only?,
         qts_and_qtls: qts_and_qtls?,
         set_membership_active: set_membership_active?,
         set_membership_expired: set_membership_expired?,
-        passed_induction: passed_induction?, 
+        passed_induction: passed_induction?,
         name: "Induction",
         type: :induction
       )
     end
 
-    def add_mandatory_qualifications
-      return if api_data.mandatory_qualifications.blank?
+    def mq_qualifications
+      return [] if api_data.mandatory_qualifications.blank?
 
-      @qualifications << api_data.mandatory_qualifications
-        .sort_by { |mq| mq.end_date&.to_date }
-        .reverse
-        .map do |mq|
+      api_data.mandatory_qualifications
+              .sort_by { |mq| mq.awarded&.to_date }
+              .reverse
+              .map do |mq|
         Qualification.new(
-          awarded_at: mq.end_date&.to_date,
+          awarded_at: mq.awarded&.to_date,
           details: mq,
           name: "Mandatory qualification (MQ)",
           type: :mandatory

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -235,8 +235,9 @@ module QualificationsApi
       return [] if api_data.routes_to_professional_statuses.blank?
 
       routes = api_data.routes_to_professional_statuses.select do |route|
-        route_ids.include?(route.route_to_professional_status_id) ||
-          (include_blank && route.route_to_professional_status_id.blank?)
+        route_id = route.route_to_professional_status_type.route_to_professional_status_type_id
+
+        route_ids.include?(route_id) || (include_blank && route_id.blank?)
       end
 
       sorted_routes = routes.sort_by { |r|

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -161,7 +161,8 @@ module QualificationsApi
 
       routes = api_data&.qts&.routes || []
       route_status_type_ids = routes.map do |route|
-        route.route_to_professional_status_type.route_to_professional_status_type_id.upcase # upcase to ensure case insensitivity
+        # upcase to ensure case insensitivity
+        route.route_to_professional_status_type.route_to_professional_status_type_id.upcase
       end
       route_status_type_ids.uniq == [QTLS_ROUTE_ID.upcase] # upcase to ensure case insensitivity
     end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -195,7 +195,7 @@ module QualificationsApi
 
       [
         qts_qualification,
-        rtps_qualifications(route_ids: qts_qualification.route_ids, include_blank: true)
+        rtps_qualifications(type: :qts, route_ids: qts_qualification.route_ids, include_blank: true)
       ].flatten
     end
 
@@ -212,7 +212,7 @@ module QualificationsApi
 
       [
         eyts_qualification,
-        rtps_qualifications(route_ids: eyts_qualification.route_ids)
+        rtps_qualifications(type: :eyts, route_ids: eyts_qualification.route_ids)
       ].flatten
     end
 
@@ -231,7 +231,7 @@ module QualificationsApi
       end
     end
 
-    def rtps_qualifications(route_ids: [], include_blank: false)
+    def rtps_qualifications(type:, route_ids: [], include_blank: false)
       return [] if api_data.routes_to_professional_statuses.blank?
 
       routes = api_data.routes_to_professional_statuses.select do |route|
@@ -249,8 +249,8 @@ module QualificationsApi
         Qualification.new(
           awarded_at: route.training_end_date&.to_date,
           details: CoercedDetails.new(route),
-          name: route.route_to_professional_status_type.name,
-          type: :rtps
+          name: "Route to #{type.to_s.upcase}",
+          type: :"#{type}_rtps"
         )
       end
     end

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -254,11 +254,11 @@ module QualificationsApi
       return if api_data.mandatory_qualifications.blank?
 
       @qualifications << api_data.mandatory_qualifications
-        .sort_by { |mq| mq.awarded&.to_date }
+        .sort_by { |mq| mq.end_date&.to_date }
         .reverse
         .map do |mq|
         Qualification.new(
-          awarded_at: mq.awarded&.to_date,
+          awarded_at: mq.end_date&.to_date,
           details: mq,
           name: "Mandatory qualification (MQ)",
           type: :mandatory

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -161,9 +161,9 @@ module QualificationsApi
 
       routes = api_data&.qts&.routes || []
       route_status_type_ids = routes.map do |route|
-        route.route_to_professional_status_type.route_to_professional_status_type_id
+        route.route_to_professional_status_type.route_to_professional_status_type_id.upcase # upcase to ensure case insensitivity
       end
-      route_status_type_ids.uniq == [QTLS_ROUTE_ID]
+      route_status_type_ids.uniq == [QTLS_ROUTE_ID.upcase] # upcase to ensure case insensitivity
     end
 
     def no_details?

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -174,6 +174,10 @@ module QualificationsApi
         npq_data.body["data"]["qualifications"].blank?
     end
 
+    def render_qtls_expired_message?
+      api_data.qtls_status == "Expired" && !qts_awarded?
+    end
+
     private
 
     def qts_qualifications

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -43,7 +43,7 @@ class Qualification
   end
 
   def rtps?
-    type == :rtps
+    [:qts_rtps, :eyts_rtps, :rtps].include?(type)
   end
 
   def mq?

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -3,14 +3,14 @@ class Qualification
 
   attr_accessor :awarded_at,
                 :name,
-                :status_description,
                 :type,
                 :qtls_only,
                 :set_membership_active,
                 :set_membership_expired,
                 :passed_induction,
                 :failed_induction,
-                :qts_and_qtls
+                :qts_and_qtls,
+                :routes
 
   attr_writer :details
 
@@ -42,8 +42,8 @@ class Qualification
     type == :induction
   end
 
-  def itt?
-    type == :itt
+  def rtps?
+    type == :rtps
   end
 
   def mq?
@@ -64,5 +64,11 @@ class Qualification
 
   def formatted_qualification_name
     FORMATTED_QUALIFICATION_TEXT[type].html_safe
+  end
+
+  def route_ids
+    routes&.map do |route|
+      route.route_to_professional_status_type.route_to_professional_status_type_id
+    end || []
   end
 end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,8 +1,17 @@
 class Qualification
   include ActiveModel::Model
 
-  attr_accessor :awarded_at, :name, :status_description, :type, :qtls_only, 
-  :set_membership_active, :set_membership_expired, :passed_induction, :failed_induction, :qts_and_qtls
+  attr_accessor :awarded_at,
+                :name,
+                :status_description,
+                :type,
+                :qtls_only,
+                :set_membership_active,
+                :set_membership_expired,
+                :passed_induction,
+                :failed_induction,
+                :qts_and_qtls
+
   attr_writer :details
 
   FORMATTED_QUALIFICATION_TEXT = {

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -19,6 +19,10 @@
       <%= @teacher.name %>
     </h1>
 
+    <% if @teacher.render_qtls_expired_message? %>
+      <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
+    <% end %>
+
     <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
       <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
         <% @teacher.sanctions.each do |sanction| %>

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -3,6 +3,10 @@
     <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
     <h1 class="govuk-heading-xl">Teaching qualifications</h1>
 
+    <% if @teacher.render_qtls_expired_message? %>
+      <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
+    <% end %>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <% @teacher.qualifications.each do |qualification| %>

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -3,12 +3,13 @@
     <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
     <h1 class="govuk-heading-xl">Teaching qualifications</h1>
 
-    <% if @teacher.render_qtls_expired_message? %>
-      <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
-    <% end %>
-
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
+
+        <% if @teacher.render_qtls_expired_message? %>
+          <%= govuk_warning_text(text: "You no longer have QTS via QTLS status because your Society for Education and Training (SET) membership expired") %>
+        <% end %>
+
         <% @teacher.qualifications.each do |qualification| %>
           <% if qualification.induction? %>
             <%= render InductionSummaryComponent.new(qualification:) %>

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -12,6 +12,6 @@ Grover.configure do |config|
   config.use_jpeg_middleware = false
   config.use_png_middleware = false
   config.ignore_path = ->(path) do
-    path !~ /^\/qualifications\/certificates\/(eyts|itt|induction|mq|npq|qts)/i
+    path !~ /^\/qualifications\/certificates\/(eyts|rtps|induction|mq|npq|qts)/i
   end
 end

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        name: "Initial teacher training (ITT)",
+        name: "Route to QTS",
         awarded_at: fake_quals_data.routes_to_professional_statuses.first.holds_from.to_date,
-        type: :rtps,
+        type: :qts_rtps,
         details: QualificationsApi::CoercedDetails.new(fake_quals_data.routes_to_professional_statuses.first)
       )
     end
@@ -29,26 +29,25 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the title of the section" do
-      expect(rendered.css("h2").text).to eq("Route to Professional Status")
+    it "renders the title of the section with the route type" do
+      expect(rendered.css("h2").text).to eq("Route to QTS: Initial teacher training (ITT)")
     end
 
     it "renders the qualification" do
-      expect(rows[0].text).to include("Initial teacher training (ITT)")
-      expect(rows[1].text).to include("BA")
-      expect(rows[2].text).to include("Earl Spencer Primary School")
-      expect(rows[3].text).to include("Business Studies")
-      expect(rows[4].text).to include("7 to 14 years")
-      expect(rows[5].text).to include("28 February 2022")
-      expect(rows[6].text).to include("28 January 2023")
-      expect(rows[7].text).to include("In training")
+      expect(rows[0].text).to include("BA")
+      expect(rows[1].text).to include("Earl Spencer Primary School")
+      expect(rows[2].text).to include("Business Studies")
+      expect(rows[3].text).to include("7 to 14 years")
+      expect(rows[4].text).to include("28 February 2022")
+      expect(rows[5].text).to include("28 January 2023")
+      expect(rows[6].text).to include("In training")
     end
 
     it "omits rows with no value" do
       qualification.details.end_date = nil
       qualification.details.status = nil
       expect(rows.text).not_to include("Course end date")
-      expect(rows.text).not_to include("Course result")
+      expect(rows.text).not_to include("Result")
     end
   end
 
@@ -63,7 +62,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         qtls_only: false,
         set_membership_active: false,
         passed_induction: false,
@@ -75,8 +74,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the qualification name" do
-      expect(rows[0].text).to include(qualification.name)
+    it "renders the title of the qualification" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
+    end
+
+    it "renders the status" do
+      expect(rows[0].text).to include("Qualified Teacher Status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -99,7 +102,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: false,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         type: :qts,
       )
     end
@@ -111,8 +114,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.count).to eq(2)
     end
 
-    it "renders the title 'Professional Status'" do
-      expect(rendered.css("h2").text).to eq('Professional Status')
+    it "renders the title of the qualification" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
     end
 
     it "renders the status description" do
@@ -139,7 +142,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         set_membership_active: false,
         passed_induction: false,
         qts_and_qtls: false,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         type: :qts,
       )
     end
@@ -147,8 +150,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the title 'Professional Status'" do
-      expect(rendered.css("h2").text).to eq('Professional Status')
+    it "renders the title of the qualification" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
     end
 
     it "renders the status description" do
@@ -175,7 +178,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: true,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         type: :qts,
       )
     end
@@ -187,8 +190,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.count).to eq(2)
     end
 
-    it "renders the title 'Professional Status'" do
-      expect(rendered.css("h2").text).to eq('Professional Status')
+    it "renders the title of the qualification" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
     end
 
     it "renders the status description" do
@@ -216,7 +219,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: true,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         type: :qts,
       )
     end
@@ -224,20 +227,19 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders two rows" do
+    it "renders one row" do
       expect(rows.count).to eq(2)
     end
 
-    it "renders the title 'Professional Status'" do
-      expect(rendered.css("h2").text).to eq('Professional Status')
+    it "renders the title of the qualification" do
+      expect(rendered.css("h2").text).to eq(qualification.name)
     end
 
-    it "renders the status description" do
-      expect(rows[0].text).to include("Qualified")
-      expect(rows[0].text).not_to include("via qualified teacher learning and skills (QTLS) status")
+    it "renders the status" do
+      expect(rows[0].text).to include("Qualified Teacher Status (QTS)")
     end
 
-    it "renders the status description" do
+    it "renders the awarded at date" do
       expect(rows[1].text).to include(qualification.awarded_at.to_fs(:long_uk))
     end
   end

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -20,54 +20,33 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:qualification) do
       Qualification.new(
         name: "Initial teacher training (ITT)",
-        awarded_at: fake_quals_data.end_date&.to_date,
-        type: :itt,
-        details: QualificationsApi::CoercedDetails.new(fake_quals_data.fetch("initial_teacher_training").first)
+        awarded_at: fake_quals_data.routes_to_professional_statuses.first.holds_from.to_date,
+        type: :rtps,
+        details: QualificationsApi::CoercedDetails.new(fake_quals_data.routes_to_professional_statuses.first)
       )
     end
     let(:component) { described_class.new(qualification:) }
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title of the section" do
+      expect(rendered.css("h2").text).to eq("Route to Professional Status")
     end
 
     it "renders the qualification" do
-      expect(rows[0].text).to include(qualification.details.dig("qualification", "name"))
-    end
-
-    it "renders the qualification provider" do
-      expect(rows[1].text).to include(qualification.details.dig("provider", "name"))
-    end
-
-    it "renders the qualification programme type" do
-      expect(rows[2].text).to include(qualification.details.programme_type_description)
-    end
-
-    it "renders the qualification subject" do
-      expect(rows[3].text).to include(qualification.details.subjects.first.name.titleize)
-    end
-
-    it "renders the qualification age range" do
-      expect(rows[4].text).to include(qualification.details.age_range&.description)
-    end
-
-    it "renders the qualification status" do
-      expect(rows[5].text).to include(Date.parse(qualification.details.start_date).to_fs(:long_uk))
-    end
-
-    it "renders the qualification course end date" do
-      expect(rows[6].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
-    end
-
-    it "renders the qualification status" do
-      expect(rows[7].text).to include(qualification.details.result)
+      expect(rows[0].text).to include("Initial teacher training (ITT)")
+      expect(rows[1].text).to include("BA")
+      expect(rows[2].text).to include("Earl Spencer Primary School")
+      expect(rows[3].text).to include("Business Studies")
+      expect(rows[4].text).to include("7 to 14 years")
+      expect(rows[5].text).to include("28 February 2022")
+      expect(rows[6].text).to include("28 January 2023")
+      expect(rows[7].text).to include("In training")
     end
 
     it "omits rows with no value" do
       qualification.details.end_date = nil
-      qualification.details.result = nil
+      qualification.details.status = nil
       expect(rows.text).not_to include("Course end date")
       expect(rows.text).not_to include("Course result")
     end
@@ -83,13 +62,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         qtls_only: false,
         set_membership_active: false,
         passed_induction: false,
         qts_and_qtls: false,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -98,12 +76,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
-    end
-
-
-    it "renders the status description" do
-      expect(rows[0].text).to include(qualification.status_description)
+      expect(rows[0].text).to include(qualification.name)
     end
 
     it "renders the awarded at date" do
@@ -121,13 +94,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: false,
         name: "QTS",
-        status_description: "Qualified Teacher Learning and Skills status",
         type: :qts,
       )
     end
@@ -139,8 +111,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.count).to eq(2)
     end
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title 'Professional Status'" do
+      expect(rendered.css("h2").text).to eq('Professional Status')
     end
 
     it "renders the status description" do
@@ -162,13 +134,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: false,
         passed_induction: false,
         qts_and_qtls: false,
         name: "QTS",
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -176,8 +147,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title 'Professional Status'" do
+      expect(rendered.css("h2").text).to eq('Professional Status')
     end
 
     it "renders the status description" do
@@ -199,13 +170,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: false,
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: true,
         name: "QTS",
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -217,8 +187,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.count).to eq(2)
     end
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title 'Professional Status'" do
+      expect(rendered.css("h2").text).to eq('Professional Status')
     end
 
     it "renders the status description" do
@@ -241,13 +211,12 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: false,
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: true,
         name: "QTS",
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -259,8 +228,8 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows.count).to eq(2)
     end
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title 'Professional Status'" do
+      expect(rendered.css("h2").text).to eq('Professional Status')
     end
 
     it "renders the status description" do
@@ -283,13 +252,13 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
         passed_induction: false,
         qts_and_qtls: true,
         name: "Induction",
-        details: CoercedDetails.new({status: "Not complete"}),
+        details: CoercedDetails.new({ status: "Not complete" }),
         type: :induction,
       )
     end
@@ -321,7 +290,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
         passed_induction: false,
@@ -359,7 +328,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: false,
         passed_induction: false,

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
               "routes" => [
                 {
                   "routeToProfessionalStatusType" => {
-                    "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                    "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                     "name" => "string",
                     "professionalStatusType" => "QualifiedTeacherStatus"
                   }

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
       let(:teacher) do QualificationsApi::Teacher.new(
         { 
           'qts' => { 
-              'awarded' => Time.current,
+              'holdsFrom' => Time.current,
               'qtls_only' => false,
               'set_membership_active' => false,
               'passed_induction' => true
@@ -37,16 +37,23 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
 
     context "when teacher has QTS via QTLS" do
       let(:teacher) do QualificationsApi::Teacher.new(
-        { 
           'qts' => { 
-              'awarded' => Time.current,
+              'holdsFrom' => Time.current,
               'awardedOrApprovedCount' => 1,
-              'statusDescription' => "Qualified Teacher Learning and Skills status",
+              "routes" => [
+                {
+                  "routeToProfessionalStatusType" => {
+                    "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,
+                    "name" => "string",
+                    "professionalStatusType" => "QualifiedTeacherStatus"
+                  }
+                }
+              ]
           },
           'qtlsStatus' => 'Active'
-        }
-        ) 
+        )
       end
+
       it { is_expected.to have_text("QTS via QTLS") }
     end
 
@@ -88,12 +95,20 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
       let(:teacher) do QualificationsApi::Teacher.new(
         { 
           'qts' => { 
-              'awarded' => Time.current,
-              'awardedOrApprovedCount' => 1,
-              'statusDescription' => "Qualified Teacher Learning and Skills status",
+            'holdsFrom' => Time.current,
+            'awardedOrApprovedCount' => 1,
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
+                }
+              }
+            ]
           },
           'induction' => { 
-              'status' => "None",
+            'status' => "None",
           },
           'qtlsStatus' => 'Active'
         }
@@ -124,9 +139,17 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
       let(:teacher) do QualificationsApi::Teacher.new(
         { 
           'qts' => { 
-              'awarded' => Time.current,
+              'holdsFrom' => Time.current,
               'awardedOrApprovedCount' => 2,
-              'statusDescription' => "Qualified",
+              "routes" => [
+                {
+                  "routeToProfessionalStatusType" => {
+                    "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                    "name" => "string",
+                    "professionalStatusType" => "QualifiedTeacherStatus"
+                  }
+                }
+              ]
           },
           'induction' => { 
               'status' => "None",

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
       Qualification.new(
         name: "Induction summary",
         awarded_at: induction.completed_date&.to_date,
-        type: :rtps,
+        type: :induction,
         qtls_only: false,
         qts_and_qtls: false,
         set_membership_active: false,

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
       Qualification.new(
         name: "Induction summary",
         awarded_at: induction.completed_date&.to_date,
-        type: :itt,
+        type: :rtps,
         qtls_only: false,
         qts_and_qtls: false,
         set_membership_active: false,

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        name: "Initial teacher training (ITT)",
+        name: "Route to QTS",
         awarded_at: fake_quals_data.routes_to_professional_statuses.first.holds_from.to_date,
-        type: :rtps,
+        type: :qts_rtps,
         details: QualificationsApi::CoercedDetails.new(fake_quals_data.routes_to_professional_statuses.first)
       )
     end
@@ -21,8 +21,8 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+    it "renders the title with the route type" do
+      expect(rendered.css("h2").text).to eq("Route to QTS: Initial teacher training (ITT)")
     end
 
     it "renders the qualification" do
@@ -40,7 +40,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       qualification.details.training_end_date = nil
       qualification.details.status = nil
       expect(rows.text).not_to include("End date")
-      expect(rows.text).not_to include("Course result")
+      expect(rows.text).not_to include("Result")
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: true,
         qtls_only: false,
         qts_and_qtls: false,
@@ -68,7 +68,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -91,7 +91,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: true,
         qtls_only: true,
         qts_and_qtls: false,
@@ -104,7 +104,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -129,7 +129,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: true,
         qtls_only: true,
         qts_and_qtls: false,
@@ -142,7 +142,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -161,7 +161,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: false,
         qtls_only: true,
         qts_and_qtls: false,
@@ -174,7 +174,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -197,7 +197,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: true,
         qtls_only: true,
         set_membership_active: true,
@@ -209,7 +209,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -234,7 +234,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: true,
         qtls_only: true,
         set_membership_active: false,
@@ -246,7 +246,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do
@@ -265,7 +265,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
-        name: "QTS",
+        name: "Qualified teacher status (QTS)",
         passed_induction: false,
         qtls_only: true,
         set_membership_active: true,
@@ -277,7 +277,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
     it "renders the qualification name" do
-      expect(rendered.css("h2").text).to eq(qualification.name)
+      expect(rendered.css("h2").text).to eq("Qualified teacher status (QTS)")
     end
 
     it "renders the awarded at date" do

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     let(:qualification) do
       Qualification.new(
         name: "Initial teacher training (ITT)",
-        awarded_at: fake_quals_data.initial_teacher_training.first.end_date.value,
-        type: :itt,
-        details: QualificationsApi::CoercedDetails.new(fake_quals_data.fetch("initial_teacher_training").first)
+        awarded_at: fake_quals_data.routes_to_professional_statuses.first.holds_from.to_date,
+        type: :rtps,
+        details: QualificationsApi::CoercedDetails.new(fake_quals_data.routes_to_professional_statuses.first)
       )
     end
     let(:component) { described_class.new(qualification:) }
@@ -26,41 +26,20 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
 
     it "renders the qualification" do
-      expect(rows[0].text).to include(qualification.details.dig("qualification", "name"))
-    end
-
-    it "renders the qualification provider" do
-      expect(rows[1].text).to include(qualification.details.dig("provider", "name"))
-    end
-
-    it "renders the qualification programme type" do
-      expect(rows[2].text).to include(qualification.details.programme_type_description)
-    end
-
-    it "renders the qualification subject" do
-      expect(rows[3].text).to include(qualification.details.subjects.first.name.titleize)
-    end
-
-    it "renders the qualification course start date" do
-      expect(rows[4].text).to include(Date.parse(qualification.details.start_date).to_fs(:long_uk))
-    end
-
-    it "renders the qualification course end date" do
-      expect(rows[5].text).to include(Date.parse(qualification.details.end_date).to_fs(:long_uk))
-    end
-
-    it "renders the qualification status" do
-      expect(rows[6].text).to include(qualification.details.result)
-    end
-
-    it "renders the qualification age range" do
-      expect(rows[7].text).to include(qualification.details.age_range&.description)
+      expect(rows[0].text).to include("Initial teacher training (ITT)")
+      expect(rows[1].text).to include("BA")
+      expect(rows[2].text).to include("Earl Spencer Primary School")
+      expect(rows[3].text).to include("Business Studies")
+      expect(rows[4].text).to include("28 February 2022")
+      expect(rows[5].text).to include("28 January 2023")
+      expect(rows[6].text).to include("In training")
+      expect(rows[7].text).to include("7 to 14 years")
     end
 
     it "omits rows with no value" do
-      qualification.details.end_date = nil
-      qualification.details.result = nil
-      expect(rows.text).not_to include("Course end date")
+      qualification.details.training_end_date = nil
+      qualification.details.status = nil
+      expect(rows.text).not_to include("End date")
       expect(rows.text).not_to include("Course result")
     end
   end
@@ -75,13 +54,12 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: true,
         qtls_only: false,
         qts_and_qtls: false,
         set_membership_active: false,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -100,10 +78,6 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     it "renders the status description" do
       expect(rows[1].text).to include("Certificate")
     end
-
-    it "renders the status description" do
-      expect(rows[2].text).to include(qualification.status_description)
-    end
   end
 
   describe "rendering QTLS with Set membership active" do
@@ -116,13 +90,12 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: true,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: true,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -155,13 +128,12 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: true,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: false,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -188,13 +160,12 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: false,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: true,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -225,12 +196,11 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: true,
         qtls_only: true,
         set_membership_active: true,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -263,12 +233,11 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: true,
         qtls_only: true,
         set_membership_active: false,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end
@@ -295,12 +264,11 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.awarded&.to_date,
+        awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "QTS",
         passed_induction: false,
         qtls_only: true,
         set_membership_active: true,
-        status_description: "Qualified (trained in the UK)",
         type: :qts,
       )
     end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -147,12 +147,12 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     it "sorts the qualifications in reverse chronological order by date of award" do
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML mandatory induction qts rtps eyts rtps]
+        %i[NPQSL NPQML mandatory induction qts qts_rtps eyts eyts_rtps]
       )
     end
 
     it "orders QTS RTPS qualifications before EYTS RTPS qualifications" do
-      rtps_qualifications = qualifications.select { |q| q.type == :rtps }
+      rtps_qualifications = qualifications.select { |q| q.type == :eyts_rtps || q.type == :qts_rtps }
       expect(rtps_qualifications.map do |q|
  q.details.route_to_professional_status_type.professional_status_type end).to eq(
         %w[QualifiedTeacherStatus EarlyYearsTeacherStatus]
@@ -165,7 +165,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       api_data["routesToProfessionalStatuses"] = [rtps_qualification]
 
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML mandatory induction qts rtps eyts]
+        %i[NPQSL NPQML mandatory induction qts qts_rtps eyts]
       )
     end
 
@@ -175,7 +175,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "returns human readable values" do
-        expect(qualifications.find { |q| q.type == :rtps }.details.status).to eq("Deferred for skills tests")
+        expect(qualifications.find { |q| q.type == :qts_rtps }.details.status).to eq("Deferred for skills tests")
       end
     end
 
@@ -320,7 +320,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "sorts the qualifications in reverse order by date of award and type" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
       end
     end
 
@@ -473,7 +473,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
       end
     end
 
@@ -618,7 +618,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
       end
     end
   end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         "statusDescription" => "Qualified",
       },
       "mandatoryQualifications" => [
-        { "awarded" => "2013-06-01", "specialism" => "Visual Impairment" }
+        { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "qualificationId" => 1 }
       ],
     }
   end

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -20,55 +20,122 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
           }
         ]
       },
-      "initialTeacherTraining" => [
+      "routesToProfessionalStatuses" => [
         {
-          "qualification" => {
-            "name" => "PGCE"
+          "routeToProfessionalStatusId" => "eyts-route-id-22222",
+          "routeToProfessionalStatusType" => {
+            "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+            "name" => "BA",
+            "professionalStatusType" => "EarlyYearsTeacherStatus"
           },
-          "startDate" => "2011-01-17",
-          "endDate" => "2012-02-2",
-          "programmeType" => "EYITTSchoolDirectEarlyYears",
-          "programmeTypeDescription" => "Early Years Initial Teacher Training (School Direct)",
-          "result" => "Passed",
-          "ageRange" => {
-            "description" => "3 to 7 years"
+          "status" => "Holds",
+          "holdsFrom" => "2012-02-2",
+          "trainingStartDate" => "2011-01-17",
+          "trainingEndDate" => "2012-02-2",
+          "trainingSubjects" => [
+            {
+              "reference" => "100079",
+              "name" => "Business Studies"
+            }
+          ],
+          "trainingAgeSpecialism" => {
+            "type" => "Range",
+            "from" => 3,
+            "to" => 7
           },
-          "provider" => {
-            "name" => "Earl Spencer Primary School",
-            "ukprn" => nil
+          "trainingCountry" => {
+            "reference" => "string",
+            "name" => "United Kingdom"
           },
-          "subjects" => [{ "code" => "100079", "name" => "business studies" }]
-        },
-        {
-          "qualification" => {
+          "trainingProvider" => {
+            "ukprn" => "12345",
+            "name" => "Earl Spencer Primary School"
+          },
+          "degreeType" => {
+            "degreeTypeId" => "degree-type-id-44444",
             "name" => "BA"
           },
-          "startDate" => "2012-02-28",
-          "endDate" => "2013-01-28",
-          "programmeType" => "HEI",
-          "programmeTypeDescription" => "Higher Education Institution",
-          "result" => "Passed",
-          "ageRange" => {
-            "description" => "10 to 16 years"
+          "inductionExemption" => {
+            "isExempt" => true,
+            "exemptionReasons" => [
+              {
+                "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                "name" => "string"
+              }
+            ]
+          }
+        },
+        {
+          "routeToProfessionalStatusId" => "qts-route-id-11111",
+          "routeToProfessionalStatusType" => {
+            "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+            "name" => "BA",
+            "professionalStatusType" => "QualifiedTeacherStatus"
           },
-          "provider" => {
-            "name" => "Earl Spencer Primary School",
-            "ukprn" => nil
+          "status" => "Holds",
+          "holdsFrom" => "2013-01-28",
+          "trainingStartDate" => "2012-02-28",
+          "trainingEndDate" => "2013-01-28",
+          "trainingSubjects" => [
+            {
+              "reference" => "100079",
+              "name" => "Business Studies"
+            }
+          ],
+          "trainingAgeSpecialism" => {
+            "type" => "Range",
+            "from" => 10,
+            "to" => 16
           },
-          "subjects" => [{ "code" => "100079", "name" => "business studies" }]
-        }
+          "trainingCountry" => {
+            "reference" => "string",
+            "name" => "United Kingdom"
+          },
+          "trainingProvider" => {
+            "ukprn" => "12345",
+            "name" => "Earl Spencer Primary School"
+          },
+          "degreeType" => {
+            "degreeTypeId" => "degree-type-id-44444",
+            "name" => "BA"
+          },
+          "inductionExemption" => {
+            "isExempt" => true,
+            "exemptionReasons" => [
+              {
+                "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                "name" => "string"
+              }
+            ]
+          }
+        },
       ],
       "qts" => {
-        "awarded" => "2015-11-01",
-        "statusDescription" => "Qualified (trained in the UK)",
+        "holdsFrom" => "2015-11-01",
+        "routes" => [
+          {
+            "routeToProfessionalStatusType" => {
+              "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+              "name" => "string",
+              "professionalStatusType" => "QualifiedTeacherStatus"
+            }
+          }
+        ]
       },
       "eyts" => {
-        "awarded" => "2015-11-02",
-        "certificateUrl" => "https://example.com/certificate.pdf",
-        "statusDescription" => "Qualified",
+        "holdsFrom" => "2015-11-02",
+        "routes" => [
+          {
+            "routeToProfessionalStatusType" => {
+              "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+              "name" => "BA",
+              "professionalStatusType" => "EarlyYearsTeacherStatus"
+            }
+          }
+        ]
       },
       "mandatoryQualifications" => [
-        { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "qualificationId" => 1 }
+        { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "mandatoryQualificationId" => 1 }
       ],
     }
   end
@@ -80,78 +147,180 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     it "sorts the qualifications in reverse chronological order by date of award" do
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML mandatory induction qts itt eyts itt]
+        %i[NPQSL NPQML mandatory induction qts rtps eyts rtps]
       )
     end
 
-    it "orders QTS ITT qualifications before EYTS ITT qualifications" do
-      itt_qualifications = qualifications.select { |q| q.type == :itt }
-      expect(itt_qualifications.map { |q| q.details.programme_type }).to eq(
-        %w[HEI EYITTSchoolDirectEarlyYears]
+    it "orders QTS RTPS qualifications before EYTS RTPS qualifications" do
+      rtps_qualifications = qualifications.select { |q| q.type == :rtps }
+      expect(rtps_qualifications.map do |q|
+ q.details.route_to_professional_status_type.professional_status_type end).to eq(
+        %w[QualifiedTeacherStatus EarlyYearsTeacherStatus]
       )
     end
 
-    it "designates ITT qualifications as QTS if no programme type is present" do
-      itt_qualification = api_data["initialTeacherTraining"].first
-      itt_qualification["programmeType"] = nil
-      api_data["initialTeacherTraining"] = [itt_qualification]
+    it "designates RTPS qualifications as QTS if no programme type is present" do
+      rtps_qualification = api_data["routesToProfessionalStatuses"].first
+      rtps_qualification["routeToProfessionalStatusId"] = nil
+      api_data["routesToProfessionalStatuses"] = [rtps_qualification]
 
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML mandatory induction qts itt eyts]
+        %i[NPQSL NPQML mandatory induction qts rtps eyts]
       )
     end
 
-    context "ITT result field" do
+    context "RTPS result field" do
       before do
-        api_data["initialTeacherTraining"].each { |itt| itt["result"] = "DeferredForSkillsTests" }
+        api_data["routesToProfessionalStatuses"].each { |rtps| rtps["status"] = "DeferredForSkillsTests" }
       end
 
       it "returns human readable values" do
-        expect(qualifications.find { |q| q.type == :itt }.details.result).to eq("Deferred for skills tests")
+        expect(qualifications.find { |q| q.type == :rtps }.details.status).to eq("Deferred for skills tests")
       end
     end
 
     context "when a qualification has no awarded date" do
       let(:api_data) do
         {
-          "trn" => "111112",
-          "initial_teacher_training" => [
+          "trn" => "1111111",
+          "induction" => {
+            "startDate" => "2015-01-01",
+            "endDate" => "2015-07-01",
+            "status" => "Complete",
+            "certificateUrl" => "https",
+            "periods" => [
+              {
+                "startDate" => "string",
+                "endDate" => "string",
+                "terms" => "integer",
+                "appropriateBody" => {
+                  "name" => "string"
+                }
+              }
+            ]
+          },
+          "routesToProfessionalStatuses" => [
             {
-              "qualification" => {
+              "routeToProfessionalStatusId" => "eyts-route-id-22222",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "name" => "BA",
+                "professionalStatusType" => "EarlyYearsTeacherStatus"
+              },
+              "status" => "Holds",
+              "holdsFrom" => nil,
+              "trainingStartDate" => "2011-01-17",
+              "trainingEndDate" => "2012-02-2",
+              "trainingSubjects" => [
+                {
+                  "reference" => "100079",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 3,
+                "to" => 7
+              },
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
                 "name" => "BA"
               },
-              "startDate" => "2012-02-28",
-              "endDate" => "2013-01-28",
-              "programmeType" => "HEI",
-              "programmeTypeDescription" => "Higher Education Institution",
-              "result" => "Passed",
-              "ageRange" => {
-                "description" => "10 to 16 years"
-              },
-              "provider" => {
-                "name" => "Earl Spencer Primary School",
-                "ukprn" => nil
-              },
-              "subjects" => [
-                { "code" => "100079", "name" => "business studies" }
-              ]
-            }
-          ],
-          "npqQualifications" => [
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
+            },
             {
-              "type" => {
-                "code" => "NPQML",
-                "name" => "NPQ for Middle Leadership"
+              "routeToProfessionalStatusId" => "qts-route-id-11111",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "name" => "BA",
+                "professionalStatusType" => "QualifiedTeacherStatus"
               },
-              "awarded" => nil,
-              "certificateUrl" => "https://example.com/v3/certificates/456"
-            }
-          ]
+              "status" => "Holds",
+              "holdsFrom" => "2013-01-28",
+              "trainingStartDate" => "2012-02-28",
+              "trainingEndDate" => "2013-01-28",
+              "trainingSubjects" => [
+                {
+                  "reference" => "100079",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 10,
+                "to" => 16
+              },
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
+                "name" => "BA"
+              },
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
+            },
+          ],
+          "qts" => {
+            "holdsFrom" => "2015-11-01",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          "eyts" => {
+            "holdsFrom" => "2015-11-02",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "name" => "BA",
+                  "professionalStatusType" => "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          "mandatoryQualifications" => [
+            { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "mandatoryQualificationId" => 1 }
+          ],
         }
       end
 
       it "sorts the qualifications in reverse order by date of award and type" do
-        expect(qualifications.map(&:type)).to eq(%i[NPQML itt])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
       end
     end
 
@@ -163,75 +332,293 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
     end
 
-    context "when QTS and ITT share the same date" do
+    context "when QTS and RTPS share the same date" do
       let(:api_data) do
         {
-          "initialTeacherTraining" => [
+          "trn" => "1111111",
+          "induction" => {
+            "startDate" => "2015-01-01",
+            "endDate" => "2015-07-01",
+            "status" => "Complete",
+            "certificateUrl" => "https",
+            "periods" => [
+              {
+                "startDate" => "string",
+                "endDate" => "string",
+                "terms" => "integer",
+                "appropriateBody" => {
+                  "name" => "string"
+                }
+              }
+            ]
+          },
+          "routesToProfessionalStatuses" => [
             {
-              "qualification" => {
+              "routeToProfessionalStatusId" => "eyts-route-id-22222",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "name" => "BA",
+                "professionalStatusType" => "EarlyYearsTeacherStatus"
+              },
+              "status" => "Holds",
+              "holdsFrom" => "2012-02-2",
+              "trainingStartDate" => "2011-01-17",
+              "trainingEndDate" => "2012-02-2",
+              "trainingSubjects" => [
+                {
+                  "reference" => "100079",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 3,
+                "to" => 7
+              },
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
                 "name" => "BA"
               },
-              "startDate" => "2012-02-28",
-              "endDate" => "2013-01-28",
-              "programmeType" => "HEI",
-              "programmeTypeDescription" => "Higher Education Institution",
-              "result" => "Passed",
-              "ageRange" => {
-                "description" => "10 to 16 years"
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
+            },
+            {
+              "routeToProfessionalStatusId" => "qts-route-id-11111",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "name" => "Initial teacher training (ITT)",
+                "professionalStatusType" => "QualifiedTeacherStatus"
               },
-              "provider" => {
-                "name" => "Earl Spencer Primary School",
-                "ukprn" => nil
+              "status" => "InTraining",
+              "holdsFrom" => "2015-11-01",
+              "trainingStartDate" => "2014-11-01",
+              "trainingEndDate" => "2015-11-01",
+              "trainingSubjects" => [
+                {
+                  "reference" => "12345",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 7,
+                "to" => 14
               },
-              "subjects" => [
-                { "code" => "100079", "name" => "business studies" }
-              ]
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
+                "name" => "BA"
+              },
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
             }
           ],
           "qts" => {
-            "awarded" => "2013-01-28",
-          }
+            "holdsFrom" => "2015-11-01",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          "eyts" => {
+            "holdsFrom" => "2015-11-02",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "name" => "string",
+                  "professionalStatusType" => "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          "mandatoryQualifications" => [
+            { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "mandatoryQualificationId" => 1 }
+          ],
         }
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq(%i[qts itt])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
       end
     end
 
     context "when programmeType is an Integer" do
       let(:api_data) do
         {
-          "initialTeacherTraining" => [
+          "trn" => "1111111",
+          "induction" => {
+            "startDate" => "2015-01-01",
+            "endDate" => "2015-07-01",
+            "status" => "Complete",
+            "certificateUrl" => "https",
+            "periods" => [
+              {
+                "startDate" => "string",
+                "endDate" => "string",
+                "terms" => "integer",
+                "appropriateBody" => {
+                  "name" => "string"
+                }
+              }
+            ]
+          },
+          "routesToProfessionalStatuses" => [
             {
-              "qualification" => {
+              "routeToProfessionalStatusId" => "eyts-route-id-22222",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "name" => "BA",
+                "professionalStatusType" => "EarlyYearsTeacherStatus"
+              },
+              "status" => "Holds",
+              "holdsFrom" => "2012-02-2",
+              "trainingStartDate" => "2011-01-17",
+              "trainingEndDate" => "2012-02-2",
+              "trainingSubjects" => [
+                {
+                  "reference" => "100079",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 3,
+                "to" => 7
+              },
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
                 "name" => "BA"
               },
-              "startDate" => "2012-02-28",
-              "endDate" => "2013-01-28",
-              "programmeType" => 1,
-              "programmeTypeDescription" => "Higher Education Institution",
-              "result" => "Passed",
-              "ageRange" => {
-                "description" => "10 to 16 years"
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
+            },
+            {
+              "routeToProfessionalStatusId" => "qts-route-id-11111",
+              "routeToProfessionalStatusType" => {
+                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "name" => "Initial teacher training (ITT)",
+                "professionalStatusType" => "QualifiedTeacherStatus"
               },
-              "provider" => {
-                "name" => "Earl Spencer Primary School",
-                "ukprn" => nil
+              "status" => "InTraining",
+              "holdsFrom" => "2015-11-01",
+              "trainingStartDate" => "2014-11-01",
+              "trainingEndDate" => "2015-11-01",
+              "trainingSubjects" => [
+                {
+                  "reference" => "12345",
+                  "name" => "Business Studies"
+                }
+              ],
+              "trainingAgeSpecialism" => {
+                "type" => "Range",
+                "from" => 7,
+                "to" => 14
               },
-              "subjects" => [
-                { "code" => "100079", "name" => "business studies" }
-              ]
+              "trainingCountry" => {
+                "reference" => "string",
+                "name" => "United Kingdom"
+              },
+              "trainingProvider" => {
+                "ukprn" => "12345",
+                "name" => "Earl Spencer Primary School"
+              },
+              "degreeType" => {
+                "degreeTypeId" => "degree-type-id-44444",
+                "name" => "BA"
+              },
+              "inductionExemption" => {
+                "isExempt" => true,
+                "exemptionReasons" => [
+                  {
+                    "inductionExemptionReasonId" => "induction-exemption-reason-id-33333",
+                    "name" => "string"
+                  }
+                ]
+              }
             }
           ],
           "qts" => {
-            "awarded" => "2013-01-28",
-          }
+            "holdsFrom" => "2015-11-01",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          "eyts" => {
+            "holdsFrom" => "2015-11-02",
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "name" => "string",
+                  "professionalStatusType" => "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          "mandatoryQualifications" => [
+            { "endDate" => "2013-06-01", "specialism" => "Visual Impairment", "mandatoryQualificationId" => 1 }
+          ],
         }
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq(%i[qts itt])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :rtps, :eyts, :rtps])
       end
     end
   end
@@ -314,7 +701,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     let(:teacher) { described_class.new(api_data) }
 
     context "qts awarded timestamp is present" do
-      let(:api_data) { { "qts" => { "awarded" => "2013-01-28", } } }
+      let(:api_data) { { "qts" => { "holdsFrom" => "2013-01-28", } } }
 
       it "returns true" do
         expect(teacher.qts_awarded?).to eq true
@@ -342,7 +729,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
     end
 
     context "induction status is anything other than 'Pass'" do
-      let(:api_data) { { "induction" => { "status_description" => "Failed", } } }
+      let(:api_data) { { "induction" => { "status" => "Failed", } } }
 
       it "returns false" do
         expect(teacher.passed_induction?).to eq false

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         {
           "routeToProfessionalStatusId" => "eyts-route-id-22222",
           "routeToProfessionalStatusType" => {
-            "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+            "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
             "name" => "BA",
             "professionalStatusType" => "EarlyYearsTeacherStatus"
           },
@@ -68,7 +68,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         {
           "routeToProfessionalStatusId" => "qts-route-id-11111",
           "routeToProfessionalStatusType" => {
-            "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+            "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
             "name" => "BA",
             "professionalStatusType" => "QualifiedTeacherStatus"
           },
@@ -115,7 +115,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         "routes" => [
           {
             "routeToProfessionalStatusType" => {
-              "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+              "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
               "name" => "string",
               "professionalStatusType" => "QualifiedTeacherStatus"
             }
@@ -127,7 +127,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
         "routes" => [
           {
             "routeToProfessionalStatusType" => {
-              "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+              "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
               "name" => "BA",
               "professionalStatusType" => "EarlyYearsTeacherStatus"
             }
@@ -161,7 +161,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
 
     it "designates RTPS qualifications as QTS if no programme type is present" do
       rtps_qualification = api_data["routesToProfessionalStatuses"].first
-      rtps_qualification["routeToProfessionalStatusId"] = nil
+      rtps_qualification["routeToProfessionalStatusType"]["routeToProfessionalStatusTypeId"] = nil
       api_data["routesToProfessionalStatuses"] = [rtps_qualification]
 
       expect(qualifications.map(&:type)).to eq(
@@ -203,7 +203,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "eyts-route-id-22222",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                 "name" => "BA",
                 "professionalStatusType" => "EarlyYearsTeacherStatus"
               },
@@ -247,7 +247,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "qts-route-id-11111",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                 "name" => "BA",
                 "professionalStatusType" => "QualifiedTeacherStatus"
               },
@@ -294,7 +294,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                   "name" => "string",
                   "professionalStatusType" => "QualifiedTeacherStatus"
                 }
@@ -306,7 +306,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                   "name" => "BA",
                   "professionalStatusType" => "EarlyYearsTeacherStatus"
                 }
@@ -356,7 +356,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "eyts-route-id-22222",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                 "name" => "BA",
                 "professionalStatusType" => "EarlyYearsTeacherStatus"
               },
@@ -400,7 +400,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "qts-route-id-11111",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                 "name" => "Initial teacher training (ITT)",
                 "professionalStatusType" => "QualifiedTeacherStatus"
               },
@@ -447,7 +447,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                   "name" => "string",
                   "professionalStatusType" => "QualifiedTeacherStatus"
                 }
@@ -459,7 +459,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                   "name" => "string",
                   "professionalStatusType" => "EarlyYearsTeacherStatus"
                 }
@@ -501,7 +501,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "eyts-route-id-22222",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                 "name" => "BA",
                 "professionalStatusType" => "EarlyYearsTeacherStatus"
               },
@@ -545,7 +545,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             {
               "routeToProfessionalStatusId" => "qts-route-id-11111",
               "routeToProfessionalStatusType" => {
-                "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                 "name" => "Initial teacher training (ITT)",
                 "professionalStatusType" => "QualifiedTeacherStatus"
               },
@@ -592,7 +592,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+                  "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
                   "name" => "string",
                   "professionalStatusType" => "QualifiedTeacherStatus"
                 }
@@ -604,7 +604,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
             "routes" => [
               {
                 "routeToProfessionalStatusType" => {
-                  "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+                  "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
                   "name" => "string",
                   "professionalStatusType" => "EarlyYearsTeacherStatus"
                 }

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -320,7 +320,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "sorts the qualifications in reverse order by date of award and type" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, 
+:eyts_rtps])
       end
     end
 
@@ -473,7 +474,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, 
+:eyts_rtps])
       end
     end
 
@@ -618,7 +620,8 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       end
 
       it "the QTS gets priority in the sort order" do
-        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, :eyts_rtps])
+        expect(qualifications.map(&:type)).to eq([:NPQSL, :NPQML, :mandatory, :induction, :qts, :qts_rtps, :eyts, 
+:eyts_rtps])
       end
     end
   end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -44,5 +44,17 @@ RSpec.describe Qualification, type: :model do
 
       it { is_expected.to be_truthy }
     end
+
+    context "when the qualification type is qts_rtps" do
+      let(:type) { :qts_rtps }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the qualification type is eyts_rtps" do
+      let(:type) { :eyts_rtps }
+
+      it { is_expected.to be_truthy }
+    end
   end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe Qualification, type: :model do
     end
   end
 
-  describe "#itt?" do
-    subject { qualification.itt? }
+  describe "#rtps?" do
+    subject { qualification.rtps? }
 
     let(:qualification) { described_class.new(type:) }
     let(:type) { :qts }
 
     it { is_expected.to be_falsey }
 
-    context "when the qualification type is itt" do
-      let(:type) { :itt }
+    context "when the qualification type is rtps" do
+      let(:type) { :rtps }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -10,8 +10,8 @@ class FakeQualificationsApi < Sinatra::Base
     case bearer_token
     when "token"
       quals_data.to_json
-    when "no-itt-token"
-      quals_data(trn: "1234567", itt: false).to_json
+    when "no-rtps-token"
+      quals_data(trn: "1234567", rtps: false).to_json
     when "nulled-quals-data"
       FakeQualificationsDataWithNulling.generate.to_json
     when "invalid-token"

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -1,5 +1,5 @@
 module FakeQualificationsData
-  def quals_data(trn: nil, itt: true)
+  def quals_data(trn: nil, rtps: true)
     {
       trn: trn || "3000299",
       dateOfBirth: "2000-01-01",
@@ -10,88 +10,107 @@ module FakeQualificationsData
         { first_name: "Terry", last_name: "Smith", middle_name: "" }
       ],
       eyts: {
-        awarded: "2022-04-01",
-        statusDescription: "Qualified (trained in the UK)",
+        holdsFrom: "2022-04-01",
+        routes: [
+          {
+            "routeToProfessionalStatusType" => {
+              "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+              "name" => "BA",
+              "professionalStatusType" => "EarlyYearsTeacherStatus"
+            }
+          }
+        ]
       },
       qts: {
-        awarded: "2023-02-27",
-        statusDescription: "Qualified (trained in the UK)",
+        holdsFrom: "2023-02-27",
+        "routes" => [
+          {
+            "routeToProfessionalStatusType" => {
+              "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+              "name" => "Initial teacher training (ITT)",
+              "professionalStatusType" => "QualifiedTeacherStatus"
+            }
+          }
+        ],
         awarded_approved_count: "1"
       },
       induction: {
         startDate: "2022-09-01",
         completedDate: "2022-10-01",
         status: "Passed",
+        exemptionReasons: [
+          {
+            inductionExemptionReasonId: "induction-exemption-reason-id-33333",
+            "name": "Gained QTS before 1999"
+          }
+        ]
       },
-      initialTeacherTraining:
-        (
-          if !itt
-            []
-          else
-            [
-              {
-                qualification: {
-                  name: "BA"
-                },
-                startDate: {
-                  value: "2022-02-28",
-                  hasValue: true,
-                },
-                endDate: {
-                  value: "2023-01-28",
-                  hasValue: true,
-                },
-                programmeType: {
-                  hasValue: true,
-                  value: "HEI",
-                },
-                programmeTypeDescription: "Higher education institution",
-                result: {
-                  hasValue: true,
-                  value: "Passed",
-                },
-                ageRange: {
-                  description: "10 to 16 years"
-                },
-                provider: {
-                  name: "Earl Spencer Primary School",
-                  ukprn: nil
-                },
-                subjects: [{ code: "100079", name: "business studies" }]
-              }
-            ]
-          end
-        ),
+      "routesToProfessionalStatuses": [rtps ? build_rtps : nil].compact,
       mandatoryQualifications: [
-        { endDate: "2023-02-28", specialism: "Visual impairment", qualificationId: 1 },
-        { endDate: "2022-01-01", specialism: "Hearing", qualificationId: 1 }
+        { endDate: "2023-02-28", specialism: "Visual impairment", mandatoryQualificationId: 1 },
+        { endDate: "2022-01-01", specialism: "Hearing", mandatoryQualificationId: 1 }
       ],
-      npqQualifications: [
-        {
-          awarded: "2023-02-27",
-          certificateUrl: "/v3/certificates/npq/1",
-          type: {
-            code: "NPQH",
-            name: "NPQ headteacher"
-          }
-        },
-        {
-          awarded: "2023-01-27",
-          certificateUrl: "/v3/certificates/npq/missing",
-          type: {
-            code: "NPQSL",
-            name: "National Professional Qualification (NPQ) for Early Years Leadership"
-          }
-        }
-      ],
-      alerts: if trn == "9876543"
-  [ { alert_type: {alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99"}, 
-startDate: "2020-10-25" } ]
-else
-  []
-end,
+      alerts: fake_alerts(trn),
       qtlsStatus: "None"
     }
+  end
+
+  def build_rtps
+    {
+      "routeToProfessionalStatusId": "qts-route-id-11111",
+      "routeToProfessionalStatusType": {
+        "routeToProfessionalStatusTypeId": "qts-route-id-11111",
+        "name": "Initial teacher training (ITT)",
+        "professionalStatusType": "QualifiedTeacherStatus"
+      },
+      "status": "InTraining",
+      "holdsFrom": "2023-02-27",
+      "trainingStartDate": "2022-02-28",
+      "trainingEndDate": "2023-01-28",
+      "trainingSubjects": [
+        {
+          "reference": "12345",
+          "name": "Business Studies"
+        }
+      ],
+      "trainingAgeSpecialism": {
+        "type": "Range",
+        "from": 7,
+        "to": 14
+      },
+      "trainingCountry": {
+        "reference": "string",
+        "name": "United Kingdom"
+      },
+      "trainingProvider": {
+        "ukprn": "12345",
+        "name": "Earl Spencer Primary School"
+      },
+      "degreeType": {
+        "degreeTypeId": "degree-type-id-44444",
+        "name": "BA"
+      },
+      "inductionExemption": {
+        "isExempt": true,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "induction-exemption-reason-id-33333",
+            "name": "string"
+          }
+        ]
+      }
+    }
+  end
+
+  def fake_alerts(trn)
+    return [] unless trn == "9876543"
+
+    [
+      {
+        alert_type: { alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99" },
+        startDate: "2020-10-25"
+      }
+    ]
   end
 
   def no_data(trn:)
@@ -104,9 +123,8 @@ end,
       eyts: nil,
       qts: nil,
       induction: nil,
-      initialTeacherTraining: nil,
       mandatoryQualifications: [],
-      npqQualifications: [],
+      routesToProfessionalStatuses: [],
       alerts: [],
       qtlsStatus: nil,
     }

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -14,7 +14,7 @@ module FakeQualificationsData
         routes: [
           {
             "routeToProfessionalStatusType" => {
-              "routeToProfessionalStatusTypeId" => "eyts-route-id-22222",
+              "routeToProfessionalStatusTypeId" => "eyts-route-type-id-22222",
               "name" => "BA",
               "professionalStatusType" => "EarlyYearsTeacherStatus"
             }
@@ -26,7 +26,7 @@ module FakeQualificationsData
         "routes" => [
           {
             "routeToProfessionalStatusType" => {
-              "routeToProfessionalStatusTypeId" => "qts-route-id-11111",
+              "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
               "name" => "Initial teacher training (ITT)",
               "professionalStatusType" => "QualifiedTeacherStatus"
             }
@@ -59,7 +59,7 @@ module FakeQualificationsData
     {
       "routeToProfessionalStatusId": "qts-route-id-11111",
       "routeToProfessionalStatusType": {
-        "routeToProfessionalStatusTypeId": "qts-route-id-11111",
+        "routeToProfessionalStatusTypeId": "qts-route-type-id-11111",
         "name": "Initial teacher training (ITT)",
         "professionalStatusType": "QualifiedTeacherStatus"
       },

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -63,8 +63,8 @@ module FakeQualificationsData
           end
         ),
       mandatoryQualifications: [
-        { awarded: "2023-02-28", specialism: "Visual impairment" },
-        { awarded: "2022-01-01", specialism: "Hearing" }
+        { endDate: "2023-02-28", specialism: "Visual impairment", qualificationId: 1 },
+        { endDate: "2022-01-01", specialism: "Hearing", qualificationId: 1 }
       ],
       npqQualifications: [
         {

--- a/spec/support/fake_qualifications_data_with_nulling.rb
+++ b/spec/support/fake_qualifications_data_with_nulling.rb
@@ -18,55 +18,32 @@ class FakeQualificationsDataWithNulling
     @data[:lastName] = nil
     @data[:previousNames] = []
 
-    minimal_eyts!
-    minimal_qts!
     minimal_induction!
-    minimal_itt!
+    minimal_rtps!
     minimal_mandatory_qualifications!
-    minimal_npq!
     minimal_sanctions!
     @data
   end
 
   private
 
-  def minimal_eyts!
-    @data[:eyts][:certificateUrl] = nil
-  end
-
-  def minimal_qts!
-    @data[:qts][:certificateUrl] = nil
-  end
-
   def minimal_induction!
     @data[:induction][:startDate] = nil
     @data[:induction][:endDate] = nil
     @data[:induction][:status] = "None"
-    @data[:induction][:statusDescription] = nil
     @data[:induction][:certificateUrl] = nil
   end
 
-  def minimal_itt!
-    @data[:initialTeacherTraining].each do |itt|
-      itt[:qualification] = nil
-      itt[:startDate] = nil
-      itt[:endDate] = nil
-      itt[:programmeType] = nil
-      itt[:programmeTypeDescription] = nil
-      itt[:result] = nil
-      itt[:ageRange] = nil
-      itt[:provider] = nil
+  def minimal_rtps!
+    @data[:routesToProfessionalStatuses].each do |rtps|
+      rtps[:trainingEndDate] = nil
+      rtps[:trainingStartDate] = nil
+      rtps[:holdsFrom] = nil
     end
   end
 
   def minimal_mandatory_qualifications!
     @data
-  end
-
-  def minimal_npq!
-    @data[:npqQualifications].each do |npq|
-      npq[:certificateUrl] = nil
-    end
   end
 
   def minimal_sanctions!

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_the_trn_is_not_in_the_url
     then_i_see_induction_details
     then_i_see_qts_details
-    then_i_see_itt_details
+    then_i_see_rtps_details
     then_i_see_eyts_details
     then_i_see_npq_details
     then_i_see_mq_details
-    then_i_see_previous_last_names
     and_a_viewed_timestamp_is_displayed
+    then_i_see_previous_last_names
     and_a_print_warning_is_displayed
   end
 
@@ -74,25 +74,26 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
-    expect(page).to have_content("Date awarded")
-    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Professional Status")
+    expect(page).to have_content("Status\tQualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t27 February 2023")
   end
 
   def then_i_see_eyts_details
     expect(page).to have_content("Early years teacher status (EYTS)")
-    expect(page).to have_content("Date awarded")
+    expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
   end
 
-  def then_i_see_itt_details
-    expect(page).to have_content("Initial teacher training (ITT)")
-    expect(page).to have_content("BA")
-    expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("Higher education institution")
-    expect(page).to have_content("Business Studies")
-    expect(page).to have_content("28 January 2023")
-    expect(page).to have_content("Passed")
+  def then_i_see_rtps_details
+    expect(page).to have_content("Route Type\tInitial teacher training (ITT)")
+    expect(page).to have_content("Qualification\tBA")
+    expect(page).to have_content("Provider\tEarl Spencer Primary School")
+    expect(page).to have_content("Subject\tBusiness Studies")
+    expect(page).to have_content("Age range\t7 to 14 years")
+    expect(page).to have_content("Start date\t28 February 2022")
+    expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Course result\tIn training")
   end
 
   def then_i_see_npq_details
@@ -101,16 +102,12 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_mq_details
-    expect(page).to have_content("Date visual impairment MQ awarded")
-    expect(page).to have_content("28 February 2023")
-    expect(page).to have_content("Date hearing MQ awarded")
-    expect(page).to have_content("1 January 2022")
+    expect(page).to have_content("MQ Specialism\tVisual impairment")
+    expect(page).to have_content("Date Awarded\t28 February 2023")
+    expect(page).to have_content("MQ Specialism\tHearing")
+    expect(page).to have_content("Date Awarded\t1 January 2022")
   end
 
-  def then_i_see_previous_last_names
-    expect(page).to have_content("Previous last names")
-    expect(page).to have_content("Jones\nSmith")
-  end
 
   def and_a_search_timestamp_is_displayed
     expect(page).to have_content "Searched at 10:21am on 1 January 2020"
@@ -124,3 +121,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     expect(page).to have_content "You should dispose of the offline records"
   end
 end
+  def then_i_see_previous_last_names
+    expect(page).to have_content("Previous last names")
+    expect(page).to have_content("Jones\nSmith")
+  end

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -74,26 +74,23 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Professional Status")
-    expect(page).to have_content("Status\tQualified teacher status (QTS)")
+    expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Held since\t27 February 2023")
   end
 
   def then_i_see_eyts_details
     expect(page).to have_content("Early years teacher status (EYTS)")
-    expect(page).to have_content("Held since")
-    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Held since\t27 February 2023")
   end
 
   def then_i_see_rtps_details
-    expect(page).to have_content("Route Type\tInitial teacher training (ITT)")
     expect(page).to have_content("Qualification\tBA")
     expect(page).to have_content("Provider\tEarl Spencer Primary School")
     expect(page).to have_content("Subject\tBusiness Studies")
     expect(page).to have_content("Age range\t7 to 14 years")
     expect(page).to have_content("Start date\t28 February 2022")
     expect(page).to have_content("End date\t28 January 2023")
-    expect(page).to have_content("Course result\tIn training")
+    expect(page).to have_content("Result\tIn training")
   end
 
   def then_i_see_npq_details

--- a/spec/system/qualifications/user_views_their_qualifications_no_rtps_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_no_rtps_spec.rb
@@ -4,12 +4,12 @@ RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "when they have no ITT", test: %i[with_stubbed_auth with_fake_quals_api] do
+  scenario "when they have no RTPS", test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    then_i_see_there_are_no_itt_details
+    then_i_see_there_are_no_rtps_details
   end
 
   private
@@ -26,7 +26,7 @@ RSpec.feature "User views their qualifications", type: :system do
           name: "Not Trained"
         },
         credentials: {
-          token: "no-itt-token",
+          token: "no-rtps-token",
           expires_in: 1.hour.to_i
         },
         extra: {
@@ -39,7 +39,7 @@ RSpec.feature "User views their qualifications", type: :system do
     )
   end
 
-  def then_i_see_there_are_no_itt_details
+  def then_i_see_there_are_no_rtps_details
     expect(page).not_to have_content("Initial teacher training (ITT)")
   end
 

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "User views their qualifications", type: :system do
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
-    then_i_see_my_itt_details
+    then_i_see_my_rtps_details
     then_i_see_my_eyts_details
     and_my_eyts_certificate_is_downloadable
     then_i_see_my_npq_details
@@ -51,7 +51,6 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Awarded")
     expect(page).to have_content("27 February 2023")
-    expect(page).to have_content("Qualified (trained in the UK)")
     expect(page).to have_content("Download QTS certificate")
   end
 
@@ -84,16 +83,15 @@ RSpec.feature "User views their qualifications", type: :system do
     )
   end
 
-  def then_i_see_my_itt_details
+  def then_i_see_my_rtps_details
     expect(page).to have_content("Initial teacher training (ITT)")
     expect(page).to have_content("BA")
     expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("Higher education institution")
     expect(page).to have_content("Business Studies")
     expect(page).to have_content("28 February 2022")
     expect(page).to have_content("28 January 2023")
     expect(page).to have_content("Status\tPass")
-    expect(page).to have_content("10 to 16 years")
+    expect(page).to have_content("7 to 14 years")
   end
 
   def then_i_see_my_npq_details

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -49,14 +49,14 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_qts_details
     expect(page).to have_content("Qualified teacher status (QTS)")
-    expect(page).to have_content("Awarded")
+    expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
     expect(page).to have_content("Download QTS certificate")
   end
 
   def then_i_see_my_eyts_details
     expect(page).to have_content("Early years teacher status (EYTS)")
-    expect(page).to have_content("Awarded")
+    expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
     expect(page).to have_content("Download EYTS certificate")
   end
@@ -96,7 +96,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_npq_details
     expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
-    expect(page).to have_content("Awarded")
+    expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
     expect(page).to have_content("Download NPQH certificate")
   end
@@ -114,7 +114,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_mq_details
     expect(page).to have_content("Mandatory qualification (MQ)")
-    expect(page).to have_content("Awarded\t28 February 2023")
+    expect(page).to have_content("Held since\t28 February 2023")
     expect(page).to have_content("Specialism\tVisual impairment")
   end
 end


### PR DESCRIPTION
### Context

The API providing info powering CTR and AYTQ is being updated to use routes rather than specifically returning Initial Teacher Training info. We need to update the system to consume this information and render it out to the user.

### Changes proposed in this pull request

- Updates api version for v3/persons/#{trn} to 20250627
- Swap interface to rendering routes information to users of both CTR and AYTQ

### Link to Trello card

- https://trello.com/c/2xip7gQR
- https://trello.com/c/YHFVdDXI
