### PR TITLE
Revert prod rate-limit-max to 300

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -27,6 +27,6 @@
       "origin_hostname": "check-a-teachers-record-production.teacherservices.cloud"
     }
   },
-  "rate_limit_max": 250,
+  "rate_limit_max": 300,
   "allow_aks": true
 }


### PR DESCRIPTION
### Context

reverting previous change to prod rate-limit-max as there were a few unexpected blocks

### Changes proposed in this pull request

change rate-limit-max

### Guidance to review

make production domains-plan (has been applied manually)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
