### PR TITLE
Accessibility audit changes

### DIFF
--- a/app/views/check_records/bulk_searches/create.html.erb
+++ b/app/views/check_records/bulk_searches/create.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Find multiple records" %>
+<% content_for :page_title, "File Summary" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Find multiple records" => new_check_records_bulk_search_path, "Results" => nil }) %>
 

--- a/app/views/check_records/bulk_searches/create.html.erb
+++ b/app/views/check_records/bulk_searches/create.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "File Summary" %>
+<% content_for :page_title, "File summary" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Find multiple records" => new_check_records_bulk_search_path, "Results" => nil }) %>
 

--- a/app/views/check_records/bulk_searches/new.html.erb
+++ b/app/views/check_records/bulk_searches/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Find multiple records" %>
+<% content_for :page_title, "Find multiple teacher records" %>
 
 <div class="govuk-grid-row" id="bulk_search">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/check_records/feedbacks/new.html.erb
+++ b/app/views/check_records/feedbacks/new.html.erb
@@ -22,7 +22,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :contact_permission_given, legend: { size: "m", text: "Can we contact you about your feedback?" } do %>
         <%= f.govuk_radio_button :contact_permission_given, 'true', label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+          <%= f.govuk_text_field :email, autocomplete: "email", label: { text: "Email address", size: "s" } %>
         <% end %>
         <%= f.govuk_radio_button :contact_permission_given, 'false', label: { text: "No" } %>
       <% end %>

--- a/app/views/check_records/search/personal_details_search.html.erb
+++ b/app/views/check_records/search/personal_details_search.html.erb
@@ -9,7 +9,13 @@
 
       <h1 class="govuk-heading-l">Find teacher record</h1>
 
-      <%= f.govuk_text_field :last_name, class: "govuk-input--width-20", label: { class: "govuk-label--s", text: "Last name" } %>
+      <%= f.govuk_text_field(
+            :last_name,
+            autocomplete: "family-name",
+            class: "govuk-input--width-20",
+            label: { class: "govuk-label--s", text: "Last name" }
+          )
+      %>
 
       <%= f.govuk_date_field(
             :date_of_birth,

--- a/app/views/check_records/search/trn_search.html.erb
+++ b/app/views/check_records/search/trn_search.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Find teacher record" %>
+<% content_for :page_title, "Multiple results found" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => nil }) %>
 <% end %>

--- a/app/views/qualifications/feedbacks/new.html.erb
+++ b/app/views/qualifications/feedbacks/new.html.erb
@@ -22,7 +22,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :contact_permission_given, legend: { size: "m", text: "Can we contact you about your feedback?" } do %>
         <%= f.govuk_radio_button :contact_permission_given, 'true', label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+          <%= f.govuk_text_field :email, autocomplete: "email", label: { text: "Email address", size: "s" } %>
         <% end %>
         <%= f.govuk_radio_button :contact_permission_given, 'false', label: { text: "No" } %>
       <% end %>

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/show.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/show.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, "Change your date of birth" %>
+<% content_for :page_title, "Confirm date of birth change" %>
 <% content_for :back_link_url, edit_qualifications_one_login_user_date_of_birth_change_path(@date_of_birth_change) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l"> Confirm change </h1>
+    <h1 class="govuk-heading-l">Confirm change</h1>
 
     <%= govuk_summary_list do |summary_list|
       summary_list.with_row do |row|

--- a/app/views/qualifications/one_login_users/date_of_birth_changes/submitted.html.erb
+++ b/app/views/qualifications/one_login_users/date_of_birth_changes/submitted.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Change your date of birth" %>
+<% content_for :page_title, "Date of birth change request submitted" %>
 <%= govuk_back_link text: "Back to change your teaching qualifications", href: qualifications_one_login_user_path %>
 
 <div class="govuk-grid-row">

--- a/app/views/qualifications/one_login_users/name_changes/_form.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form.govuk_text_field :first_name, label: { text: "First name" } %>
-<%= form.govuk_text_field :middle_name, label: { text: "Middle name" }, hint_text: "Optional" %>
-<%= form.govuk_text_field :last_name, label: { text: "Last name" } %>
+<%= form.govuk_text_field :first_name, autocomplete: "given-name", label: { text: "First name" } %>
+<%= form.govuk_text_field :middle_name, autocomplete: "additional-name", label: { text: "Middle name" }, hint_text: "Optional" %>
+<%= form.govuk_text_field :last_name, autocomplete: "family-name", label: { text: "Last name" } %>
 
 <h2 class="govuk-heading-s">Upload evidence</h2>
 <p>Documents we accept</p>

--- a/app/views/qualifications/one_login_users/name_changes/show.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Change your name on teaching certificates" %>
+<% content_for :page_title, "Confirm name change" %>
 <% content_for :back_link_url, edit_qualifications_one_login_user_name_change_path(@name_change) %>
 
 <div class="govuk-grid-row">

--- a/app/views/qualifications/one_login_users/name_changes/submitted.html.erb
+++ b/app/views/qualifications/one_login_users/name_changes/submitted.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Change your name on teaching certificates" %>
+<% content_for :page_title, "Name change request submitted" %>
 <%= govuk_back_link text: "Back to change your teaching qualifications", href: qualifications_one_login_user_path %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,7 @@ en:
         trn_search:
           attributes:
             trn:
-              blank: Enter a valid TRN
+              blank: Enter a valid TRN or skip this question
 
   activerecord:
     errors:

--- a/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   alias_method :and_i_submit_the_form, :when_i_submit_the_form
 
   def then_i_see_an_error
-    expect(page).to have_content "Enter a valid TRN"
+    expect(page).to have_content "Enter a valid TRN or skip this question"
   end
 
   def when_i_enter_a_trn


### PR DESCRIPTION
### Context

Issues raised by the accessibility audit

### Changes proposed in this pull request

- Add autocompletes to forms
    - Add autocomplete to first/last/middle name fields on one_login user name changes form
    - Add autocomplete to email field on CTR and AYTQ feedback forms
    - Add autocomplete to surname field on search page
- Add indication you can skip the question to error message on multiple results page when invalid TRN is entered
- Update page titles to match page function and titles
    - Update page title on CSV update File Summary page to “File Summary”
    - Update page title on bulk search page to “Find multiple teacher records” 
    - Update page title on multiple results found page to “Multiple results found”
    - Update page title on DoB change confirmation page to “Confirm date of birth change”
    - Update page title on DoB change submitted page to “Date of birth change request submitted”
    - Update page title on name change confirmation page to “Confirm name change”
    - Update page title on name change submitted page to “Name change request submitted”

### Link to Trello card

- https://trello.com/c/l352yNbL
- https://trello.com/c/iAmkp43b
- https://trello.com/c/SyTAgb2X

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
