### PR TITLE
Add specific page titles for each action

### DIFF
--- a/app/views/check_records/sign_in/new.html.erb
+++ b/app/views/check_records/sign_in/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for :page_title, "Check a teacher’s record" %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Check a teacher’s record</h1>

--- a/app/views/check_records/sign_in/not_authorised.html.erb
+++ b/app/views/check_records/sign_in/not_authorised.html.erb
@@ -1,4 +1,7 @@
+<% content_for :page_title, "Not Authorized" %>
+
 <h1 class="govuk-heading-l">You cannot use the DfE Sign-in account for <%= session[:organisation_name] %> to check a teacher’s record</h1>
+
 <p class="govuk-body">
   If you have access to another organisation in DfE Sign-in, you can <%= govuk_link_to("sign out and start again", check_records_dsi_sign_out_path(id_token_hint: session[:id_token])) %>.
 </p>

--- a/app/views/qualifications/identity_users/show.html.erb
+++ b/app/views/qualifications/identity_users/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, "DfE Identity account" %>
 <% content_for :back_link_url, qualifications_dashboard_path %>
 
 <%= govuk_panel(title_text: "DfE Identity account", classes: "app-panel--interruption") do %>

--- a/app/views/qualifications/one_login_users/show.html.erb
+++ b/app/views/qualifications/one_login_users/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, "Change your details" %>
 <% content_for :back_link_url, qualifications_dashboard_path %>
 
 <div class="govuk-grid-row">

--- a/app/views/qualifications/qualifications/show.html.erb
+++ b/app/views/qualifications/qualifications/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Teaching qualifications" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl"><%= @user.name.possessive.gsub("'","’") %></span>

--- a/app/views/qualifications/users/sign_in/new.html.erb
+++ b/app/views/qualifications/users/sign_in/new.html.erb
@@ -1,6 +1,9 @@
+<% content_for :page_title, "Sign in to access your teaching qualifications" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sign in to access your teaching qualifications</h1>
+
     <% if FeatureFlags::FeatureFlag.active?(:one_login) %>
       <p class="govuk-body">You’ll need a GOV.UK One Login account to access your teaching qualifications.</p>
       <p class="govuk-body">You can create an account if you do not have one already.</p>

--- a/app/views/qualifications/users/sign_out/complete.html.erb
+++ b/app/views/qualifications/users/sign_out/complete.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "You are now signed out" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You are now signed out</h1>

--- a/app/views/qualifications/users/sign_out/new.html.erb
+++ b/app/views/qualifications/users/sign_out/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Are you sure you want to sign out?" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Are you sure you want to sign out?</h1>

--- a/app/views/support_interface/roles/edit.html.erb
+++ b/app/views/support_interface/roles/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, ["Edit role", @role.code].compact.join(" - ") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Check role codes" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/support_interface/roles/new.html.erb
+++ b/app/views/support_interface/roles/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "New role" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/support_interface/support_interface/index.html.erb
+++ b/app/views/support_interface/support_interface/index.html.erb
@@ -1,1 +1,3 @@
+<% content_for :page_title, "Support Interface" %>
+
 <h1 class="govuk-heading-xl">Support Interface</h1>


### PR DESCRIPTION
### Context

The page title for the ‘sign in’ page has not been given a unique page title. The page title currently reads ‘access your teaching qualifications’ which is the same as other pages across the service.

Screen reader users rely on the page title to provide them with information about the page. Having duplicate page title names can be confusing for screen reader users as it’s not clear when they have moved to the next page.

Recommendation: Ensure all pages have unique page titles which are front loaded with the pages heading level 1, followed by the service name, and then the domain. For example: 

### Changes proposed in this pull request

- Add page titles to all pages

### Guidance to review

- Visit each page and check that the page title is set.

### Link to Trello card

https://trello.com/c/zsSri8Go

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
