### PR TITLE
Add notification banners for certain attributes being unavailable

### DIFF
--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -19,6 +19,10 @@
       <%= @teacher.name %>
     </h1>
 
+    <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+      <% notification_banner.with_heading(text: "ITT qualification, programme type and result details are not available at the moment. They will be available in the next few days. You can still check if someone has QTS or EYTS.") %>
+    <% end %>
+
     <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
       <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
         <% @teacher.sanctions.each do |sanction| %>

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -15,13 +15,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
-      <%= @teacher.name %>
-    </h1>
-
     <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
       <% notification_banner.with_heading(text: "ITT qualification, programme type and result details are not available at the moment. They will be available in the next few days. You can still check if someone has QTS or EYTS.") %>
     <% end %>
+
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
+      <%= @teacher.name %>
+    </h1>
 
     <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
       <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
-
     <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
       <% notification_banner.with_heading(text: "ITT qualification, training type and result details are not available at the moment. They will be available in the next few days. You can still download your QTS or EYTS certificate.") %>
     <% end %>
+
+    <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
 
     <h1 class="govuk-heading-xl">Teaching qualifications</h1>
 

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -1,6 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>
+
+    <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+      <% notification_banner.with_heading(text: "ITT qualification, training type and result details are not available at the moment. They will be available in the next few days. You can still download your QTS or EYTS certificate.") %>
+    <% end %>
+
     <h1 class="govuk-heading-xl">Teaching qualifications</h1>
 
     <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

We need to inform users of the current state of the service.

### Changes proposed in this pull request

Add banners to CTR and AYTQ info pages informing users of missing info
