### PR TITLE
Expand supported induction status' to include "Passed" and "Pass"

### DIFF
--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -88,7 +88,7 @@ class InductionSummaryComponent < ViewComponent::Base
       }
     ]
 
-    if details.status == "Passed"
+    if ["Passed", "Pass"].include?(details.status)
       qualification_rows << {
         key: {
           text: "Certificate"

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -125,16 +125,20 @@ module QualificationsApi
       'No induction'
     end
 
+    def induction_status_values
+      [api_data.induction&.status, api_data.induction_status&.status]
+    end
+
     def passed_induction?
-      api_data.induction&.status == "Passed" || api_data.induction_status&.status == "Passed"
+      induction_status_values.include?("Passed")
     end
 
     def failed_induction?
-      api_data.induction&.status == "Failed" || api_data.induction_status&.status == "Failed"
+      induction_status_values.include?("Failed")
     end
 
     def exempt_from_induction_via_induction_status?
-      api_data.induction&.status == "Exempt" || api_data.induction_status&.status == "Exempt"
+      induction_status_values.include?("Exempt")
     end
 
     def exempt_from_induction_via_qts_via_qtls?

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -130,7 +130,7 @@ module QualificationsApi
     end
 
     def passed_induction?
-      induction_status_values.include?("Passed")
+      induction_status_values.intersect?(["Passed", "Pass"])
     end
 
     def failed_induction?

--- a/app/views/check_records/search/_results_table.html.erb
+++ b/app/views/check_records/search/_results_table.html.erb
@@ -22,7 +22,7 @@
               text: teacher.restriction_status == 'Restriction' ? govuk_tag(text: teacher.restriction_status, colour: 'red') : teacher.restriction_status
             )
             row.with_cell(text: teacher.teaching_status)
-            row.with_cell(text: teacher.induction_status)
+            row.with_cell(text: teacher.induction_status, html_attributes: { data: { raw_values: teacher.induction_status_values.join(",") }})
           end
         end
       end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -82,7 +82,7 @@ class FakeQualificationsApi < Sinatra::Base
     case bearer_token
     when "token"
       {
-        results: [quals_data(trn: "9876543")],
+        results: [quals_data(trn: "9876543", bulk_response: true)],
         total: 1
       }.to_json
     when "invalid-token"

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -1,5 +1,8 @@
 module FakeQualificationsData
-  def quals_data(trn: nil, rtps: true)
+  def quals_data(trn: nil, rtps: true, bulk_response: false)
+    # Bulk queries use an older version of the API that returns Pass instead of Passed
+    passed_value = bulk_response ? "Pass" : "Passed"
+
     {
       trn: trn || "3000299",
       dateOfBirth: "2000-01-01",
@@ -37,7 +40,7 @@ module FakeQualificationsData
       induction: {
         startDate: "2022-09-01",
         completedDate: "2022-10-01",
-        status: "Passed",
+        status: passed_value,
         exemptionReasons: [
           {
             inductionExemptionReasonId: "induction-exemption-reason-id-33333",

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     expect(page).to have_content "Terry Walsh"
     expect(page).to have_content "Restriction"
     expect(page).to have_content "Passed"
+    expect(page).to have_selector('td[data-raw-values="Passed,"]')
   end
 
   def and_my_search_is_logged

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     expect(page).to have_content "Terry Walsh"
     expect(page).to have_content "Restriction"
     expect(page).to have_content "Passed"
-    expect(page).to have_selector('td[data-raw-values="Passed,"]')
+    expect(page).to have_selector('td[data-raw-values="Pass,"]')
   end
 
   def and_my_search_is_logged


### PR DESCRIPTION
### Context

Some records are not coming through with the correct values in the bulk search system. 

### Changes proposed in this pull request

- Insert induction values into HTML for debugging purposes
- Support both Passed and Pass as induction status (The bulk search API returns `Pass` while the regular search returns `Passed`)


### Link to Trello card

https://trello.com/c/WhQ8xSYD

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
