### PR TITLE
Tune rate limiting

### DIFF
--- a/terraform/domains/environment_domains/config/preprod.tfvars.json
+++ b/terraform/domains/environment_domains/config/preprod.tfvars.json
@@ -14,5 +14,7 @@
       "environment_short": "pp",
       "origin_hostname": "check-a-teachers-record-preprod.test.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 200,
+  "allow_aks": true
 }

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -27,15 +27,6 @@
       "origin_hostname": "check-a-teachers-record-production.teacherservices.cloud"
     }
   },
-  "rate_limit": [
-    {
-      "agent": "all",
-      "priority": 100,
-      "duration": 5,
-      "limit": 300,
-      "selector": "Host",
-      "operator": "GreaterThanOrEqual",
-      "match_values": "0"
-    }
-  ]
+  "rate_limit_max": 250,
+  "allow_aks": true
 }

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -14,5 +14,7 @@
       "environment_short": "test",
       "origin_hostname": "check-a-teachers-record-test.test.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 200,
+  "allow_aks": true
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -12,4 +12,6 @@ module "domains" {
   cached_paths        = try(each.value.cached_paths, [])
   redirect_rules      = try(each.value.redirect_rules, [])
   rate_limit          = try(var.rate_limit, null)
+  rate_limit_max      = try(var.rate_limit_max, null)
+  allow_aks           = try(var.allow_aks, null)
 }

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -15,3 +15,12 @@ variable "rate_limit" {
   }))
   default = null
 }
+
+variable "rate_limit_max" {
+  type    = string
+  default = null
+}
+
+variable "allow_aks" {
+  default = false
+}


### PR DESCRIPTION
### Context

Improve rate limiting via front door

### Changes proposed in this pull request

- add for non prod envs
- allow aks egress
- lower threshold based on reviewing the last months logs

### Guidance to review

make env domains-plan (already applied to non prod envs)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
