### PR TITLE
Update Database Recovery Github Actions and Documentation

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -24,6 +24,8 @@ on:
         description: Name of the backup file in Azure storage. e.g. aytq_prod_2024-08-09.sql.gz. The default value is today's scheduled backup.
         type: string
         required: false
+permissions:
+  id-token: write
 
 env:
   SERVICE_NAME: access-your-teaching-qualifications

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN apk add --no-cache \
     udev \
     dumb-init \
     curl \
-    libssl3=3.3.6-r0 \
+    libssl3=3.3.7-r0 \
     chromium=131.0.6778.108-r0
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser

--- a/docs/disaster_recovery.md
+++ b/docs/disaster_recovery.md
@@ -60,7 +60,7 @@ Run the [Recover deleted postgres database server workflow](https://github.com/D
 | Server name to restore | The server name to be restored.                                  | See table below                 |
 
 Restore point in time:
-- This should be at least 10 minutes after the server was deleted.
+- The restore point provided should be at least 10 minutes after the server was deleted and should be in the past, this is to provide time for the backup to become available.
 - **Important:** You should convert the time to UTC before actually using it. When you record the time, note what timezone you are using. Especially during BST (British Summer Time).
 
 Environment server names:
@@ -184,6 +184,8 @@ e.g. `bin/konduit.sh -x itt-mentor-services-staging -- psql`
 ### Restore data into the live server
 
 To perform a complete restore of the live server from the PTR copy, use the [Restore database from Azure storage workflow](https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/workflows/database-restore.yml) and choose the backup file created above to restore to the live postgres server.
+
+Note that when entering the backup filename that the name entered in the `Upload restored database to Azure storage` job should be appended with `.sql.gz` so that the file can correctly be looked up. 
 
 ### Restart applications
 


### PR DESCRIPTION
# Changes

- Add required permissions to database restore Github Action
- Add clarifying information to disaster recovery documentation
- Update libssl3 version (3.3.6-r0 is no longer available for alpine 3.20)