### PR TITLE
Allow downloading of multiple QTS certificates

### DIFF
--- a/app/components/qualification_summary_component.html.erb
+++ b/app/components/qualification_summary_component.html.erb
@@ -2,13 +2,13 @@
     <%= govuk_summary_card(title:) do |card| %>
         <%= govuk_summary_list(rows:)%>
         <% if render_qts_induction_exemption_message? %>
-            <hr class="govuk-section-break govuk-section-break--visible">
-              <p> </p>
-              <p>You will no longer have QTS via QTLS status if your Society for Education and Training (SET) membership expires</p>
+          <hr class="govuk-section-break govuk-section-break--visible">
+          <p> </p>
+          <p>You will no longer have QTS via QTLS status if your Society for Education and Training (SET) membership expires</p>
         <% elsif render_qtls_warning_message? %>
           <hr class="govuk-section-break govuk-section-break--visible">
-            <p> </p>
-            <%= govuk_warning_text(text: "You no longer have QTS via QTLS status because your Society for Education and Training (SET) membership expired") %>
+          <p> </p>
+          <%= govuk_warning_text(text: "You no longer have QTS via QTLS status because your Society for Education and Training (SET) membership expired") %>
         <% end %>
     <% end %>
 <% end %>

--- a/app/components/qualification_summary_component.rb
+++ b/app/components/qualification_summary_component.rb
@@ -11,7 +11,9 @@ class QualificationSummaryComponent < ApplicationComponent
            :details,
            :id,
            :rtps?,
+           :qtls_rtps?,
            :qts?,
+           :qtls?,
            :eyts?,
            :induction_status,
            :set_membership_active,
@@ -28,7 +30,9 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def rows
-    @rows ||= build_rows.select { |row| row[:value][:text].present? }
+    @rows ||= build_rows.select do |row|
+      row[:value][:text].present?
+    end
   end
 
   def build_rows
@@ -82,7 +86,7 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def rtps_rows
-    return [] if details.training_end_date.blank?
+    return [] if details.training_end_date.blank? && !qtls_rtps?
 
     [
       {
@@ -215,7 +219,7 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def render_qts_induction_exemption_message?
-    qts? && set_membership_active && !failed_induction?
+    qtls? && set_membership_active && !failed_induction?
   end
 
   def failed_induction?
@@ -223,6 +227,6 @@ class QualificationSummaryComponent < ApplicationComponent
   end
 
   def render_qtls_warning_message?
-    qts? && set_membership_expired
+    qtls? && set_membership_expired
   end
 end

--- a/app/controllers/qualifications/certificates_controller.rb
+++ b/app/controllers/qualifications/certificates_controller.rb
@@ -45,7 +45,9 @@ type: 'application/pdf', disposition: 'attachment'
       when :induction
         teacher.passed_induction?
       when :qts
-        teacher.qts_awarded? || teacher.qtls_only?
+        teacher.qts_awarded?
+      when :qtls
+        teacher.qtls_awarded?
       when :eyts
         teacher.eyts_awarded?
       when :NPQEL,:NPQLTD,:NPQLT,:NPQH,:NPQML,:NPQLL,:NPQEYL,:NPQSL,:NPQLBC,:NPQSENCO, :NPQLPM

--- a/app/lib/qualifications_api/certificate.rb
+++ b/app/lib/qualifications_api/certificate.rb
@@ -3,7 +3,7 @@ module QualificationsApi
     include ActiveModel::Model
 
     VALID_TYPES = %i[eyts induction rtps NPQEL NPQLTD NPQLT NPQH NPQML NPQLL NPQEYL NPQSL NPQLBC NPQSENCO NPQLPM
-qts].freeze
+qts qtls].freeze
 
     attr_accessor :name, :type, :file_data
 

--- a/app/lib/qualifications_api/client.rb
+++ b/app/lib/qualifications_api/client.rb
@@ -102,7 +102,7 @@ module QualificationsApi
 
       case response.status
       when 200
-        QualificationsApi::Teacher.new response.body
+        QualificationsApi::Teacher.new(response.body)
       when 404
         raise QualificationsApi::TeacherNotFoundError
       when 403

--- a/app/lib/qualifications_api/teacher.rb
+++ b/app/lib/qualifications_api/teacher.rb
@@ -199,30 +199,36 @@ module QualificationsApi
 
     private
 
-    def qts_qualification
-      qts_data = api_data.qts
-      return if qts_data.blank? && !qtls_only?
-
-      @qts_qualification ||= Qualification.new(
-        awarded_at: qts_data&.holds_from&.to_date,
-        name: "Qualified teacher status (QTS)",
-        qtls_only: qtls_only?,
-        qts_and_qtls: qts_and_qtls?,
-        set_membership_active: set_membership_active?,
-        set_membership_expired: set_membership_expired?,
-        induction_status: induction_status,
-        type: :qts,
-        routes: qts_data.routes || []
-      )
-    end
-
     def qts_qualifications
-      return if qts_qualification.nil?
+      qts_data = api_data.qts
+      return if qts_data.blank?
 
-      [
-        qts_qualification,
-        rtps_qualifications(type: :qts, route_ids: qts_qualification.route_ids, include_blank: true)
-      ].flatten
+      @qts_qualifications ||= qts_data.routes.map { |route|
+        route_id = route.route_to_professional_status_type.route_to_professional_status_type_id
+        route_data = rtps_by_id(route_ids: [route_id]).first
+
+        type = route_id.upcase == QTLS_ROUTE_ID.upcase ? :qtls : :qts
+        name = if type == :qtls
+                 "QTS via qualified teacher learning and skills (QTLS) status"
+               else
+                 "Qualified teacher status (QTS)"
+               end
+
+        [
+          Qualification.new(
+            awarded_at: route_data&.holds_from&.to_date,
+            name: name,
+            qtls_only: qtls_only?,
+            qts_and_qtls: qts_and_qtls?,
+            set_membership_active: set_membership_active?,
+            set_membership_expired: set_membership_expired?,
+            induction_status: induction_status,
+            type: type,
+            routes: [route]
+          ),
+          rtps_qualifications(type: type, route_ids: [route_id], include_blank: true)
+        ]
+      }.flatten
     end
 
     def eyts_qualification
@@ -254,9 +260,14 @@ module QualificationsApi
       end
     end
 
+    def qts_route_ids
+      return [] if qts_qualifications.blank?
+
+      @qts_route_ids ||= qts_qualifications.map(&:route_ids).flatten.compact
+    end
+
     def all_other_rtps_qualifications
       eyts_route_ids = eyts_qualification&.route_ids || []
-      qts_route_ids = qts_qualification&.route_ids || []
 
       non_qts_eyts_route_ids = all_rtps_ids - eyts_route_ids - qts_route_ids
 
@@ -282,21 +293,27 @@ module QualificationsApi
       end
     end
 
-    def rtps_qualifications(type:, route_ids: [], include_blank: false, name: nil)
+    def rtps_by_id(route_ids: [], include_blank: false)
       return [] if api_data.routes_to_professional_statuses.blank?
 
-      routes = api_data.routes_to_professional_statuses.select do |route|
+      selected_routes = api_data.routes_to_professional_statuses.select do |route|
         route_id = route.route_to_professional_status_type.route_to_professional_status_type_id
 
         route_ids.include?(route_id) || (include_blank && route_id.blank?)
       end
 
-      sorted_routes = routes.sort_by { |r|
+      selected_routes.sort_by { |r|
         date = r.holds_from&.to_date
         [date ? 1 : 0, date]
       }.reverse
+    end
 
-      sorted_routes.map do |route|
+    def rtps_qualifications(type:, route_ids: [], include_blank: false, name: nil)
+      routes = rtps_by_id(route_ids: route_ids, include_blank: include_blank)
+
+      return [] if routes.blank?
+
+      routes.map do |route|
         Qualification.new(
           awarded_at: route.training_end_date&.to_date,
           details: CoercedDetails.new(route),

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -42,7 +42,11 @@ class Qualification
   end
 
   def rtps?
-    [:qts_rtps, :eyts_rtps, :other_rtps, :rtps].include?(type)
+    [:qts_rtps, :qtls_rtps, :eyts_rtps, :other_rtps, :rtps].include?(type)
+  end
+
+  def qtls_rtps?
+    type == :qtls_rtps
   end
 
   def mq?
@@ -55,6 +59,10 @@ class Qualification
 
   def qts?
     type == :qts
+  end
+
+  def qtls?
+    type == :qtls
   end
 
   def eyts?

--- a/app/views/qualifications/certificates/_qtls.html.erb
+++ b/app/views/qualifications/certificates/_qtls.html.erb
@@ -1,0 +1,34 @@
+<img src="/qts-certificate.jpg" class="header-image" alt="Department for Education" />
+
+<div class="content">
+  <h1 class="heading">Qualified<br/>Teacher Status</h1>
+  <p class="text">This is to certify that: <strong><%= teacher.name %></strong></p>
+  <p class="text">Teacher Reference Number: <strong><%= teacher.trn %></strong></p>
+  <ul>
+    <li class="text">
+      has attained qualified teacher status (QTS) via qualified teacher learning and<br/>
+      skills (QTLS) status
+    </li>
+    <li class="text">
+      meets the requirements for employment in maintained schools and non-maintained<br/>
+      special schools in England
+    </li>
+    <li class="text">
+      is exempt from the requirement to serve a statutory induction period.
+    </li>
+  </ul>
+  <p class="text">
+    QTS attained via QTLS status depends on an active membership with the Society<br/>
+    for Education and Training (SET). If you hold QTS only via QTLS and SET membership<br/>
+    and your membership ends, you will lose QTS. If you were directly awarded QTS<br/>
+    (for example, following initial teacher training) as well as holding QTS via<br/>
+    QTLS and SET membership and your membership ends, you will not lose QTS.<br/>
+    However, your exemption from induction will end.
+  </p>
+  <p>&#160;</p>
+  <p class="text">Date of QTS: <strong><%= qualification.awarded_at.to_fs(:long_uk) %></strong></p>
+  <p>&#160;</p>
+  <p class="text">Congratulations and best wishes for your future career</p>
+  <p>&#160;</p>
+  <p class="text">Any potential employer can independently confirm your teacher status online at:<br/><a>https://www.gov.uk/guidance/check-a-teachers-record</a></p>
+</div>

--- a/app/views/qualifications/certificates/_qts.html.erb
+++ b/app/views/qualifications/certificates/_qts.html.erb
@@ -4,29 +4,7 @@
   <h1 class="heading">Qualified<br/>Teacher Status</h1>
   <p class="text">This is to certify that: <strong><%= teacher.name %></strong></p>
   <p class="text">Teacher Reference Number: <strong><%= teacher.trn %></strong></p>
-  <% if @qualification.set_membership_active %>
-    <ul>
-      <li class="text">
-        has attained qualified teacher status (QTS) via qualified teacher learning and<br/>
-        skills (QTLS) status
-      </li>
-      <li class="text">
-        meets the requirements for employment in maintained schools and non-maintained<br/>
-        special schools in England
-      </li>
-      <li class="text">
-        is exempt from the requirement to serve a statutory induction period.
-      </li>
-    </ul>
-    <p class="text">
-      QTS attained via QTLS status depends on an active membership with the Society<br/>
-      for Education and Training (SET). If you hold QTS only via QTLS and SET membership<br/>
-      and your membership ends, you will lose QTS. If you were directly awarded QTS<br/>
-      (for example, following initial teacher training) as well as holding QTS via<br/>
-      QTLS and SET membership and your membership ends, you will not lose QTS.<br/>
-      However, your exemption from induction will end.
-    </p>
-  <% elsif teacher.exempt_from_induction_via_induction_status? %>
+  <% if teacher.exempt_from_induction_via_induction_status? %>
   <p>&#160;</p>
   <p class="text">has attained qualified teacher status (QTS), meets the requirements for employment in <br/>
     maintained schools and non-maintained special schools in England and is exempt from the <br/>

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -12,6 +12,6 @@ Grover.configure do |config|
   config.use_jpeg_middleware = false
   config.use_png_middleware = false
   config.ignore_path = ->(path) do
-    path !~ /^\/qualifications\/certificates\/(eyts|rtps|induction|mq|npq|qts)/i
+    path !~ /^\/qualifications\/certificates\/(eyts|rtps|induction|mq|npq|qts|qtls)/i
   end
 end

--- a/spec/components/check_records/qualification_summary_component_spec.rb
+++ b/spec/components/check_records/qualification_summary_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CheckRecords::QualificationSummaryComponent, test: :with_fake_qua
   describe "rendering" do
     let(:fake_quals_data) do
       Hashie::Mash.new(
-        quals_data(trn: "1234567")
+        quals_data(trn: "1234567", qts_via_qtls: false)
           .deep_transform_keys(&:to_s)
           .deep_transform_keys(&:underscore)
       )

--- a/spec/components/qualification_summary_component_spec.rb
+++ b/spec/components/qualification_summary_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QualificationSummaryComponent, test: :with_fake_quals_data, type:
   describe "rendering" do
     let(:fake_quals_data) do
       Hashie::Mash.new(
-        quals_data(trn: "1234567")
+        quals_data(trn: "1234567", qts_via_qtls: false)
           .deep_transform_keys(&:to_s)
           .deep_transform_keys(&:underscore)
       )

--- a/spec/support/fake_qualifications_data.rb
+++ b/spec/support/fake_qualifications_data.rb
@@ -23,7 +23,7 @@ module FakeQualificationsData
       },
       qts: qts_data(qts_via_qtls:),
       induction: induction_data(induction_status),
-      "routesToProfessionalStatuses": [rtps ? build_rtps : nil].compact.flatten,
+      "routesToProfessionalStatuses": [rtps ? build_rtps(qts_via_qtls:) : nil].compact.flatten,
       mandatoryQualifications: [
         { endDate: "2023-02-28", specialism: "Visual impairment", mandatoryQualificationId: 1 },
         { endDate: "2022-01-01", specialism: "Hearing", mandatoryQualificationId: 1 }
@@ -89,7 +89,41 @@ module FakeQualificationsData
     }
   end
 
-  def build_rtps
+  def build_rtps(qts_via_qtls: true)
+    if qts_via_qtls
+      return [
+        {
+          "routeToProfessionalStatusId": "qtls-route-id-33333",
+          "routeToProfessionalStatusType": {
+            "routeToProfessionalStatusTypeId": QualificationsApi::Teacher::QTLS_ROUTE_ID,
+            "name": "QTLS and SET Membership",
+            "professionalStatusType": "QualifiedTeacherStatus"
+          },
+          "status": "Holds",
+          "holdsFrom": "2023-02-27",
+          "trainingStartDate": nil,
+          "trainingEndDate": nil,
+          "trainingSubjects": [],
+          "trainingAgeSpecialism": nil,
+          "trainingCountry": {
+            "reference": "GB-ENG",
+            "name": "England"
+          },
+          "trainingProvider": nil,
+          "degreeType": nil,
+          "inductionExemption": {
+            "isExempt": true,
+            "exemptionReasons": [
+              {
+                "inductionExemptionReasonId": "35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db",
+                "name": "Exempt through QTLS status provided they maintain membership of SET"
+              }
+            ]
+          }
+        }
+      ]
+    end
+
     [
       {
         "routeToProfessionalStatusId": "qts-route-id-11111",

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_1_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Qualified via qualified teacher learning and skills (QTLS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since\t1 January 2025")
   end
 

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_4_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_rtps_details
-    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
   end
 

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_5_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_rtps_details
-    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
   end
 

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_6_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_rtps_details
-    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
   end
 

--- a/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
+++ b/spec/system/check_records/scenarios/user_searches_with_valid_last_name_and_dob_scenario_7_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe "Check Teacher Records", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_rtps_details
-    expect(page).to have_content("Route to QTS: QTLS and SET Membership")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Route to QTS: Apply for Qualified Teacher Status in England")
   end
 

--- a/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
+++ b/spec/system/check_records/user_searches_with_qts_via_qtls_and_failed_induction_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_qts_details
     then_i_see_rtps_details
     then_i_see_eyts_details
-    then_i_see_other_rtps_details
     then_i_see_npq_details
     then_i_see_mq_details
     and_a_viewed_timestamp_is_displayed
@@ -74,7 +73,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since\t27 February 2023")
   end
 
@@ -84,23 +83,8 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Primary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t7 to 14 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Result\tHolds")
-  end
-
-  def then_i_see_other_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Secondary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t15 to 18 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2030")
-    expect(page).to have_content("Result\tIn training")
   end
 
   def then_i_see_npq_details

--- a/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
+++ b/spec/system/check_records/user_searches_with_valid_last_name_and_dob_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_qts_details
     then_i_see_rtps_details
     then_i_see_eyts_details
-    then_i_see_other_rtps_details
     then_i_see_npq_details
     then_i_see_mq_details
     and_a_viewed_timestamp_is_displayed
@@ -74,7 +73,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since\t27 February 2023")
   end
 
@@ -84,23 +83,8 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Primary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t7 to 14 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Result\tHolds")
-  end
-
-  def then_i_see_other_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Secondary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t15 to 18 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2030")
-    expect(page).to have_content("Result\tIn training")
   end
 
   def then_i_see_npq_details

--- a/spec/system/check_records/user_searches_with_whitespace_spec.rb
+++ b/spec/system/check_records/user_searches_with_whitespace_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
     then_i_see_qts_details
     then_i_see_rtps_details
     then_i_see_eyts_details
-    then_i_see_other_rtps_details
     then_i_see_npq_details
     then_i_see_mq_details
     and_a_viewed_timestamp_is_displayed
@@ -74,7 +73,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since\t27 February 2023")
   end
 
@@ -84,23 +83,8 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def then_i_see_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Primary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t7 to 14 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2023")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Result\tHolds")
-  end
-
-  def then_i_see_other_rtps_details
-    expect(page).to have_content("Qualification\tBA")
-    expect(page).to have_content("Provider\tEarl Spencer Secondary School")
-    expect(page).to have_content("Subject\tBusiness Studies")
-    expect(page).to have_content("Age range\t15 to 18 years")
-    expect(page).to have_content("Start date\t28 February 2022")
-    expect(page).to have_content("End date\t28 January 2030")
-    expect(page).to have_content("Result\tIn training")
   end
 
   def then_i_see_npq_details

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
@@ -110,17 +110,17 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def then_i_see_my_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
-    expect(page).to have_content("Download QTS certificate")
+    expect(page).to have_content("Download QTLS certificate")
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
+    click_on "Download QTLS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
-    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -124,6 +124,8 @@ RSpec.feature "User views their qualifications", type: :system do
     then_i_see_my_induction_details
     then_i_see_my_qts_details
     and_my_qts_certificate_is_downloadable
+    then_i_see_my_qtls_details
+    and_my_qtls_certificate_is_downloadable
     then_i_see_my_npq_details
     and_my_npq_certificate_is_downloadable
     and_event_tracking_is_working
@@ -152,6 +154,20 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
+  end
+
+  def then_i_see_my_qtls_details
+    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("Held since")
+    expect(page).to have_content("1 January 2025")
+    expect(page).to have_content("Download QTLS certificate")
+  end
+
+  def and_my_qtls_certificate_is_downloadable
+    click_on "Download QTLS certificate"
+    expect(page.response_headers["content-type"]).to eq("application/pdf")
+    expect(page.response_headers["content-disposition"]).to include("attachment")
+    expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
   end
 
   def then_i_see_my_npq_details

--- a/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
+++ b/spec/system/qualifications/user_token_expires_while_viewing_qualifications_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Identity auth", type: :system do
   end
 
   def and_i_try_to_download_a_certificate
-    click_on "Download QTS certificate"
+    click_on "Download QTLS certificate"
   end
 
   def then_i_am_required_to_sign_in_again

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -34,10 +34,10 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def then_i_see_my_qts_details
-    expect(page).to have_content("Qualified teacher status (QTS)")
+    expect(page).to have_content("QTS via qualified teacher learning and skills (QTLS)")
     expect(page).to have_content("Held since")
     expect(page).to have_content("27 February 2023")
-    expect(page).to have_content("Download QTS certificate")
+    expect(page).to have_content("Download QTLS certificate")
   end
 
   def then_i_see_my_eyts_details
@@ -48,13 +48,13 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
+    click_on "Download QTLS certificate"
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"
                                                             )
     expect(page.response_headers["content-disposition"]).to include(
-                                                              "filename=\"Terry Walsh_qts_certificate.pdf\";"
+                                                              "filename=\"Terry Walsh_qtls_certificate.pdf\";"
                                                             )
   end
 
@@ -70,14 +70,8 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def then_i_see_my_rtps_details
-    expect(page).to have_content("Initial teacher training (ITT)")
-    expect(page).to have_content("BA")
-    expect(page).to have_content("Earl Spencer Primary School")
-    expect(page).to have_content("Business Studies")
-    expect(page).to have_content("28 February 2022")
-    expect(page).to have_content("28 January 2023")
+    expect(page).to have_content("Route to QTLS: QTLS and SET Membership")
     expect(page).to have_content("Status\tHolds")
-    expect(page).to have_content("7 to 14 years")
   end
 
   def then_i_see_my_npq_details


### PR DESCRIPTION
### Context

Citizens who have more than one route to QTS require the ability to view the various Routes, Induction Statuses for each route and if applicable, a link to each Certificate for their route

### Changes proposed in this pull request

- When multiple QTS routes are present all are now rendered into AYTQ and CTR
- On AYTQ when multiple QTS routes are present, all will be rendered with links to download their certificate.
- Update specs to correctly use QTLS route data when a QTS status is gained via a QTLS route

### Guidance to review

The pre-prepared scenarios, 1-10, are set up and available for testing, specifically scenario 4 will provide a user that has both QTS and QTLS certificates.

### Link to Trello card

https://trello.com/c/0k2O61eb

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
