### PR TITLE
Strip whitespace on TRN search

### DIFF
--- a/app/models/trn_search.rb
+++ b/app/models/trn_search.rb
@@ -7,6 +7,7 @@ class TrnSearch
 
   def find_teacher(teachers:)
     return unless valid?
-    teachers.find { |t| t.trn == trn }
+
+    teachers.find { |t| t.trn == trn.strip }
   end
 end

--- a/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
+++ b/spec/system/check_records/user_searches_and_refines_results_with_trn_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Teacher search", host: :check_records, type: :system do
   end
 
   def when_i_enter_a_trn
-    fill_in "TRN", with: "1234567"
+    fill_in "TRN", with: "1234567 " # Testing with excess whitespace to check that it is properly stripped out
   end
 
   def then_i_see_a_teacher_record_in_the_results


### PR DESCRIPTION
### Context

Excess whitespace was leading to users not getting the results they should be

### Changes proposed in this pull request

- Strip whitespace from TRNs entered by users

### Link to Trello card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/305

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
