### PR TITLE
Move print button below content in the DOM

### DIFF
--- a/app/assets/stylesheets/check_records.scss
+++ b/app/assets/stylesheets/check_records.scss
@@ -123,3 +123,12 @@ h1 .govuk-tag {
     display: none;
   }
 }
+
+.flex-reverse-direction {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.govuk-margin-top-minus-4 {
+  margin-top: govuk-spacing(-4) !important;
+}

--- a/app/views/check_records/bulk_searches/create.html.erb
+++ b/app/views/check_records/bulk_searches/create.html.erb
@@ -1,7 +1,6 @@
 <% content_for :page_title, "File summary" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Find multiple records" => new_check_records_bulk_search_path, "Results" => nil }) %>
-
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/check_records/teachers/show.html.erb
+++ b/app/views/check_records/teachers/show.html.erb
@@ -4,103 +4,107 @@
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_breadcrumbs(breadcrumbs: { "Home" => check_records_search_path, "Search results" => url_for(:back), @teacher.name => nil}) %>
     </div>
-
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-3 govuk-!-margin-bottom-2">
-      <a href="#" data-print-button class="app__no-print">Print this page</a>
-    </div>
   </div>
 
   <%= render ActionAtComponent.new(action: "Viewed") %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
-      <%= @teacher.name %>
-    </h1>
+<div class="flex-reverse-direction">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
+        <%= @teacher.name %>
+      </h1>
 
-    <% if @teacher.render_qtls_expired_message? %>
-      <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
-    <% end %>
-
-    <% if @teacher.render_has_qtls_message? %>
-      <%= govuk_notification_banner(title_text: "Important") do %>
-        <p>Qualified teacher learning and skills (QTLS) status will expire if <%= link_to("Society for Education and Training (SET)", "https://set.et-foundation.co.uk/your-career/qtls") %> membership is not renewed.</p>
+      <% if @teacher.render_qtls_expired_message? %>
+        <%= govuk_warning_text(text: "No longer has QTS via QTLS status because their Society for Education and Training (SET) membership expired") %>
       <% end %>
-    <% end %>
 
-    <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
-      <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
-        <% @teacher.sanctions.each do |sanction| %>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-0">
-            <%= sanction.title %>
-          </h2>
-          <% if sanction.description.present? %>
-            <div class="govuk-!-margin-bottom-1">
-              <%= GovukMarkdown.render(sanction.description).html_safe %>
-            </div>
+      <% if @teacher.render_has_qtls_message? %>
+        <%= govuk_notification_banner(title_text: "Important") do %>
+          <p>Qualified teacher learning and skills (QTLS) status will expire if <%= link_to("Society for Education and Training (SET)", "https://set.et-foundation.co.uk/your-career/qtls") %> membership is not renewed.</p>
+        <% end %>
+      <% end %>
+
+      <% if @teacher.sanctions.any? && @teacher.sanctions&.first&.description.present? %>
+        <%= govuk_inset_text classes: "app-inset-text--red govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0" do %>
+          <% @teacher.sanctions.each do |sanction| %>
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+              <%= sanction.title %>
+            </h2>
+            <% if sanction.description.present? %>
+              <div class="govuk-!-margin-bottom-1">
+                <%= GovukMarkdown.render(sanction.description).html_safe %>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
 
-    <% if @teacher.no_details? %>
-      <%= govuk_warning_text(text: "We have no details of this person's qualifications, teacher status or induction status. Please contact them directly for this information.") %>
-    <% end %>
-    <% if @mqs.present? %>
-      <%= render CheckRecords::MqSummaryComponent.new(mqs: @mqs) %>
-    <% end %>
+      <% if @teacher.no_details? %>
+        <%= govuk_warning_text(text: "We have no details of this person's qualifications, teacher status or induction status. Please contact them directly for this information.") %>
+      <% end %>
+      <% if @mqs.present? %>
+        <%= render CheckRecords::MqSummaryComponent.new(mqs: @mqs) %>
+      <% end %>
 
-    <% if @npqs.present? %>
-      <%= render CheckRecords::NpqSummaryComponent.new(npqs: @npqs) %>
-    <% end %>
+      <% if @npqs.present? %>
+        <%= render CheckRecords::NpqSummaryComponent.new(npqs: @npqs) %>
+      <% end %>
 
-    <% @other_qualifications.each do |qualification| %>
-      <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
-    <% end %>
+      <% @other_qualifications.each do |qualification| %>
+        <%= render CheckRecords::QualificationSummaryComponent.new(qualification:) %>
+      <% end %>
 
-    <%= govuk_inset_text classes: "govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0 app__no-print" do %>
-      <div class="govuk-!-margin-bottom-1">
-        You should review the terms and conditions before printing this page. You should dispose of the offline records you maintain once they have served their purpose.
-      </div>
-    <% end %>
+      <%= govuk_inset_text classes: "govuk-!-padding-bottom-2 govuk-!-padding-top-3 govuk-!-margin-bottom- govuk-!-margin-top-0 app__no-print" do %>
+        <div class="govuk-!-margin-bottom-1">
+          You should review the terms and conditions before printing this page. You should dispose of the offline records you maintain once they have served their purpose.
+        </div>
+      <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <% if FeatureFlags::FeatureFlag.active?(:teacher_profile_tags) %>
+        <%= render CheckRecords::TeacherProfileSummaryComponent.new(@teacher) %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">Personal details</h2>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <ul class="govuk-list govuk-!-font-size-16">
+        <% if @teacher.trn.present? %>
+          <li>
+            <h4>Teacher Reference number (TRN)</h4>
+          </li>
+          <li>
+            <p><%= @teacher.trn  %></p>
+          </li>
+        <% end %>
+
+        <% if @teacher.date_of_birth.present? %>
+          <li>
+            <h4>Date of birth</h4>
+          </li>
+          <li>
+            <p><%= Date.parse(@teacher.date_of_birth).to_fs(:long) %></p>
+          </li>
+        <% end %>
+
+        <% if @teacher.previous_names.present? %>
+            <li>
+              <h4>Previous last names</h4>
+            </li>
+            <% @teacher.previous_names.each do |name| %>
+              <li><%= name %></li>
+            <% end %>
+        <% end %>
+      </ul>
+    </div>
   </div>
 
-  <div class="govuk-grid-column-one-third">
-    <% if FeatureFlags::FeatureFlag.active?(:teacher_profile_tags) %>
-      <%= render CheckRecords::TeacherProfileSummaryComponent.new(@teacher) %>
-    <% end %>
-
-    <h2 class="govuk-heading-m">Personal details</h2>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-    <ul class="govuk-list govuk-!-font-size-16">
-      <% if @teacher.trn.present? %>
-        <li>
-          <h4>Teacher Reference number (TRN)</h4>
-        </li>
-        <li>
-          <p><%= @teacher.trn  %></p>
-        </li>
-      <% end %>
-
-      <% if @teacher.date_of_birth.present? %>
-        <li>
-          <h4>Date of birth</h4>
-        </li>
-        <li>
-          <p><%= Date.parse(@teacher.date_of_birth).to_fs(:long) %></p>
-        </li>
-      <% end %>
-
-      <% if @teacher.previous_names.present? %>
-          <li>
-            <h4>Previous last names</h4>
-          </li>
-          <% @teacher.previous_names.each do |name| %>
-            <li><%= name %></li>
-          <% end %>
-      <% end %>
-    </ul>
+  <div class="govuk-grid-row govuk-!-margin-bottom-4 govuk-margin-top-minus-4">
+    <div class="govuk-grid-column-full">
+      <a href="#" data-print-button class="app__no-print">Print this page</a>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### Context

Severity: Medium

The ‘Print this page’ link is within the DOM before the content which gives information on printing the page contents.

Screen reader users would encounter the ‘Print this page’ link before getting to the content which provides users with content on printing the page. This could mean that screen reader users print the page without having all the information they need.

Recommendation: Change the placement of the ‘Print this page’ link so that it appears after the content.

### Changes proposed in this pull request

- Move print button below content in the DOM.

### Guidance to review

- Check positioning in DOM of button on check records page.

### Link to Trello card

- https://trello.com/c/Bz7KVW9e

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
