### PR TITLE
Prioritised induction failure over QTS via QTLS exemption

### DIFF
--- a/app/components/check_records/qualification_summary_component.html.erb
+++ b/app/components/check_records/qualification_summary_component.html.erb
@@ -2,12 +2,12 @@
   <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-m"><%= title %></h2>
   <%= govuk_summary_list(rows:)%>
-    <% if render_induction_exemption_message?%>
-        <%= govuk_inset_text do %>
-          <p>Exempt from induction via qualified teacher learning and skills (QTLS) status and an active membership with the <a href="https://set.et-foundation.co.uk/your-career/qtls">Society for Education and Training (SET)</a></p>
+    <% if render_induction_exemption_message? %>
+      <%= govuk_inset_text do %>
+        <p>Exempt from induction via qualified teacher learning and skills (QTLS) status and an active membership with the <a href="https://set.et-foundation.co.uk/your-career/qtls">Society for Education and Training (SET)</a></p>
 
-          <p>They will need to complete induction if their SET membership expires.</p>
-        <% end %>
+        <p>They will need to complete induction if their SET membership expires.</p>
+      <% end %>
     <% elsif render_qts_induction_exemption_message %>
       <%= govuk_inset_text do %>
         <p>Holds QTS and is Exempt from Induction as they have QTLS status and an active membership with the <a href="https://set.et-foundation.co.uk/your-career/qtls">Society for Education and Training (SET)</a></p>

--- a/app/components/check_records/qualification_summary_component.html.erb
+++ b/app/components/check_records/qualification_summary_component.html.erb
@@ -1,7 +1,7 @@
 <% if rows.any? %>
   <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-m"><%= title %></h2>
-  <%= govuk_summary_list(rows:)%>
+  <%= govuk_summary_list(rows:) %>
     <% if render_induction_exemption_message? %>
       <%= govuk_inset_text do %>
         <p>Exempt from induction via qualified teacher learning and skills (QTLS) status and an active membership with the <a href="https://set.et-foundation.co.uk/your-career/qtls">Society for Education and Training (SET)</a></p>

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -177,13 +177,12 @@ class CheckRecords::QualificationSummaryComponent < ApplicationComponent
   def render_induction_exemption_warning?
     induction? &&
       set_membership_expired &&
-      !passed_induction &&
       details&.status != "Failed" &&
       details&.status != "Exempt"
   end
 
   def render_qtls_warning_message?
-    qts? && qtls_only && set_membership_expired && !passed_induction
+    qts? && qtls_only && set_membership_expired
   end
 
   def description_text(status)

--- a/app/components/check_records/qualification_summary_component.rb
+++ b/app/components/check_records/qualification_summary_component.rb
@@ -53,15 +53,16 @@ class CheckRecords::QualificationSummaryComponent < ApplicationComponent
   end
 
   def induction_rows
-    if qtls_only && !passed_induction && !failed_induction?
+    unless failed_induction?
       if set_membership_active
         return [
           { key: { text: "Induction status" }, value: { text: "Exempt" } },
-          { key: { text: "Reason for exemption" },
-            value: { text: details[:exemption_reasons]&.map(&:name)&.join(", ") } }
+          { key: { text: "Reason for exemption" }, value: { text: details[:exemption_reasons]&.map(&:name)&.join(", ") } }
         ]
-      else
-        return [{ key: { text: "Induction status" }, value: { text: "No induction"} }]
+      end
+
+      if qtls_only && !passed_induction
+        return [{ key: { text: "Induction status" }, value: { text: "No induction" }}]
       end
     end
 
@@ -162,16 +163,12 @@ class CheckRecords::QualificationSummaryComponent < ApplicationComponent
     details&.status.present? ? details&.status == "Failed" : false
   end
 
-  def induction_required_to_complete?
-    !passed_induction && !failed_induction?
-  end
-
   def render_induction_exemption_message?
-    induction? && set_membership_active && induction_required_to_complete?
+    induction? && set_membership_active && !failed_induction?
   end
 
   def render_qts_induction_exemption_message
-    qts? && qtls_only && set_membership_active && !passed_induction && !failed_induction
+    qts? && qtls_only && set_membership_active && !failed_induction
   end
 
   def render_induction_exemption_warning?

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -20,7 +20,7 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
     ].compact
   end
 
-  delegate :induction_status, :no_induction?, :no_restrictions?, :no_qts_or_eyts?, :teaching_status, 
+  delegate :induction_status, :no_induction?, :no_restrictions?, :no_qts_or_eyts?, :teaching_status,
            :restriction_status, :set_membership_active?, :set_membership_expired?, :qtls_only?, :qts_and_qtls?,
            :passed_induction?, :failed_induction?, :exempt_from_induction?,
            to: :teacher
@@ -30,19 +30,15 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
   end
 
   def teaching_status_tag
-    { message: teaching_status, colour: teaching_status_tag_colour}
+    { message: teaching_status, colour: teaching_status_tag_colour }
   end
 
   def induction_tag
-    { message: induction_tag_message, colour: no_induction? ? 'blue' : 'green'}
+    { message: induction_tag_message, colour: no_induction? ? 'blue' : 'green' }
   end
 
   def induction_tag_message
-    return 'Failed induction' if failed_induction?
-    return 'Induction Exempt' if exempt_from_induction?
-    return 'Passed induction' if passed_induction?
-
-    'No induction'
+    I18n.t("summary_tags.induction.status.#{induction_status}")
   end
 
   def teaching_status_tag_colour

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -38,9 +38,9 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
   end
 
   def induction_tag_message
-    return 'Passed induction' if passed_induction?
     return 'Failed induction' if failed_induction?
     return 'Induction Exempt' if exempt_from_induction?
+    return 'Passed induction' if passed_induction?
 
     'No induction'
   end

--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -7,24 +7,26 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
   def initialize(teacher)
     super()
     @teacher = teacher
-    @tags = []
-    build_tags
-  end
-
-  def build_tags
-    tags << restriction_tag
-    tags << teaching_status_tag
-    tags << induction_tag
+    @tags = build_tags
   end
 
   private
 
+  def build_tags
+    [
+      restriction_tag,
+      teaching_status_tag,
+      induction_tag,
+    ].compact
+  end
+
   delegate :induction_status, :no_induction?, :no_restrictions?, :no_qts_or_eyts?, :teaching_status, 
-           :restriction_status, :set_membership_active?, :set_membership_expired?,
+           :restriction_status, :set_membership_active?, :set_membership_expired?, :qtls_only?, :qts_and_qtls?,
+           :passed_induction?, :failed_induction?, :exempt_from_induction?,
            to: :teacher
 
   def restriction_tag
-    { message: restriction_status, colour: no_restrictions? ? "green" : "red"}
+    { message: "Restricted", colour: "red" } unless no_restrictions?
   end
 
   def teaching_status_tag
@@ -32,17 +34,26 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
   end
 
   def induction_tag
-    { message: induction_status, colour: no_induction? ? 'blue' : 'green'}
+    { message: induction_tag_message, colour: no_induction? ? 'blue' : 'green'}
+  end
+
+  def induction_tag_message
+    return 'Passed induction' if passed_induction?
+    return 'Failed induction' if failed_induction?
+    return 'Induction Exempt' if exempt_from_induction?
+
+    'No induction'
   end
 
   def teaching_status_tag_colour
-    if teacher.qtls_only?
+    if qtls_only?
       if set_membership_active?
         return 'green'
       elsif set_membership_expired?
         return 'blue'
       end
     end
+
     no_qts_or_eyts? ? 'blue' : 'green'
   end
 end

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -112,29 +112,18 @@ class InductionSummaryComponent < ApplicationComponent
   end
 
   def qtls_rows
-    if set_membership_active
-      [
-        {
-          key: {
-            text: "Status"
-          },
-          value: {
-            text: "Exempt"
-          } ,
+    status = set_membership_active ? "Exempt" : "No induction"
+
+    [
+      {
+        key: {
+          text: "Status"
+        },
+        value: {
+          text: status
         }
-      ]
-    elsif !set_membership_active
-      [
-        {
-          key: {
-            text: "Status"
-          },
-          value: {
-            text: "No induction"
-          } ,
-        }
-      ]
-    end
+      }
+    ]
   end
 
   def render_induction_exemption_reminder?

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -67,26 +67,19 @@ class InductionSummaryComponent < ApplicationComponent
   end
 
   def build_rows
-    return qtls_rows if qtls_only && !passed_induction && details&.status != "Failed"
+    return induction_status_row("Failed") if details&.status == "Failed"
+    return induction_status_row("Exempt") if set_membership_active
+    return induction_status_row("No induction") if qtls_only && !passed_induction
 
-    qualification_rows = [
-      {
-        key: {
-          text: "Status"
-        },
-        value: {
-          text: description_text(details&.status)
-        },
+    qualification_rows = induction_status_row(description_text(details&.status))
+    qualification_rows << {
+      key: {
+        text: "Completed"
       },
-      {
-        key: {
-          text: "Completed"
-        },
-        value: {
-          text: awarded_at&.to_fs(:long_uk)
-        }
+      value: {
+        text: awarded_at&.to_fs(:long_uk)
       }
-    ]
+    }
 
     if ["Passed", "Pass"].include?(details.status)
       qualification_rows << {
@@ -111,16 +104,14 @@ class InductionSummaryComponent < ApplicationComponent
     name
   end
 
-  def qtls_rows
-    status = set_membership_active ? "Exempt" : "No induction"
-
+  def induction_status_row(induction_status)
     [
       {
         key: {
           text: "Status"
         },
         value: {
-          text: status
+          text: induction_status
         }
       }
     ]

--- a/app/components/induction_summary_component.rb
+++ b/app/components/induction_summary_component.rb
@@ -76,7 +76,7 @@ class InductionSummaryComponent < ApplicationComponent
         },
         value: {
           text: description_text(details&.status)
-        } ,
+        },
       },
       {
         key: {
@@ -131,7 +131,7 @@ class InductionSummaryComponent < ApplicationComponent
   end
 
   def render_induction_exemption_warning?
-    set_membership_expired && !passed_induction && details&.status != "Failed" && details&.status != "Exempt"
+    set_membership_expired && details&.status != "Failed" && details&.status != "Exempt"
   end
 
   def description_text(status)

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -13,8 +13,7 @@ class QualificationSummaryComponent < ApplicationComponent
            :rtps?,
            :qts?,
            :eyts?,
-           :passed_induction,
-           :failed_induction,
+           :induction_status,
            :set_membership_active,
            :set_membership_expired,
            :name,
@@ -216,10 +215,14 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def render_qts_induction_exemption_message?
-    qts? && qtls_only && set_membership_active && !passed_induction && !failed_induction
+    qts? && set_membership_active && !failed_induction?
+  end
+
+  def failed_induction?
+    induction_status == :failed
   end
 
   def render_qtls_warning_message?
-    qts? && qtls_only && set_membership_expired
+    qts? && set_membership_expired
   end
 end

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -220,6 +220,6 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def render_qtls_warning_message?
-    qts? && qtls_only && set_membership_expired && !passed_induction
+    qts? && qtls_only && set_membership_expired
   end
 end

--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -26,7 +26,7 @@ type: 'application/pdf', disposition: 'attachment'
         :onelogin_user_token
       else
         :identity_user_token
-              end
+      end
       @client ||= QualificationsApi::Client.new(token: session[token])
     end
 

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -78,6 +78,7 @@ module QualificationsApi
         return 'QTS via QTLS' if set_membership_active?
         return 'No QTS' if set_membership_expired?
       end
+      return 'QTS and QTLS' if qts_and_qtls?
       return 'QTS' if qts_awarded?
       return 'EYTS' if eyts_awarded?
       return 'EYPS' if eyps_awarded?
@@ -186,6 +187,10 @@ module QualificationsApi
 
     def render_qtls_expired_message?
       api_data.qtls_status == "Expired" && !qts_awarded?
+    end
+
+    def render_has_qtls_message?
+      set_membership_active?
     end
 
     private

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -119,9 +119,9 @@ module QualificationsApi
 
     def induction_status
       return 'Passed' if passed_induction?
-      if exempt_from_induction_via_induction_status? || exempt_from_induction_via_qts_via_qtls?
-        return 'Exempt from induction'
-      end
+      return 'Failed' if failed_induction?
+      return 'Exempt from induction' if exempt_from_induction?
+
       'No induction'
     end
 
@@ -135,6 +135,10 @@ module QualificationsApi
 
     def failed_induction?
       induction_status_values.include?("Failed")
+    end
+
+    def exempt_from_induction?
+      exempt_from_induction_via_induction_status? || exempt_from_induction_via_qts_via_qtls?
     end
 
     def exempt_from_induction_via_induction_status?

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -7,8 +7,7 @@ class Qualification
                 :qtls_only,
                 :set_membership_active,
                 :set_membership_expired,
-                :passed_induction,
-                :failed_induction,
+                :induction_status,
                 :qts_and_qtls,
                 :routes
 

--- a/app/models/sanction.rb
+++ b/app/models/sanction.rb
@@ -261,7 +261,6 @@ class Sanction
     },
   }.freeze
 
-
   def description
     SANCTIONS[alert_type_id][:description] if SANCTIONS[alert_type_id]
   end

--- a/app/views/check_records/search/_results_table.html.erb
+++ b/app/views/check_records/search/_results_table.html.erb
@@ -22,7 +22,10 @@
               text: teacher.restriction_status == 'Restriction' ? govuk_tag(text: teacher.restriction_status, colour: 'red') : teacher.restriction_status
             )
             row.with_cell(text: teacher.teaching_status)
-            row.with_cell(text: teacher.induction_status, html_attributes: { data: { raw_values: teacher.induction_status_values.join(",") }})
+            row.with_cell(
+              text: t("bulk_search.induction.status.#{teacher.induction_status}"),
+              html_attributes: { data: { raw_values: teacher.induction_status_values.join(",") }}
+            )
           end
         end
       end

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -23,6 +23,12 @@
       <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
     <% end %>
 
+    <% if @teacher.render_has_qtls_message? %>
+      <%= govuk_notification_banner(title_text: "Important") do %>
+        <p>Qualified teacher learning and skills (QTLS) status will expire if <%= link_to("Society for Education and Training (SET)", "https://set.et-foundation.co.uk/your-career/qtls") %> membership is not renewed.</p>
+      <% end %>
+    <% end %>
+
     <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
       <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
         <% @teacher.sanctions.each do |sanction| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,38 @@ en:
     feedback_auth_failure: You must be signed in to give feedback.
     session_expired: Your session has expired. Please sign in again.
 
+  bulk_search:
+    induction:
+      status:
+        failed: Failed
+        exempt: Exempt from induction
+        passed: Passed
+        none: No induction
+        required_to_complete: Required to complete
+        in_progress: In Progress
+        failed_in_wales: Failed in Wales
+
+  summary_tags:
+    induction:
+      status:
+        failed: Failed induction
+        exempt: Induction exempt
+        passed: Passed induction
+        none: No induction
+        required_to_complete: Required to complete Induction
+        in_progress: Induction in progress
+        failed_in_wales: Induction failed in wales
+
+  induction_summary:
+    status:
+      failed: Failed
+      exempt: Exempt
+      passed: Passed
+      none: No induction
+      required_to_complete: Required to complete
+      in_progress: In Progress
+      failed_in_wales: Failed in Wales
+
   activemodel:
     errors:
       models:

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         name: "Qualified teacher status (QTS)",
         qtls_only: false,
         set_membership_active: false,
-        passed_induction: false,
+        induction_status: :none,
         qts_and_qtls: false,
         type: :qts,
       )
@@ -100,7 +100,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
-        passed_induction: false,
+        induction_status: :exempt,
         qts_and_qtls: false,
         name: "Qualified teacher status (QTS)",
         type: :qts,
@@ -140,7 +140,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: false,
-        passed_induction: false,
+        induction_status: :none,
         qts_and_qtls: false,
         name: "Qualified teacher status (QTS)",
         type: :qts,
@@ -176,7 +176,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: false,
         set_membership_active: true,
-        passed_induction: false,
+        induction_status: :exempt,
         qts_and_qtls: true,
         name: "Qualified teacher status (QTS)",
         type: :qts,
@@ -217,7 +217,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: false,
         set_membership_active: true,
-        passed_induction: false,
+        induction_status: :exempt,
         qts_and_qtls: true,
         name: "Qualified teacher status (QTS)",
         type: :qts,
@@ -257,7 +257,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
-        passed_induction: false,
+        induction_status: :exempt,
         qts_and_qtls: true,
         name: "Induction",
         details: CoercedDetails.new({ status: "Not complete" }),
@@ -295,7 +295,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         qtls_only: true,
         set_membership_active: true,
-        passed_induction: false,
+        induction_status: :exempt,
         qts_and_qtls: false,
         name: "Induction",
         details: CoercedDetails.new(status: "Something else"),
@@ -330,10 +330,11 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     end
     let(:qualification) do
       Qualification.new(
-        awarded_at: fake_quals_data.qts.holds_from&.to_date,
+        awarded_at: nil,
         qtls_only: true,
         set_membership_active: false,
-        passed_induction: false,
+        set_membership_expired: true,
+        induction_status: :none,
         qts_and_qtls: false,
         name: "Induction",
         details: CoercedDetails.new({status: "Something else"}),
@@ -345,7 +346,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
     let(:rendered) { render_inline(component) }
     let(:rows) { rendered.css(".govuk-summary-list__row") }
 
-    it "renders two rows" do
+    it "renders one row" do
       expect(rows.count).to eq(1)
     end
 

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -18,83 +18,26 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
 
       it { is_expected.to have_text("EYPS") }
     end
-    
+
     context "when teacher has QTS" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
-          'qts' => { 
-              'holdsFrom' => Time.current,
-              'qtls_only' => false,
-              'set_membership_active' => false,
-              'passed_induction' => true
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'qts' => {
+            'holdsFrom' => Time.current,
+            'qtls_only' => false,
+            'set_membership_active' => false,
+            'passed_induction' => true
           }
-        }
-        ) 
+        )
       end
 
       it { is_expected.to have_text("QTS") }
     end
 
     context "when teacher has QTS via QTLS" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-          'qts' => { 
-              'holdsFrom' => Time.current,
-              'awardedOrApprovedCount' => 1,
-              "routes" => [
-                {
-                  "routeToProfessionalStatusType" => {
-                    "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,
-                    "name" => "string",
-                    "professionalStatusType" => "QualifiedTeacherStatus"
-                  }
-                }
-              ]
-          },
-          'qtlsStatus' => 'Active'
-        )
-      end
-
-      it { is_expected.to have_text("QTS via QTLS") }
-    end
-
-    context "when teacher has passed induction" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
-          'induction' => { 
-              'status' => "Passed",
-              },
-          'qtlsStatus' => 'None'
-        }
-        ) 
-      end
-
-      it { is_expected.to have_text("Passed") }
-    end
-
-    context "when teacher has failed induction" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
-          'induction' => { 
-              'status' => "Failed",
-              },
-          'qtlsStatus' => 'None'
-        }
-        ) 
-      end
-
-      it { is_expected.not_to have_text("Passed") }
-    end
-
-    context "when teacher is exempt from induction" do
-      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status' => 'Exempt' }}) }
-
-      it { is_expected.to have_text("Exempt from induction") }
-    end
-
-    context "when teacher does not have QTS is exempt from induction via QTLS" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
-          'qts' => { 
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'qts' => {
             'holdsFrom' => Time.current,
             'awardedOrApprovedCount' => 1,
             "routes" => [
@@ -107,59 +50,111 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
               }
             ]
           },
-          'induction' => { 
+          'qtlsStatus' => 'Active'
+        )
+      end
+
+      it { is_expected.to have_text("QTS via QTLS") }
+    end
+
+    context "when teacher has passed induction" do
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'induction' => {
+            'status' => "Passed",
+          },
+          'qtlsStatus' => 'None'
+        )
+      end
+
+      it { is_expected.to have_text("Passed") }
+    end
+
+    context "when teacher has failed induction" do
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'induction' => {
+            'status' => "Failed",
+          },
+          'qtlsStatus' => 'None'
+        )
+      end
+
+      it { is_expected.not_to have_text("Passed") }
+    end
+
+    context "when teacher is exempt from induction" do
+      let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status' => 'Exempt' }}) }
+
+      it { is_expected.to have_text("Induction Exempt") }
+    end
+
+    context "when teacher does not have QTS is exempt from induction via QTLS" do
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'qts' => {
+            'holdsFrom' => Time.current,
+            'awardedOrApprovedCount' => 1,
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          'induction' => {
             'status' => "None",
           },
           'qtlsStatus' => 'Active'
-        }
-        ) 
+        )
       end
 
-      it { is_expected.to have_text("Exempt from induction") }
+      it { is_expected.to have_text("Induction Exempt") }
       it { is_expected.to have_text("QTS via QTLS")}
     end
 
     context "when teacher does not have QTS is exempt from induction via QTLS and SET membership expires" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
           'qts' => {},
-          'induction' => { 
-              'status' => "Failed",
-              },
+          'induction' => {
+            'status' => "Failed",
+          },
           'qtlsStatus' => 'Expired'
-        }
-        ) 
+        )
       end
 
-      it { is_expected.to have_text("No induction") }
+      it { is_expected.to have_text("Failed induction") }
       it { is_expected.to have_text("No QTS") }
     end
 
     context "when teacher has QTS but not completed induction and has QTLS" do
-      let(:teacher) do QualificationsApi::Teacher.new(
-        { 
-          'qts' => { 
-              'holdsFrom' => Time.current,
-              'awardedOrApprovedCount' => 2,
-              "routes" => [
-                {
-                  "routeToProfessionalStatusType" => {
-                    "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
-                    "name" => "string",
-                    "professionalStatusType" => "QualifiedTeacherStatus"
-                  }
+      let(:teacher) do
+        QualificationsApi::Teacher.new(
+          'qts' => {
+            'holdsFrom' => Time.current,
+            'awardedOrApprovedCount' => 2,
+            "routes" => [
+              {
+                "routeToProfessionalStatusType" => {
+                  "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
+                  "name" => "string",
+                  "professionalStatusType" => "QualifiedTeacherStatus"
                 }
-              ]
+              }
+            ]
           },
-          'induction' => { 
-              'status' => "None",
-              },
+          'induction' => {
+            'status' => "None",
+          },
           'qtlsStatus' => 'Active'
-        }
-        ) 
+        )
       end
 
-      it { is_expected.to have_text("Exempt from induction") }
+      it { is_expected.to have_text("Induction Exempt") }
       it { is_expected.to have_text("QTS") }
     end
   end

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
     context "when teacher is exempt from induction" do
       let(:teacher) { QualificationsApi::Teacher.new({ 'induction' => { 'status' => 'Exempt' }}) }
 
-      it { is_expected.to have_text("Induction Exempt") }
+      it { is_expected.to have_text("Induction exempt") }
     end
 
     context "when teacher does not have QTS is exempt from induction via QTLS" do
@@ -112,7 +112,7 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
         )
       end
 
-      it { is_expected.to have_text("Induction Exempt") }
+      it { is_expected.to have_text("Induction exempt") }
       it { is_expected.to have_text("QTS via QTLS")}
     end
 
@@ -154,7 +154,7 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
         )
       end
 
-      it { is_expected.to have_text("Induction Exempt") }
+      it { is_expected.to have_text("Induction exempt") }
       it { is_expected.to have_text("QTS") }
     end
   end

--- a/spec/components/induction_summary_component_spec.rb
+++ b/spec/components/induction_summary_component_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe InductionSummaryComponent, test: :with_fake_quals_data, type: :co
         qtls_only: false,
         qts_and_qtls: false,
         set_membership_active: false,
+        induction_status: :passed,
         details: induction
       )
     end

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: true,
+        induction_status: :passed,
         qtls_only: false,
         qts_and_qtls: false,
         set_membership_active: false,
@@ -92,7 +92,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: true,
+        induction_status: :passed,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: true,
@@ -130,7 +130,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: true,
+        induction_status: :passed,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: false,
@@ -162,7 +162,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: false,
+        induction_status: :failed,
         qtls_only: true,
         qts_and_qtls: false,
         set_membership_active: true,
@@ -198,7 +198,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: true,
+        induction_status: :passed,
         qtls_only: true,
         set_membership_active: true,
         type: :qts,
@@ -235,7 +235,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: true,
+        induction_status: :passed,
         qtls_only: true,
         set_membership_active: false,
         type: :qts,
@@ -266,7 +266,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
       Qualification.new(
         awarded_at: fake_quals_data.qts.holds_from&.to_date,
         name: "Qualified teacher status (QTS)",
-        passed_induction: false,
+        induction_status: :exempt,
         qtls_only: true,
         set_membership_active: true,
         type: :qts,

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -44,6 +44,11 @@ class FakeQualificationsApi < Sinatra::Base
           total: 1,
           results: [no_data]
         }.to_json
+      when "FailedInduction"
+        {
+          total: 1,
+          results: [teacher_data(trn: "1357913")]
+        }.to_json
       else
         {
           total: 1,
@@ -68,6 +73,8 @@ class FakeQualificationsApi < Sinatra::Base
         quals_data(trn:).to_json
       when "1212121"
         no_data.to_json
+      when "1357913"
+        quals_data(trn:, qts_via_qtls: true, induction_status: "Failed").to_json
       else
         halt 404
       end

--- a/spec/support/fake_qualifications_api.rb
+++ b/spec/support/fake_qualifications_api.rb
@@ -191,7 +191,7 @@ class FakeQualificationsApi < Sinatra::Base
       alerts: [
         {
           alert_type: {
-            alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99",
+            alert_type_id: "ed0cd700-3fb2-4db0-9403-ba57126090ed",
           },
           startDate: "2019-10-25"
         },

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -57,7 +57,7 @@ module FakeQualificationsData
   end
 
   def qts_data(qts_via_qtls:)
-    route = if qts_via_qtls  && false
+    route = if qts_via_qtls
       {
         "routeToProfessionalStatusType" => {
           "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -1,5 +1,5 @@
 module FakeQualificationsData
-  def quals_data(trn: nil, rtps: true)
+  def quals_data(trn: nil, rtps: true, qts_via_qtls: true, induction_status: "Passed")
     {
       trn: trn || "3000299",
       dateOfBirth: "2000-01-01",
@@ -21,37 +21,64 @@ module FakeQualificationsData
           }
         ]
       },
-      qts: {
-        holdsFrom: "2023-02-27",
-        "routes" => [
-          {
-            "routeToProfessionalStatusType" => {
-              "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
-              "name" => "Initial teacher training (ITT)",
-              "professionalStatusType" => "QualifiedTeacherStatus"
-            }
-          }
-        ],
-        awarded_approved_count: "1"
-      },
-      induction: {
-        startDate: "2022-09-01",
-        completedDate: "2022-10-01",
-        status: "Passed",
-        exemptionReasons: [
-          {
-            inductionExemptionReasonId: "induction-exemption-reason-id-33333",
-            "name": "Gained QTS before 1999"
-          }
-        ]
-      },
+      qts: qts_data(qts_via_qtls:),
+      induction: induction_data(induction_status),
       "routesToProfessionalStatuses": [rtps ? build_rtps : nil].compact.flatten,
       mandatoryQualifications: [
         { endDate: "2023-02-28", specialism: "Visual impairment", mandatoryQualificationId: 1 },
         { endDate: "2022-01-01", specialism: "Hearing", mandatoryQualificationId: 1 }
       ],
       alerts: fake_alerts(trn),
-      qtlsStatus: "None"
+      qtlsStatus: qts_via_qtls ? "Active" : "None"
+    }
+  end
+
+  def induction_data(induction_status)
+    if induction_status == "Failed"
+      return {
+        startDate: "2022-09-01",
+        completedDate: nil,
+        status: induction_status,
+        exemptionReasons: []
+      }
+    end
+
+    {
+      startDate: "2022-09-01",
+      completedDate: "2022-10-01",
+      status: induction_status,
+      exemptionReasons: [
+        {
+          inductionExemptionReasonId: "induction-exemption-reason-id-33333",
+          "name": "Gained QTS before 1999"
+        }
+      ]
+    }
+  end
+
+  def qts_data(qts_via_qtls:)
+    route = if qts_via_qtls  && false
+      {
+        "routeToProfessionalStatusType" => {
+          "routeToProfessionalStatusTypeId" => QualificationsApi::Teacher::QTLS_ROUTE_ID,
+          "name" => "string",
+          "professionalStatusType" => "QualifiedTeacherStatus"
+        }
+      }
+    else
+      {
+        "routeToProfessionalStatusType" => {
+          "routeToProfessionalStatusTypeId" => "qts-route-type-id-11111",
+          "name" => "Initial teacher training (ITT)",
+          "professionalStatusType" => "QualifiedTeacherStatus"
+        }
+      }
+    end
+
+    {
+      holdsFrom: "2023-02-27",
+      "routes" => [route],
+      awarded_approved_count: "1"
     }
   end
 

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -182,8 +182,16 @@ module FakeQualificationsData
 
     [
       {
-        alert_type: { alert_type_id: "40794ea8-eda2-40a8-a26a-5f447aae6c99" },
-        startDate: "2020-10-25"
+        alert_type: {
+          alert_type_id: "ed0cd700-3fb2-4db0-9403-ba57126090ed",
+        },
+        startDate: "2019-10-25"
+      },
+      {
+        alert_type: {
+          alert_type_id: "fa6bd220-61b0-41fc-9066-421b3b9d7885"
+        },
+        startDate: "2018-9-20"
       }
     ]
   end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012585",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "c4c6e6a8-2390-4129-90f4-e492e2faa1ab",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  before do
+    FeatureFlags::FeatureFlag.activate(:teacher_profile_tags)
+  end
+
+  after { travel_back }
+
+  scenario "Scenario 1",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_1.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_rtps_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified via qualified teacher learning and skills (QTLS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_rtps_details
+    expect(page).to have_content("Result\tHolds")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012585",
       "firstName": "Christopher",
@@ -81,7 +82,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   before do
     FeatureFlags::FeatureFlag.activate(:teacher_profile_tags)
@@ -102,7 +104,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_1.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_2_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_2_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  let(:override_quals_data) do
     {
       "trn": "3012586",
       "firstName": "Christopher",
@@ -35,7 +35,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   after { travel_back }
 
@@ -52,7 +52,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_2.png", full: true)
     then_i_see_an_expired_qtls_message
     then_i_see_npq_details
     and_a_viewed_timestamp_is_displayed
@@ -94,7 +93,9 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_an_expired_qtls_message
-    expect(page).to have_content("No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired")
+    expect(page).to have_content(
+      "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired"
+    )
   end
 
   def then_i_see_npq_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_2_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_2_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012586",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Two",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": nil,
+      "eyts": nil,
+      "induction": {
+        "status": "None",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 2",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_2.png", full: true)
+    then_i_see_an_expired_qtls_message
+    then_i_see_npq_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_an_expired_qtls_message
+    expect(page).to have_content("No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_1_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  let(:override_quals_data) do
     {
       "trn": "3012602",
       "firstName": "Christopher",
@@ -71,7 +71,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "None"
     }
-  }
+  end
 
   after { travel_back }
 
@@ -88,7 +88,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_3_1.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_1_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012602",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Three One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "RequiredToComplete",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "cb158f27-d7fb-4ed9-81f4-16014f4a92ef",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "None"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 3",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_3_1.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_rtps_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Required to complete")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_rtps_details
+    expect(page).to have_content("Result\tHolds")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  let(:override_quals_data) do
     {
       "trn": "3012601",
       "firstName": "Christopher",
@@ -71,7 +71,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "None"
     }
-  }
+  end
 
   after { travel_back }
 
@@ -88,7 +88,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_3.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_3_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012601",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Three",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-03-03",
+        "completedDate": "2025-06-03",
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "2a5eed72-2886-4bfe-87df-0cfd484e9102",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "None"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 3",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_3.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_rtps_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Passed")
+    expect(page).to have_content("3 June 2025")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_rtps_details
+    expect(page).to have_content("Result\tHolds")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012591",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Four One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "184c4537-8668-4ff7-91b7-ddb28fc424bc",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 4.1",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_4_1.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    then_i_see_appropriate_warnings
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Passed")
+    expect(page).to have_content("1 March 2025")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_appropriate_warnings
+    # expect(page).to have_content("No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired")
+    expect(page).to have_content("No longer exempt from induction because their Society for Education and Training (SET) membership expired")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end
+def then_i_see_previous_last_names
+  expect(page).to have_content("Previous last names")
+  expect(page).to have_content("Jones\nSmith")
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  let(:override_quals_data) do
     {
       "trn": "3012591",
       "firstName": "Christopher",
@@ -71,7 +71,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   after { travel_back }
 
@@ -88,7 +88,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_4_1.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details
@@ -153,8 +152,12 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_appropriate_warnings
-    # expect(page).to have_content("No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired")
-    expect(page).to have_content("No longer exempt from induction because their Society for Education and Training (SET) membership expired")
+    # expect(page).to have_content(
+    #   "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired"
+    # )
+    expect(page).to have_content(
+      "No longer exempt from induction because their Society for Education and Training (SET) membership expired"
+    )
   end
 
   def and_a_search_timestamp_is_displayed

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_1_spec.rb
@@ -152,9 +152,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_appropriate_warnings
-    # expect(page).to have_content(
-    #   "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired"
-    # )
     expect(page).to have_content(
       "No longer exempt from induction because their Society for Education and Training (SET) membership expired"
     )

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012584",
       "firstName": "Christopher",
@@ -112,7 +113,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   after { travel_back }
 
@@ -129,7 +131,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_4.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details
@@ -195,7 +196,9 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
   def then_i_see_appropriate_warnings
     expect(page).to have_content("They will need to complete induction if their SET membership expires.")
-    expect(page).to have_content("No longer exempt from induction because their Society for Education and Training (SET) membership expired")
+    expect(page).to have_content(
+      "No longer exempt from induction because their Society for Education and Training (SET) membership expired"
+    )
   end
 
   def and_a_search_timestamp_is_displayed

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012584",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Four",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "3b96f567-9a35-4b12-81c0-576868ba8e89",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "e66e5be2-28d5-4ecb-b245-fc71edc4df38",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 4",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_4.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    then_i_see_appropriate_warnings
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_appropriate_warnings
+    expect(page).to have_content("They will need to complete induction if their SET membership expires.")
+    expect(page).to have_content("No longer exempt from induction because their Society for Education and Training (SET) membership expired")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
@@ -196,9 +196,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
   def then_i_see_appropriate_warnings
     expect(page).to have_content("They will need to complete induction if their SET membership expires.")
-    expect(page).to have_content(
-      "No longer exempt from induction because their Society for Education and Training (SET) membership expired"
-    )
   end
 
   def and_a_search_timestamp_is_displayed

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_1_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  let(:override_quals_data) do
     {
       "trn": "3012593",
       "firstName": "Christopher",
@@ -71,7 +71,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   after { travel_back }
 
@@ -88,7 +88,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_5_1.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_1_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012593",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Five One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "RequiredToComplete",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "778f50a4-e19b-42c7-ab93-abd048fa2507",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 5.1",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_5_1.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Required to complete")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012588",
       "firstName": "Christopher",
@@ -112,7 +113,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   after { travel_back }
 
@@ -129,7 +131,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_5.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012588",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Five",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "5a6fcdf6-36e2-4997-9e07-009a5341d1f7",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "48b4ea24-43ca-4a14-a0b1-ee3ef5022687",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 5",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_5.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012589",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Six",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Failed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "33c2ccb5-d4a2-4920-bc81-ef38e31396d1",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "8d9aea28-88ff-4477-bc14-4b26520d5509",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 6",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_6.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Failed")
+    expect(page).to have_content("1 March 2025")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2025")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012589",
       "firstName": "Christopher",
@@ -112,7 +113,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   after { travel_back }
 
@@ -129,7 +131,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_6.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:override_quals_data) {
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012590",
       "firstName": "Christopher",
@@ -112,7 +113,8 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   after { travel_back }
 
@@ -129,7 +131,6 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
 
     when_i_click_on_the_teacher_record
     then_the_trn_is_not_in_the_url
-    save_screenshot("scenario_screenshots/ctr/scenario_7.png", full: true)
     then_i_see_induction_details
     then_i_see_qts_details
     then_i_see_qts_rtps_details

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:override_quals_data) {
+    {
+      "trn": "3012590",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Seven",
+      "dateOfBirth": "1975-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2012-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "6d897624-35e5-4a75-a8e7-048547cde8ec",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "ea3d4d0c-a12d-465d-8901-ad4f4332e8f5",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2012-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  after { travel_back }
+
+  scenario "Scenario 7",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    save_screenshot("scenario_screenshots/ctr/scenario_7.png", full: true)
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_qts_rtps_details
+    then_i_see_npq_details
+    and_a_viewed_timestamp_is_displayed
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "Walsh"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1234567')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "Walsh"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t1 January 2012")
+  end
+
+  def then_i_see_qts_rtps_details
+    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Headship awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Teacher search with restrictions",
     then_i_see_the_restriction_on_the_result
 
     when_i_click_on_the_result
+    save_screenshot("scenario_screenshots/ctr/sanctions.png", full: true)
     then_i_see_the_details_of_the_record
   end
 

--- a/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
+++ b/spec/system/check_records/user_searches_for_teacher_with_restrictions_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Teacher search with restrictions",
     then_i_see_the_restriction_on_the_result
 
     when_i_click_on_the_result
-    save_screenshot("scenario_screenshots/ctr/sanctions.png", full: true)
     then_i_see_the_details_of_the_record
   end
 

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
     expect(page).to have_content "1 teacher record found"
     expect(page).to have_content "Terry Walsh"
     expect(page).to have_content "Restriction"
-    expect(page).to have_content "Passed"
+    expect(page).to have_content "Exempt from induction"
     expect(page).to have_selector('td[data-raw-values="Passed,"]')
   end
 

--- a/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
+++ b/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher search", host: :check_records, type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  after { travel_back }
+
+  scenario "User searches with qts_via_qtls and failed induction does not show as exempt",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_check_service_is_open
+    and_time_is_frozen
+
+    when_i_sign_in_via_dsi
+    and_search_with_a_valid_name_and_dob
+    then_i_see_a_teacher_record_in_the_results
+    then_i_see_previous_last_names
+    and_my_search_is_logged
+    and_a_search_timestamp_is_displayed
+
+    when_i_click_on_the_teacher_record
+    then_the_trn_is_not_in_the_url
+    then_i_see_induction_details
+    then_i_see_qts_details
+    then_i_see_rtps_details
+    then_i_see_eyts_details
+    then_i_see_other_rtps_details
+    then_i_see_npq_details
+    then_i_see_mq_details
+    and_a_viewed_timestamp_is_displayed
+    then_i_see_previous_last_names
+    and_a_print_warning_is_displayed
+  end
+
+  private
+
+  def and_time_is_frozen
+    @frozen_time = Time.zone.local(2020, 1, 1, 10, 21)
+    travel_to @frozen_time
+  end
+
+  def and_search_with_a_valid_name_and_dob
+    fill_in "Last name", with: "FailedInduction"
+    fill_in "Day", with: "5"
+    fill_in "Month", with: "April"
+    fill_in "Year", with: "1992"
+    click_button "Find record"
+  end
+
+  def then_i_see_a_teacher_record_in_the_results
+    expect(page).to have_content "Terry John Walsh"
+  end
+
+  def then_the_trn_is_not_in_the_url
+    expect(page).to have_current_path("/check-records/teachers/#{SecureIdentifier.encode('1357913')}")
+  end
+
+  def and_my_search_is_logged
+    search_log = SearchLog.last
+    expect(search_log.last_name).to eq "FailedInduction"
+    expect(search_log.date_of_birth.to_s).to eq "1992-04-05"
+    expect(search_log.result_count).to eq 1
+  end
+
+  def when_i_click_on_the_teacher_record
+    click_on "Terry John Walsh"
+  end
+
+  def then_i_see_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Passed")
+    expect(page).to have_content("1 October 2022")
+  end
+
+  def then_i_see_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since\t27 February 2023")
+  end
+
+  def then_i_see_eyts_details
+    expect(page).to have_content("Early years teacher status (EYTS)")
+    expect(page).to have_content("Held since\t27 February 2023")
+  end
+
+  def then_i_see_rtps_details
+    expect(page).to have_content("Qualification\tBA")
+    expect(page).to have_content("Provider\tEarl Spencer Primary School")
+    expect(page).to have_content("Subject\tBusiness Studies")
+    expect(page).to have_content("Age range\t7 to 14 years")
+    expect(page).to have_content("Start date\t28 February 2022")
+    expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Result\tHolds")
+  end
+
+  def then_i_see_other_rtps_details
+    expect(page).to have_content("Qualification\tBA")
+    expect(page).to have_content("Provider\tEarl Spencer Secondary School")
+    expect(page).to have_content("Subject\tBusiness Studies")
+    expect(page).to have_content("Age range\t15 to 18 years")
+    expect(page).to have_content("Start date\t28 February 2022")
+    expect(page).to have_content("End date\t28 January 2030")
+    expect(page).to have_content("Result\tIn training")
+  end
+
+  def then_i_see_npq_details
+    expect(page).to have_content("Date NPQ for Early Years Leadership awarded")
+    expect(page).to have_content("27 February 2023")
+  end
+
+  def then_i_see_mq_details
+    expect(page).to have_content("MQ Specialism\tVisual impairment")
+    expect(page).to have_content("Date Awarded\t28 February 2023")
+    expect(page).to have_content("MQ Specialism\tHearing")
+    expect(page).to have_content("Date Awarded\t1 January 2022")
+  end
+
+
+  def and_a_search_timestamp_is_displayed
+    expect(page).to have_content "Searched at 10:21am on 1 January 2020"
+  end
+
+  def and_a_viewed_timestamp_is_displayed
+    expect(page).to have_content "Viewed at 10:21am on 1 January 2020"
+  end
+
+  def and_a_print_warning_is_displayed
+    expect(page).to have_content "You should dispose of the offline records"
+  end
+end
+  def then_i_see_previous_last_names
+    expect(page).to have_content("Previous last names")
+    expect(page).to have_content("Jones\nSmith")
+  end

--- a/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
+++ b/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
+    expect(page).to have_content("Failed")
   end
 
   def then_i_see_qts_details
@@ -105,7 +104,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_npq_details
-    expect(page).to have_content("Date NPQ for Early Years Leadership awarded")
+    expect(page).to have_content("Date NPQ for Headship awarded")
     expect(page).to have_content("27 February 2023")
   end
 

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
+    expect(page).to have_content("Exempt")
   end
 
   def then_i_see_qts_details

--- a/spec/system/check_records/user_searches_with_whitespace_spec.rb
+++ b/spec/system/check_records/user_searches_with_whitespace_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
 
   def then_i_see_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
+    expect(page).to have_content("Exempt")
   end
 
   def then_i_see_qts_details

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012585",
       "firstName": "Christopher",
@@ -80,7 +81,8 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   scenario "scenario 1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -88,7 +90,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_1.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -119,7 +120,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -133,6 +134,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012585",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "c4c6e6a8-2390-4129-90f4-e492e2faa1ab",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  scenario "scenario 1",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_1.png", full: true)
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) do
     {
       "trn": "3012586",
       "firstName": "Christopher",
@@ -34,7 +34,7 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   scenario "scenario 2",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -42,7 +42,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_2.png", full: true)
     then_i_see_my_npq_details
     and_my_npq_certificate_is_downloadable
     and_event_tracking_is_working
@@ -65,6 +64,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012586",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Two",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": nil,
+      "eyts": nil,
+      "induction": {
+        "status": "None",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  scenario "scenario 2",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_2.png", full: true)
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) do
     {
       "trn": "3012602",
       "firstName": "Christopher",
@@ -70,7 +70,7 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "None"
     }
-  }
+  end
 
   scenario "scenario 3.1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -78,7 +78,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_3_1.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -117,7 +116,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_qts_certificate.pdf\";"
+                                                              "filename=\"#{name}_qts_certificate.pdf\";"
                                                             )
   end
 
@@ -126,7 +125,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_eyts_certificate.pdf\";"
+                                                              "filename=\"#{name}_eyts_certificate.pdf\";"
                                                             )
   end
 
@@ -153,7 +152,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_npqh_certificate.pdf\";"
+                                                              "filename=\"#{name}_npqh_certificate.pdf\";"
                                                             )
   end
 

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
@@ -4,22 +4,86 @@ RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "when they have qualifications",
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012602",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Three One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "RequiredToComplete",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "cb158f27-d7fb-4ed9-81f4-16014f4a92ef",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "None"
+    }
+  }
+
+  scenario "scenario 3.1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_3_1.png", full: true)
     then_i_see_my_induction_details
-    and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
-    then_i_see_my_rtps_details
-    then_i_see_my_eyts_details
-    and_my_eyts_certificate_is_downloadable
     then_i_see_my_npq_details
     and_my_npq_certificate_is_downloadable
-    then_i_see_my_mq_details
     and_event_tracking_is_working
   end
 
@@ -31,20 +95,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
-    expect(page).to have_link("Download Induction certificate")
-  end
-
-  def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    expect(page.response_headers["content-type"]).to eq("application/pdf")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_induction_certificate.pdf\""
-                                                            )
+    expect(page).to have_content("Required to complete")
   end
 
   def then_i_see_my_qts_details
@@ -64,22 +115,18 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_qts_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_qts_certificate.pdf\";"
                                                             )
   end
 
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_eyts_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_eyts_certificate.pdf\";"
                                                             )
   end
 
@@ -104,11 +151,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_npqh_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_npqh_certificate.pdf\";"
                                                             )
   end
 

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012601",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Three",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-03-03",
+        "completedDate": "2025-06-03",
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "2a5eed72-2886-4bfe-87df-0cfd484e9102",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "None"
+    }
+  }
+
+  scenario "scenario 3",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_3.png", full: true)
+    then_i_see_my_induction_details
+    and_my_induction_certificate_is_downloadable
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Passed")
+    expect(page).to have_content("3 June 2025")
+    expect(page).to have_link("Download Induction certificate")
+  end
+
+  def and_my_induction_certificate_is_downloadable
+    click_on "Download Induction certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) do
     {
       "trn": "3012601",
       "firstName": "Christopher",
@@ -70,7 +70,7 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "None"
     }
-  }
+  end
 
   scenario "scenario 3",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -78,7 +78,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_3.png", full: true)
     then_i_see_my_induction_details
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
@@ -105,7 +104,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
   end
 
   def then_i_see_my_qts_details
@@ -119,7 +118,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -133,6 +132,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
@@ -4,12 +4,81 @@ RSpec.feature "User views their qualifications", type: :system do
   include CommonSteps
   include QualificationAuthenticationSteps
 
-  scenario "when they have qualifications",
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012591",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Four One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "184c4537-8668-4ff7-91b7-ddb28fc424bc",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  scenario "scenario 4.1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_qualifications_service_is_open
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_4_1.png", full: true)
     then_i_see_my_induction_details
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
@@ -39,11 +108,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_induction_certificate_is_downloadable
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_induction_certificate.pdf\""
+                                                              "filename=\"#{full_name}_induction_certificate.pdf\""
                                                             )
   end
 
@@ -64,22 +131,18 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_qts_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_qts_certificate.pdf\";"
                                                             )
   end
 
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_eyts_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_eyts_certificate.pdf\";"
                                                             )
   end
 
@@ -104,11 +167,9 @@ RSpec.feature "User views their qualifications", type: :system do
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_npqh_certificate.pdf\";"
+                                                              "filename=\"#{full_name}_npqh_certificate.pdf\";"
                                                             )
   end
 

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) do
     {
       "trn": "3012591",
       "firstName": "Christopher",
@@ -70,7 +70,7 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   scenario "scenario 4.1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -78,7 +78,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_4_1.png", full: true)
     then_i_see_my_induction_details
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
@@ -110,7 +109,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_induction_certificate.pdf\""
+                                                              "filename=\"#{name}_induction_certificate.pdf\""
                                                             )
   end
 
@@ -133,7 +132,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_qts_certificate.pdf\";"
+                                                              "filename=\"#{name}_qts_certificate.pdf\";"
                                                             )
   end
 
@@ -142,7 +141,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_eyts_certificate.pdf\";"
+                                                              "filename=\"#{name}_eyts_certificate.pdf\";"
                                                             )
   end
 
@@ -169,7 +168,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{full_name}_npqh_certificate.pdf\";"
+                                                              "filename=\"#{name}_npqh_certificate.pdf\";"
                                                             )
   end
 

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
@@ -82,12 +82,8 @@ RSpec.feature "User views their qualifications", type: :system do
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
-    then_i_see_my_rtps_details
-    then_i_see_my_eyts_details
-    and_my_eyts_certificate_is_downloadable
     then_i_see_my_npq_details
     and_my_npq_certificate_is_downloadable
-    then_i_see_my_mq_details
     and_event_tracking_is_working
   end
 
@@ -100,7 +96,7 @@ RSpec.feature "User views their qualifications", type: :system do
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
     expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
+    expect(page).to have_content("1 March 2025")
     expect(page).to have_link("Download Induction certificate")
   end
 
@@ -108,9 +104,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{name}_induction_certificate.pdf\""
-                                                            )
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
   end
 
   def then_i_see_my_qts_details
@@ -120,41 +114,13 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Download QTS certificate")
   end
 
-  def then_i_see_my_eyts_details
-    expect(page).to have_content("Early years teacher status (EYTS)")
-    expect(page).to have_content("Held since")
-    expect(page).to have_content("27 February 2023")
-    expect(page).to have_content("Download EYTS certificate")
-  end
-
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{name}_qts_certificate.pdf\";"
-                                                            )
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
-  def and_my_eyts_certificate_is_downloadable
-    click_on "Download EYTS certificate"
-    expect(page.response_headers["content-type"]).to eq("application/pdf")
-    expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{name}_eyts_certificate.pdf\";"
-                                                            )
-  end
-
-  def then_i_see_my_rtps_details
-    expect(page).to have_content("Initial teacher training (ITT)")
-    expect(page).to have_content("BA")
-    expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("Business Studies")
-    expect(page).to have_content("28 February 2022")
-    expect(page).to have_content("28 January 2023")
-    expect(page).to have_content("Status\tPass")
-    expect(page).to have_content("7 to 14 years")
-  end
 
   def then_i_see_my_npq_details
     expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
@@ -167,14 +133,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"#{name}_npqh_certificate.pdf\";"
-                                                            )
-  end
-
-  def then_i_see_my_mq_details
-    expect(page).to have_content("Mandatory qualification (MQ)")
-    expect(page).to have_content("Held since\t28 February 2023")
-    expect(page).to have_content("Specialism\tVisual impairment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012584",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Four",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Passed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "3b96f567-9a35-4b12-81c0-576868ba8e89",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "e66e5be2-28d5-4ecb-b245-fc71edc4df38",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  scenario "scenario 4",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_4.png", full: true)
+    then_i_see_my_induction_details
+    and_my_induction_certificate_is_downloadable
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Passed")
+    expect(page).to have_content("1 March 2025")
+    expect(page).to have_link("Download Induction certificate")
+  end
+
+  def and_my_induction_certificate_is_downloadable
+    click_on "Download Induction certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("1 January 2025")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -122,7 +122,6 @@ RSpec.feature "User views their qualifications", type: :system do
 
     when_i_visit_the_qualifications_page
     then_i_see_my_induction_details
-    and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
     then_i_see_my_npq_details
@@ -138,16 +137,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 March 2025")
-    expect(page).to have_link("Download Induction certificate")
-  end
-
-  def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    expect(page.response_headers["content-type"]).to eq("application/pdf")
-    expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
+    expect(page).to have_content("Exempt")
   end
 
   def then_i_see_my_qts_details

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012584",
       "firstName": "Christopher",
@@ -111,7 +112,8 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   scenario "scenario 4",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -119,7 +121,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_4.png", full: true)
     then_i_see_my_induction_details
     and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
@@ -146,7 +147,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
   end
 
   def then_i_see_my_qts_details
@@ -160,7 +161,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -174,6 +175,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012593",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Five One",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "RequiredToComplete",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": []
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "778f50a4-e19b-42c7-ab93-abd048fa2507",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Expired"
+    }
+  }
+
+  scenario "scenario 5.1",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_5_1.png", full: true)
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    then_i_see_appropriate_warnings
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Required to complete")
+  end
+
+  def and_my_induction_certificate_is_downloadable
+    click_on "Download Induction certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+
+  def then_i_see_appropriate_warnings
+    expect(page).to have_content("You are no longer exempt from induction because your Society for Education and Training (SET) membership expired")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) do
     {
       "trn": "3012593",
       "firstName": "Christopher",
@@ -70,7 +70,7 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Expired"
     }
-  }
+  end
 
   scenario "scenario 5.1",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -78,7 +78,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_5_1.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -103,7 +102,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
   end
 
   def then_i_see_my_qts_details
@@ -117,7 +116,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -131,10 +130,12 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 
   def then_i_see_appropriate_warnings
-    expect(page).to have_content("You are no longer exempt from induction because your Society for Education and Training (SET) membership expired")
+    expect(page).to have_content(
+      "You are no longer exempt from induction because your Society for Education and Training (SET) membership expired"
+    )
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012588",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Five",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "5a6fcdf6-36e2-4997-9e07-009a5341d1f7",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "48b4ea24-43ca-4a14-a0b1-ee3ef5022687",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  scenario "scenario 5",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_5.png", full: true)
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012588",
       "firstName": "Christopher",
@@ -111,7 +112,8 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   scenario "scenario 5",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -119,7 +121,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_5.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -150,7 +151,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -164,6 +165,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012589",
+      "firstName": "Christopher",
+      "middleName": "Scenario",
+      "lastName": "Six",
+      "dateOfBirth": "1985-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2025-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Failed",
+        "startDate": "2025-01-01",
+        "completedDate": "2025-03-01",
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "33c2ccb5-d4a2-4920-bc81-ef38e31396d1",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "8d9aea28-88ff-4477-bc14-4b26520d5509",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  scenario "scenario 6",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_6.png", full: true)
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Failed")
+    expect(page).to have_content("1 March 2025")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -138,7 +138,6 @@ RSpec.feature "User views their qualifications", type: :system do
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
     expect(page).to have_content("Failed")
-    expect(page).to have_content("1 March 2025")
   end
 
   def then_i_see_my_qts_details

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012589",
       "firstName": "Christopher",
@@ -111,7 +112,8 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   scenario "scenario 6",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -119,7 +121,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_6.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -151,7 +152,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -165,6 +166,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -143,7 +143,7 @@ RSpec.feature "User views their qualifications", type: :system do
   def then_i_see_my_qts_details
     expect(page).to have_content("Qualified teacher status (QTS)")
     expect(page).to have_content("Held since")
-    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("1 January 2025")
     expect(page).to have_content("Download QTS certificate")
   end
 

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.feature "User views their qualifications", type: :system do
+  include CommonSteps
+  include QualificationAuthenticationSteps
+
+  before do
+    allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
+  end
+
+  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  let(:override_quals_data) {
+    {
+      "trn": "3012590",
+      "firstName": "Christopher",
+      "middleName": "Scenario ",
+      "lastName": "Seven",
+      "dateOfBirth": "1975-09-04",
+      "nationalInsuranceNumber": nil,
+      "pendingNameChange": false,
+      "pendingDateOfBirthChange": false,
+      "emailAddress": nil,
+      "qts": {
+        "holdsFrom": "2012-01-01",
+        "routes": [
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              "name": "Apply for Qualified Teacher Status in England",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          },
+          {
+            "routeToProfessionalStatusType": {
+              "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+              "name": "QTLS and SET Membership",
+              "professionalStatusType": "QualifiedTeacherStatus"
+            }
+          }
+        ]
+      },
+      "eyts": nil,
+      "induction": {
+        "status": "Exempt",
+        "startDate": nil,
+        "completedDate": nil,
+        "exemptionReasons": [
+          {
+            "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+            "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+          }
+        ]
+      },
+      "routesToProfessionalStatuses": [
+        {
+          "routeToProfessionalStatusId": "6d897624-35e5-4a75-a8e7-048547cde8ec",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            "name": "Apply for Qualified Teacher Status in England",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2025-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": false,
+            "exemptionReasons": []
+          }
+        },
+        {
+          "routeToProfessionalStatusId": "ea3d4d0c-a12d-465d-8901-ad4f4332e8f5",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": "be6eaf8c-92dd-4eff-aad3-1c89c4bec18c",
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2012-01-01",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of The Society of Education and Training"
+              }
+            ]
+          }
+        }
+      ],
+      "mandatoryQualifications": [],
+      "alerts": [],
+      "previousNames": [],
+      "qtlsStatus": "Active"
+    }
+  }
+
+  scenario "scenario 7",
+           test: %i[with_stubbed_auth with_fake_quals_api] do
+    given_the_qualifications_service_is_open
+    and_i_am_signed_in_via_identity
+
+    when_i_visit_the_qualifications_page
+    save_screenshot("scenario_screenshots/aytq/scenario_7.png", full: true)
+    then_i_see_my_induction_details
+    then_i_see_my_qts_details
+    and_my_qts_certificate_is_downloadable
+    then_i_see_my_npq_details
+    and_my_npq_certificate_is_downloadable
+    and_event_tracking_is_working
+  end
+
+  private
+
+  def when_i_visit_the_qualifications_page
+    visit qualifications_dashboard_path
+  end
+
+  def then_i_see_my_induction_details
+    expect(page).to have_content("Induction")
+    expect(page).to have_content("Exempt")
+  end
+
+  def and_my_induction_certificate_is_downloadable
+    click_on "Download Induction certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+  end
+
+  def then_i_see_my_qts_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download QTS certificate")
+  end
+  def and_my_qts_certificate_is_downloadable
+    click_on "Download QTS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_npq_details
+    expect(page).to have_content("National Professional Qualification (NPQ) for Headship")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("27 February 2023")
+    expect(page).to have_content("Download NPQH certificate")
+  end
+
+  def and_my_npq_certificate_is_downloadable
+    click_on "Download NPQH certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+  end
+end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "User views their qualifications", type: :system do
     allow_any_instance_of(FakeQualificationsData).to receive(:quals_data).and_return(override_quals_data)
   end
 
-  let(:full_name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
-  let(:override_quals_data) {
+  let(:name) { override_quals_data.slice(:firstName, :middleName, :lastName).values.map(&:strip).join(" ") }
+  # rubocop:disable Layout/LineLength
+  let(:override_quals_data) do
     {
       "trn": "3012590",
       "firstName": "Christopher",
@@ -111,7 +112,8 @@ RSpec.feature "User views their qualifications", type: :system do
       "previousNames": [],
       "qtlsStatus": "Active"
     }
-  }
+  end
+  # rubocop:enable Layout/LineLength
 
   scenario "scenario 7",
            test: %i[with_stubbed_auth with_fake_quals_api] do
@@ -119,7 +121,6 @@ RSpec.feature "User views their qualifications", type: :system do
     and_i_am_signed_in_via_identity
 
     when_i_visit_the_qualifications_page
-    save_screenshot("scenario_screenshots/aytq/scenario_7.png", full: true)
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
@@ -143,7 +144,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download Induction certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_induction_certificate.pdf\"")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
   end
 
   def then_i_see_my_qts_details
@@ -156,7 +157,7 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download QTS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details
@@ -170,6 +171,6 @@ RSpec.feature "User views their qualifications", type: :system do
     click_on "Download NPQH certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{full_name}_npqh_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")
   end
 end

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "User views their qualifications", type: :system do
 
     when_i_visit_the_qualifications_page
     then_i_see_my_induction_details
-    and_my_induction_certificate_is_downloadable
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
     then_i_see_my_rtps_details
@@ -31,20 +30,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def then_i_see_my_induction_details
     expect(page).to have_content("Induction")
-    expect(page).to have_content("Passed")
-    expect(page).to have_content("1 October 2022")
-    expect(page).to have_link("Download Induction certificate")
-  end
-
-  def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    expect(page.response_headers["content-type"]).to eq("application/pdf")
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "attachment"
-                                                            )
-    expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_induction_certificate.pdf\""
-                                                            )
+    expect(page).to have_content("Exempt")
   end
 
   def then_i_see_my_qts_details
@@ -90,7 +76,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Business Studies")
     expect(page).to have_content("28 February 2022")
     expect(page).to have_content("28 January 2023")
-    expect(page).to have_content("Status\tPass")
+    expect(page).to have_content("Status\tHolds")
     expect(page).to have_content("7 to 14 years")
   end
 


### PR DESCRIPTION
### Context

QTLS/set logic is not accurate to what the system should be presenting to users. The logic needs updating to properly render out status tags, error messages, and induction statuses.

### Changes proposed in this pull request

- Add in specs for specific scenarios and expected outcomes.
- Centralise induction status logic into teacher.rb
  - Ensures a single source of truth for induction status
  - Removes dependency on API resources in other services that previously determined this information via the `details` hash
  - Allows induction status output to be moved into locales
- Correct logic for when to render errors

### Guidance to review

- Changes have been reviewed and approved by Chris Jeffery

### Link to Trello card

- https://trello.com/c/10qAv7gD
- https://trello.com/c/AlcUUJom
- https://trello.com/c/yPj70gRw

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
