### PR TITLE
Ensure no restrictions tag displays on teacher profiles

### DIFF
--- a/app/components/check_records/teacher_profile_summary_component.rb
+++ b/app/components/check_records/teacher_profile_summary_component.rb
@@ -21,12 +21,15 @@ class CheckRecords::TeacherProfileSummaryComponent < ApplicationComponent
   end
 
   delegate :induction_status, :no_induction?, :no_restrictions?, :no_qts_or_eyts?, :teaching_status,
-           :restriction_status, :set_membership_active?, :set_membership_expired?, :qtls_only?, :qts_and_qtls?,
+           :set_membership_active?, :set_membership_expired?, :qtls_only?, :qts_and_qtls?,
            :passed_induction?, :failed_induction?, :exempt_from_induction?,
            to: :teacher
 
   def restriction_tag
-    { message: "Restricted", colour: "red" } unless no_restrictions?
+    {
+      message: I18n.t("summary_tags.restrictions.#{!no_restrictions?}"),
+      colour: no_restrictions? ? "green" : "red"
+    }
   end
 
   def teaching_status_tag

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -54,12 +54,6 @@ module QualificationsApi
       ].flatten.compact
     end
 
-    def restriction_status
-      return 'No restrictions' if no_restrictions?
-
-      'Restriction'
-    end
-
     def no_restrictions?
       return true if sanctions.blank? ||
         sanctions.all?(&:guilty_but_not_prohibited?) ||

--- a/app/views/check_records/search/_results_table.html.erb
+++ b/app/views/check_records/search/_results_table.html.erb
@@ -18,9 +18,11 @@
           body.with_row do |row|
             row.with_cell(text: govuk_link_to(teacher.name, check_records_teacher_path(SecureIdentifier.encode(teacher.trn)), class: 'govuk-link--no-visited-state govuk-!-font-weight-bold'))
             row.with_cell(text: teacher.trn)
-            row.with_cell(
-              text: teacher.restriction_status == 'Restriction' ? govuk_tag(text: teacher.restriction_status, colour: 'red') : teacher.restriction_status
-            )
+            if teacher.no_restrictions?
+              row.with_cell(text: t("bulk_search.restrictions.false"))
+            else
+              row.with_cell(text: govuk_tag(text: t("bulk_search.restrictions.true"), colour: 'red'))
+            end
             row.with_cell(text: teacher.teaching_status)
             row.with_cell(
               text: t("bulk_search.induction.status.#{teacher.induction_status}"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,9 @@ en:
     session_expired: Your session has expired. Please sign in again.
 
   bulk_search:
+    restrictions:
+      true: Restriction
+      false: No restrictions
     induction:
       status:
         failed: Failed
@@ -26,6 +29,9 @@ en:
         failed_in_wales: Failed in Wales
 
   summary_tags:
+    restrictions:
+      true: Restricted
+      false: No restrictions
     induction:
       status:
         failed: Failed induction

--- a/spec/components/check_records/teacher_profile_summary_component_spec.rb
+++ b/spec/components/check_records/teacher_profile_summary_component_spec.rb
@@ -13,6 +13,29 @@ RSpec.describe CheckRecords::TeacherProfileSummaryComponent, type: :component, t
     it { is_expected.to have_text("No QTS or EYTS") }
     it { is_expected.to have_text("No induction") }
 
+    describe "restrictions tag" do
+      context "when the teacher has no restrictions" do
+        let(:teacher) { QualificationsApi::Teacher.new({}) }
+
+        it { is_expected.to have_text("No restrictions") }
+      end
+
+      context "when the teacher has restrictions" do
+        let(:teacher) do
+          QualificationsApi::Teacher.new({
+            "alerts" => [
+              "alert_type" =>  {
+                "alert_type_id" => "1a2b06ae-7e9f-4761-b95d-397ca5da4b13"
+              },
+              "start_date" => "2024-01-01"
+            ]
+          })
+        end
+
+        it { is_expected.to have_text("Restricted") }
+      end
+    end
+
     context "when teacher has EYPS" do
       let(:teacher) { QualificationsApi::Teacher.new({ 'eyps' => { 'awarded' => Time.current }}) }
 


### PR DESCRIPTION
### Context

This tag must be displayed when no restrictions are present.

### Changes proposed in this pull request

- Add in missing no restrictions tag.

### Guidance to review

- View a teacher profile without restrictions and ensure tag is present.

### Trello link

https://trello.com/c/uOEgcK1K

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
