### PR TITLE
Update bulk search to use new API

### DIFF
--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -138,7 +138,7 @@ module QualificationsApi
 
     def bulk_teachers(queries: [])
       response = client.post("v3/persons/find", { persons: queries }) do |request|
-        request.headers["X-Api-Version"] = "20240814"
+        request.headers["X-Api-Version"] = "20250627"
       end
       case response.status
       when 200

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -81,10 +81,7 @@ class FakeQualificationsApi < Sinatra::Base
 
     case bearer_token
     when "token"
-      {
-        results: [quals_data(trn: "9876543", bulk_response: true)],
-        total: 1
-      }.to_json
+      bulk_quals_data(trn: "9876543").to_json
     when "invalid-token"
       halt 401
     when "forbidden"

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -1,8 +1,5 @@
 module FakeQualificationsData
-  def quals_data(trn: nil, rtps: true, bulk_response: false)
-    # Bulk queries use an older version of the API that returns Pass instead of Passed
-    passed_value = bulk_response ? "Pass" : "Passed"
-
+  def quals_data(trn: nil, rtps: true)
     {
       trn: trn || "3000299",
       dateOfBirth: "2000-01-01",
@@ -40,7 +37,7 @@ module FakeQualificationsData
       induction: {
         startDate: "2022-09-01",
         completedDate: "2022-10-01",
-        status: passed_value,
+        status: "Passed",
         exemptionReasons: [
           {
             inductionExemptionReasonId: "induction-exemption-reason-id-33333",
@@ -55,6 +52,13 @@ module FakeQualificationsData
       ],
       alerts: fake_alerts(trn),
       qtlsStatus: "None"
+    }
+  end
+
+  def bulk_quals_data(trn: nil)
+    {
+      results: [quals_data(trn:, rtps: true)],
+      total: 1
     }
   end
 

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     expect(page).to have_content "Terry Walsh"
     expect(page).to have_content "Restriction"
     expect(page).to have_content "Passed"
-    expect(page).to have_selector('td[data-raw-values="Pass,"]')
+    expect(page).to have_selector('td[data-raw-values="Passed,"]')
   end
 
   def and_my_search_is_logged


### PR DESCRIPTION
### Context

The bulk search API is using an old API version but feeding data into a system that expects the new API format. This update brings things in line.

### Changes proposed in this pull request

- Update version of API called by bulk search API to match that of the single use search.

### Guidance to review

- Run bulk searches on TRNs for users who have had known issues.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
