### PR TITLE
Update AYTQ accessibility statement link

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -52,7 +52,7 @@
 
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
-            <%= govuk_link_to("Accessibility", "/qualifications/accessibility", class: "govuk-footer__link") %>
+            <%= govuk_link_to("Accessibility", "https://accessibility-statements.education.gov.uk/s/37", class: "govuk-footer__link") %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= govuk_link_to("Cookies", "/qualifications/cookies", class: "govuk-footer__link") %>


### PR DESCRIPTION
### Context

DfE Governance have a utility that automatically generates Accessibility Statements for services - and updates those as Accessibility changes are made to them

Each Service should provide a link to it’s Accessibility Statement in the footer of each page

The TRS Front-End Services currently use hardcoded Accessibility Statements

These should be replaced with links to those provided by the DfE Governance Service

### Changes proposed in this pull request

- Update AYTQ accessibility statement link to point to DfE Governance statement

### Guidance to review

- Deploy review app
- Access AYTQ and confirm that accessibility link in footer points to https://accessibility-statements.education.gov.uk/s/37

### Link to Trello card

https://trello.com/c/ag4GpwWO

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
