### PR TITLE
Pin exact third party github action versions

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
 
   steps:
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # Pinned at v3.1.2
       with:
         terraform_version: 1.6.4
         terraform_wrapper: false

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -46,7 +46,7 @@ runs:
         key: GOVUK_NOTIFY_API_KEY,SUPPORT_USERNAME,SUPPORT_PASSWORD
 
     # Run deployment smoke test
-    - uses: nick-fields/retry@v2.8.3
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # Pinned at v2.8.3
       with:
         max_attempts: 5
         timeout_minutes: 3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -91,7 +91,7 @@ jobs:
           kubectl exec -n tra-development deployment/access-your-teaching-qualifications-pr-${{ github.event.number }} -- /bin/sh -c "cd /app && bundle exec rake db:seed_role_codes"
 
       - name: Post comment to Pull Request ${{ github.event.number }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           header: aks
           message: |

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -26,7 +26,7 @@ jobs:
           snyk-token: ${{ secrets.SNYK_TOKEN }}
 
       - name: Notify slack on failure
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         if: ${{ failure() }}
         with:
           SLACK_USERNAME: CI Deployment


### PR DESCRIPTION
### Context

Github action tags can be changed and pointed at new versions of a repo, this can lead to supply chain attacks and evidence of this occuring on other projects outside DfE exists.

Pinning to exact git hashes ensures that the version of the action cannot be changed without us explicitly changing it.

### Changes proposed in this pull request

- Pin untrusted third party github actions to specific git hashes

### Guidance to review

Check that these actions run successfully

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
