### PR TITLE
Update copy for AYTQ login page

### DIFF
--- a/app/lib/current_session.rb
+++ b/app/lib/current_session.rb
@@ -78,6 +78,15 @@ class CurrentSession
     ].join("?")
   end
 
+  def onelogin_login_path(trn_token: nil)
+    hash = { trn_token: trn_token }.compact_blank
+
+    [
+      "/qualifications/users/auth/onelogin",
+      hash.to_query
+    ].join("?")
+  end
+
   def identity_new_registration_bypass_enabled?
     session[:identity_new_registration_bypass_token].present?
   end

--- a/app/views/qualifications/starts/show.html.erb
+++ b/app/views/qualifications/starts/show.html.erb
@@ -13,30 +13,35 @@
     </ul>
     <h2 class="govuk-heading-m">Before you start</h2>
 
-    <% if current_session.one_login_available? %>
-      <h3 class="govuk-heading-s">Sign in with GOV.UK One Login</h3>
-      <p class="govuk-body">
-        You’ll need to sign in to your GOV.UK One Login. If you do not have a GOV.UK One Login, you can create one.
-      </p>
+    <% if current_session.identity_new_registration_bypass_enabled? %>
+      <p class="govuk-body">You'll need a DfE Identity account to access your teaching qualifications.</p>
+      <p class="govuk-body">You can create an account if you do not have one already.</p>
+
       <%=
         govuk_button_to(
-          "Sign in with GOVUK One Login",
-          ["/qualifications/users/auth/onelogin", "trn_token=#{params[:trn_token]}"].join("?"),
+          "Sign in with DfE Identity",
+          current_session.dfe_identity_login_path(trn_token: params[:trn_token]),
           method: :post
         )
       %>
-    <% end %>
+    <% else %>
+      <p class="govuk-body">Use your GOV.UK One Login to access this service. You can create one if you do not have one.</p>
 
-    <h3 class="govuk-heading-s">Sign in with DfE Identity</h3>
-    <p class="govuk-body">
-      You’ll need to create a DfE Identity account to access your teaching qualifications. You’ll use the account to sign-in to this service and other DfE teaching services.
-    </p>
+      <%=
+        govuk_button_to(
+          "Start now",
+          current_session.onelogin_login_path(trn_token: params[:trn_token]),
+          method: :post
+        )
+      %>
 
-    <%= button_to current_session.dfe_identity_login_path(trn_token: params[:trn_token]), class: "govuk-button govuk-button--start" do %>
-      Start now
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
-      </svg>
+      <span class="govuk-body">You can also</span>
+      <%=
+        form_with(url: current_session.dfe_identity_login_path(trn_token: params[:trn_token]), method: :post, class: "govuk-!-display-inline-block") do |form|
+          form.submit "sign in with your DfE Identity account", class: "govuk-link govuk-link--button"
+        end
+      %>
+      <span class="govuk-body">.</span>
     <% end %>
   </div>
 </div>

--- a/app/views/qualifications/users/sign_in/new.html.erb
+++ b/app/views/qualifications/users/sign_in/new.html.erb
@@ -7,27 +7,32 @@
     <% if current_session.identity_new_registration_bypass_enabled? %>
       <p class="govuk-body">You'll need a DfE Identity account to access your teaching qualifications.</p>
       <p class="govuk-body">You can create an account if you do not have one already.</p>
-    <% else  %>
-      <p class="govuk-body">Use your DfE Identity account to access this service.</p>
-    <% end %>
 
-    <%=
-      govuk_button_to(
-        "Sign in with DfE Identity",
-        current_session.dfe_identity_login_path(trn_token: params[:trn_token]),
-        method: :post
-      )
-    %>
-
-    <% if current_session.one_login_available? %>
-      <h2 class="govuk-heading-m">If you’re a new user</h2>
-      <span class="govuk-body">You can</span>
       <%=
-        form_with(url: ["/qualifications/users/auth/onelogin", "trn_token=#{params[:trn_token]}"].join("?"), method: :post, class: "govuk-!-display-inline-block") do |form|
-          form.submit "create a GOV.UK One Login", class: "govuk-link govuk-link--button"
+        govuk_button_to(
+          "Sign in with DfE Identity",
+          current_session.dfe_identity_login_path(trn_token: params[:trn_token]),
+          method: :post
+        )
+      %>
+    <% else %>
+      <p class="govuk-body">Use your GOV.UK One Login to access this service. You can create one if you do not have one.</p>
+
+      <%=
+        govuk_button_to(
+          "Sign in with GOV.UK One Login",
+          current_session.onelogin_login_path(trn_token: params[:trn_token]),
+          method: :post
+        )
+      %>
+
+      <span class="govuk-body">You can also</span>
+      <%=
+        form_with(url: current_session.dfe_identity_login_path(trn_token: params[:trn_token]), method: :post, class: "govuk-!-display-inline-block") do |form|
+          form.submit "sign in with your DfE Identity account", class: "govuk-link govuk-link--button"
         end
       %>
-      <span class="govuk-body">if you do not have a DfE Identity account.</span>
+      <span class="govuk-body">.</span>
     <% end %>
   </div>
 </div>

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -56,10 +56,10 @@ module QualificationAuthenticationSteps
   end
 
   def and_click_the_sign_in_button
-    click_button "Sign in with DfE Identity"
+    click_button "sign in with your DfE Identity account"
   end
 
   def and_click_the_onelogin_sign_in_button
-    click_button "create a GOV.UK One Login"
+    click_button "Sign in with GOV.UK One Login"
   end
 end

--- a/spec/system/qualifications/user_visits_the_root_path_spec.rb
+++ b/spec/system/qualifications/user_visits_the_root_path_spec.rb
@@ -15,6 +15,6 @@ RSpec.feature "The root path", type: :system do
   end
 
   def signin_button_text
-    "Sign in with DfE Identity"
+    "sign in with your DfE Identity account"
   end
 end


### PR DESCRIPTION
### Context

- Ops and Support have advised that some citizens are getting confused upon re-entry to the service following creation of their OneLogin accounts
- They have asked if the wording can be updated

### Changes proposed in this pull request

- Update copy for login pages

### Guidance to review

- View login page

### Link to Trello card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/280

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
