### PR TITLE
Show all non qts/eyts rtps on qualifications page

### DIFF
--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -43,7 +43,7 @@ class Qualification
   end
 
   def rtps?
-    [:qts_rtps, :eyts_rtps, :rtps].include?(type)
+    [:qts_rtps, :eyts_rtps, :other_rtps, :rtps].include?(type)
   end
 
   def mq?

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
       expect(rows[3].text).to include("7 to 14 years")
       expect(rows[4].text).to include("28 February 2022")
       expect(rows[5].text).to include("28 January 2023")
-      expect(rows[6].text).to include("In training")
+      expect(rows[6].text).to include("Holds")
     end
 
     it "omits rows with no value" do

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       expect(rows[3].text).to include("Business Studies")
       expect(rows[4].text).to include("28 February 2022")
       expect(rows[5].text).to include("28 January 2023")
-      expect(rows[6].text).to include("In training")
+      expect(rows[6].text).to include("Holds")
       expect(rows[7].text).to include("7 to 14 years")
     end
 

--- a/spec/lib/qualifications_api/teacher_spec.rb
+++ b/spec/lib/qualifications_api/teacher_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe QualificationsApi::Teacher, type: :model do
       api_data["routesToProfessionalStatuses"] = [rtps_qualification]
 
       expect(qualifications.map(&:type)).to eq(
-        %i[NPQSL NPQML mandatory induction qts qts_rtps eyts]
+        %i[NPQSL NPQML mandatory induction qts qts_rtps eyts other_rtps]
       )
     end
 

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -45,7 +45,7 @@ module FakeQualificationsData
           }
         ]
       },
-      "routesToProfessionalStatuses": [rtps ? build_rtps : nil].compact,
+      "routesToProfessionalStatuses": [rtps ? build_rtps : nil].compact.flatten,
       mandatoryQualifications: [
         { endDate: "2023-02-28", specialism: "Visual impairment", mandatoryQualificationId: 1 },
         { endDate: "2022-01-01", specialism: "Hearing", mandatoryQualificationId: 1 }
@@ -56,50 +56,91 @@ module FakeQualificationsData
   end
 
   def build_rtps
-    {
-      "routeToProfessionalStatusId": "qts-route-id-11111",
-      "routeToProfessionalStatusType": {
-        "routeToProfessionalStatusTypeId": "qts-route-type-id-11111",
-        "name": "Initial teacher training (ITT)",
-        "professionalStatusType": "QualifiedTeacherStatus"
-      },
-      "status": "InTraining",
-      "holdsFrom": "2023-02-27",
-      "trainingStartDate": "2022-02-28",
-      "trainingEndDate": "2023-01-28",
-      "trainingSubjects": [
-        {
-          "reference": "12345",
-          "name": "Business Studies"
-        }
-      ],
-      "trainingAgeSpecialism": {
-        "type": "Range",
-        "from": 7,
-        "to": 14
-      },
-      "trainingCountry": {
-        "reference": "string",
-        "name": "United Kingdom"
-      },
-      "trainingProvider": {
-        "ukprn": "12345",
-        "name": "Earl Spencer Primary School"
-      },
-      "degreeType": {
-        "degreeTypeId": "degree-type-id-44444",
-        "name": "BA"
-      },
-      "inductionExemption": {
-        "isExempt": true,
-        "exemptionReasons": [
+    [
+      {
+        "routeToProfessionalStatusId": "qts-route-id-11111",
+        "routeToProfessionalStatusType": {
+          "routeToProfessionalStatusTypeId": "qts-route-type-id-11111",
+          "name": "Initial teacher training (ITT)",
+          "professionalStatusType": "QualifiedTeacherStatus"
+        },
+        "status": "Holds",
+        "holdsFrom": "2023-02-27",
+        "trainingStartDate": "2022-02-28",
+        "trainingEndDate": "2023-01-28",
+        "trainingSubjects": [
           {
-            "inductionExemptionReasonId": "induction-exemption-reason-id-33333",
-            "name": "string"
+            "reference": "12345",
+            "name": "Business Studies"
           }
-        ]
+        ],
+        "trainingAgeSpecialism": {
+          "type": "Range",
+          "from": 7,
+          "to": 14
+        },
+        "trainingCountry": {
+          "reference": "string",
+          "name": "United Kingdom"
+        },
+        "trainingProvider": {
+          "ukprn": "12345",
+          "name": "Earl Spencer Primary School"
+        },
+        "degreeType": {
+          "degreeTypeId": "degree-type-id-44444",
+          "name": "BA"
+        },
+        "inductionExemption": {
+          "isExempt": true,
+          "exemptionReasons": [
+            {
+              "inductionExemptionReasonId": "induction-exemption-reason-id-33333",
+              "name": "string"
+            }
+          ]
+        }
+      },
+      {
+        "routeToProfessionalStatusId": "other-route-id-11111",
+        "routeToProfessionalStatusType": {
+          "routeToProfessionalStatusTypeId": "other-route-type-id-11111",
+          "name": "Non-held Route",
+          "professionalStatusType": "QualifiedTeacherStatus"
+        },
+        "status": "InTraining",
+        "holdsFrom": nil,
+        "trainingStartDate": "2022-02-28",
+        "trainingEndDate": "2030-01-28",
+        "trainingSubjects": [
+          {
+            "reference": "12345",
+            "name": "Business Studies"
+          }
+        ],
+        "trainingAgeSpecialism": {
+          "type": "Range",
+          "from": 15,
+          "to": 18
+        },
+        "trainingCountry": {
+          "reference": "string",
+          "name": "United Kingdom"
+        },
+        "trainingProvider": {
+          "ukprn": "23456",
+          "name": "Earl Spencer Secondary School"
+        },
+        "degreeType": {
+          "degreeTypeId": "degree-type-id-55555",
+          "name": "MA"
+        },
+        "inductionExemption": {
+          "isExempt": false,
+          "exemptionReasons": []
+        }
       }
-    }
+    ]
   end
 
   def fake_alerts(trn)

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_qts_details
     then_i_see_rtps_details
     then_i_see_eyts_details
+    then_i_see_other_rtps_details
     then_i_see_npq_details
     then_i_see_mq_details
     and_a_viewed_timestamp_is_displayed
@@ -90,6 +91,16 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     expect(page).to have_content("Age range\t7 to 14 years")
     expect(page).to have_content("Start date\t28 February 2022")
     expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Result\tHolds")
+  end
+
+  def then_i_see_other_rtps_details
+    expect(page).to have_content("Qualification\tBA")
+    expect(page).to have_content("Provider\tEarl Spencer Secondary School")
+    expect(page).to have_content("Subject\tBusiness Studies")
+    expect(page).to have_content("Age range\t15 to 18 years")
+    expect(page).to have_content("Start date\t28 February 2022")
+    expect(page).to have_content("End date\t28 January 2030")
     expect(page).to have_content("Result\tIn training")
   end
 


### PR DESCRIPTION
### Context

We no longer show the routes for teachers on CTR if their status does not equal Holds. This means some users that want to verify someone is training toward QTS/other professional status cannot do so.

### Changes proposed in this pull request

- Display RTPS that are not attached to a QTS or EYTS, I.e. those not yet held.

### Link to Trello card

https://trello.com/c/dOzrRb5S

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
