### PR TITLE
Fix intermittent spec failures

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,18 @@ require "dfe/analytics/rspec/matchers"
 WebMock.disable_net_connect!(allow_localhost: true)
 
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, timeout: 200, process_timeout: 120, window_size: [1200, 800])
+  # Without an explicit download path Chrome denies downloads, which can
+  # hang clicks on download links and leaves response_headers unset. The
+  # directory must exist or Chrome stalls the download instead.
+  download_path = Rails.root.join("tmp/capybara/downloads").to_s
+  FileUtils.mkdir_p(download_path)
+  Capybara::Cuprite::Driver.new(
+    app,
+    timeout: 200,
+    process_timeout: 120,
+    window_size: [1200, 800],
+    save_path: download_path
+  )
 end
 Capybara.default_driver = :cuprite
 Capybara.javascript_driver = :cuprite

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,6 +102,7 @@ RSpec.configure do |config|
 
     OmniAuth.config.mock_auth.delete(:identity)
     OmniAuth.config.mock_auth.delete(:dfe)
+    OmniAuth.config.mock_auth.delete(:onelogin)
   end
 
   config.around(:each, host: :check_records) do |example|

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -4,7 +4,6 @@ module AuthenticationSteps
     when_i_visit_the_sign_in_page
     and_wait_for_the_page_to_load
     and_i_accept_the_terms_and_conditions(accept_terms_and_conditions)
-    and_wait_for_the_page_to_load
   end
   alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
 
@@ -96,11 +95,20 @@ module AuthenticationSteps
 
   def and_i_accept_the_terms_and_conditions(accept)
     if accept
-      click_on "Accept"
+      click_on "Accept", wait: 10
+      expect(page).to have_no_current_path(check_records_terms_and_conditions_path, wait: 10)
     end
   end
 
+  # The sign in page POSTs to DSI via an auto-submitting form (see
+  # CheckRecords::SignInController#new). On the first request of a session the
+  # form's inline script is blocked by the Content-Security-Policy (the nonce
+  # is derived from the session id, which doesn't exist until the first
+  # response sets the session cookie), so the page never submits itself.
+  # Reloading once renders the form with a valid nonce. Only reload while
+  # still stuck on the form: reloading mid-redirect can abort the navigation
+  # and strand the test on a blank page.
   def and_wait_for_the_page_to_load
-    page.driver.refresh
+    page.driver.refresh unless page.has_no_css?("form[action*='/auth/']", wait: 2)
   end
 end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -6,6 +6,20 @@ module CommonSteps
     expect(:web_request).to have_been_enqueued_as_analytics_events
   end
 
+  # Certificate downloads don't navigate or change the DOM, so there is
+  # nothing for Capybara to synchronise on: response_headers can still be the
+  # previous response's (the HTML page, or an earlier download) until this
+  # download's response arrives. Poll for the expected download before
+  # asserting on it; on timeout fall through and let the caller's
+  # expectations report the actual headers.
+  def and_i_wait_for_the_download_to_finish(filename:)
+    Timeout.timeout(Capybara.default_max_wait_time * 5) do
+      sleep 0.1 until page.response_headers&.dig("content-disposition").to_s.include?(filename)
+    end
+  rescue Timeout::Error
+    nil
+  end
+
   def when_i_visit_the_service
     visit root_path
   end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -6,6 +6,16 @@ module CommonSteps
     expect(:web_request).to have_been_enqueued_as_analytics_events
   end
 
+  # Chrome occasionally stalls acknowledging a mouse click that triggers a
+  # download, which surfaces as Ferrum::TimeoutError on the click itself.
+  # Triggering the click from JavaScript avoids the CDP input
+  # acknowledgement entirely; the download still starts.
+  def download_certificate(link_text, filename:)
+    link = find_link(link_text)
+    page.execute_script("arguments[0].click()", link)
+    and_i_wait_for_the_download_to_finish(filename:)
+  end
+
   # Certificate downloads don't navigate or change the DOM, so there is
   # nothing for Capybara to synchronise on: response_headers can still be the
   # previous response's (the HTML page, or an earlier download) until this

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -8,12 +8,22 @@ module QualificationAuthenticationSteps
     given_identity_auth_is_mocked
     when_i_go_to_the_sign_in_page
     and_click_the_sign_in_button
+    and_i_am_taken_to_my_qualifications_dashboard
   end
 
   def and_i_am_signed_in_via_onelogin
     given_onelogin_auth_is_mocked
     when_i_go_to_the_sign_in_page
     and_click_the_onelogin_sign_in_button
+    and_i_am_taken_to_my_qualifications_dashboard
+  end
+
+  # Signing in navigates through the OmniAuth callback asynchronously, so a
+  # bare `visit` straight after clicking the sign in button can run before
+  # the session cookie is set and land back on the sign in page. Wait for
+  # the post-auth redirect to complete before handing back to the spec.
+  def and_i_am_taken_to_my_qualifications_dashboard
+    expect(page).to have_current_path(qualifications_dashboard_path, wait: 10)
   end
 
   def given_auth_is_mocked_for(provider:)

--- a/spec/system/check_records/user_accepts_terms_and_conditions_spec.rb
+++ b/spec/system/check_records/user_accepts_terms_and_conditions_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Terms and conditions acceptance", host: :check_records do
   include AuthenticationSteps
   include ActivateFeaturesSteps
 
+  after { travel_back }
+
   scenario "User accepts terms and conditions", test: :with_stubbed_auth do
     given_the_check_service_is_open
     when_i_sign_in_via_dsi(accept_terms_and_conditions: false)

--- a/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
+++ b/spec/system/check_records/user_searches_with_a_valid_csv_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
   include ActivateFeaturesSteps
   include AuthenticationSteps
 
+  after { travel_back }
+
   scenario "User searches with a valid CSV", test: %i[with_stubbed_auth with_fake_quals_api] do
     given_the_check_service_is_open
     and_bulk_search_is_enabled
@@ -60,6 +62,5 @@ RSpec.describe "Bulk search", host: :check_records, type: :system do
 
   def then_i_see_the_expired_search_message
     expect(page).to have_content "Bulk search expired"
-    travel_back
-  end 
+  end
 end

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
@@ -117,8 +117,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTLS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qtls_certificate.pdf")
+    download_certificate("Download QTLS certificate", filename: "#{name}_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
@@ -132,8 +131,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_1_spec.rb
@@ -118,6 +118,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTLS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
@@ -132,6 +133,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
@@ -62,6 +62,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_2_spec.rb
@@ -61,8 +61,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
@@ -113,6 +113,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
@@ -122,6 +123,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_eyts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
@@ -149,6 +151,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_1_spec.rb
@@ -112,8 +112,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
@@ -122,8 +121,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_eyts_certificate_is_downloadable
-    click_on "Download EYTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_eyts_certificate.pdf")
+    download_certificate("Download EYTS certificate", filename: "#{name}_eyts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(
@@ -150,8 +148,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include(

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
@@ -101,8 +101,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
+    download_certificate("Download Induction certificate", filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -116,8 +115,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -131,8 +129,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_3_spec.rb
@@ -102,6 +102,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_induction_certificate_is_downloadable
     click_on "Download Induction certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -116,6 +117,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -130,6 +132,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
@@ -102,6 +102,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_induction_certificate_is_downloadable
     click_on "Download Induction certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -116,6 +117,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -131,6 +133,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_1_spec.rb
@@ -101,8 +101,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
+    download_certificate("Download Induction certificate", filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -116,8 +115,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -132,8 +130,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -151,6 +151,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -165,6 +166,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qtls_certificate_is_downloadable
     click_on "Download QTLS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
@@ -179,6 +181,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_4_spec.rb
@@ -150,8 +150,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -165,8 +164,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qtls_certificate_is_downloadable
-    click_on "Download QTLS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qtls_certificate.pdf")
+    download_certificate("Download QTLS certificate", filename: "#{name}_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qtls_certificate.pdf\";")
@@ -180,8 +178,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
@@ -99,8 +99,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
+    download_certificate("Download Induction certificate", filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -114,8 +113,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -129,8 +127,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_1_spec.rb
@@ -100,6 +100,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_induction_certificate_is_downloadable
     click_on "Download Induction certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -114,6 +115,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -128,6 +130,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
@@ -149,6 +149,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -163,6 +164,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_5_spec.rb
@@ -148,8 +148,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -163,8 +162,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -149,6 +149,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -163,6 +164,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_6_spec.rb
@@ -148,8 +148,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -163,8 +162,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
@@ -142,6 +142,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_induction_certificate_is_downloadable
     click_on "Download Induction certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -155,6 +156,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -169,6 +171,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
+++ b/spec/system/qualifications/scenarios/user_views_their_qualifications_scenario_7_spec.rb
@@ -141,8 +141,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_induction_certificate_is_downloadable
-    click_on "Download Induction certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_induction_certificate.pdf")
+    download_certificate("Download Induction certificate", filename: "#{name}_induction_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_induction_certificate.pdf\"")
@@ -155,8 +154,7 @@ RSpec.feature "User views their qualifications", type: :system do
     expect(page).to have_content("Download QTS certificate")
   end
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_qts_certificate.pdf")
+    download_certificate("Download QTS certificate", filename: "#{name}_qts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_qts_certificate.pdf\";")
@@ -170,8 +168,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "#{name}_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "#{name}_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include("attachment")
     expect(page.response_headers["content-disposition"]).to include("filename=\"#{name}_npqh_certificate.pdf\";")

--- a/spec/system/qualifications/user_signs_in_via_identity_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_identity_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "Identity auth", type: :system do
   private
 
   def then_i_am_signed_in_after_successfully_authenticating_with_identity
+    expect(page).to have_current_path qualifications_dashboard_path
     expect(User.last.email).to eq "test@example.com"
     expect(User.last.auth_provider).to eq "identity"
   end

--- a/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
+++ b/spec/system/qualifications/user_signs_in_via_onelogin_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "GOVUK One Login auth", type: :system do
   private
 
   def then_i_am_signed_in_after_successfully_authenticating_with_onelogin
+    expect(page).to have_current_path qualifications_dashboard_path
     expect(User.last.email).to eq "test@example.com"
     expect(User.last.auth_provider).to eq "onelogin"
   end

--- a/spec/system/qualifications/user_submits_a_request_to_change_name_spec.rb
+++ b/spec/system/qualifications/user_submits_a_request_to_change_name_spec.rb
@@ -97,10 +97,10 @@ RSpec.feature "Account page", type: :system do
   end
 
   def then_my_request_is_submitted
-    expect(NameChange.last.full_name).to eq "Ray Purchase"
-    expect(NameChange.last.reference_number).to eq "CASE-TEST-123"
     expect(page).to have_content "Name change request submitted"
     expect(page).to have_content "CASE-TEST-123"
+    expect(NameChange.last.full_name).to eq "Ray Purchase"
+    expect(NameChange.last.reference_number).to eq "CASE-TEST-123"
   end
 
   def and_my_evidence_is_uploaded

--- a/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
+++ b/spec/system/qualifications/user_views_qualifications_with_missing_data_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Handling null data", type: :system do
     OmniAuth.config.mock_auth[:identity].credentials.token = "nulled-quals-data"
     when_i_go_to_the_sign_in_page
     and_click_the_sign_in_button
+    and_i_am_taken_to_my_qualifications_dashboard
   end
 
   def when_i_visit_the_qualifications_page

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -48,8 +48,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_qts_certificate_is_downloadable
-    click_on "Download QTLS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_qtls_certificate.pdf")
+    download_certificate("Download QTLS certificate", filename: "Terry Walsh_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"
@@ -60,8 +59,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_eyts_certificate_is_downloadable
-    click_on "Download EYTS certificate"
-    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_eyts_certificate.pdf")
+    download_certificate("Download EYTS certificate", filename: "Terry Walsh_eyts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"
@@ -84,8 +82,7 @@ RSpec.feature "User views their qualifications", type: :system do
   end
 
   def and_my_npq_certificate_is_downloadable
-    click_on "Download NPQH certificate"
-    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_npqh_certificate.pdf")
+    download_certificate("Download NPQH certificate", filename: "Terry Walsh_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"

--- a/spec/system/qualifications/user_views_their_qualifications_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_qts_certificate_is_downloadable
     click_on "Download QTLS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_qtls_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"
@@ -60,6 +61,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_eyts_certificate_is_downloadable
     click_on "Download EYTS certificate"
+    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_eyts_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"
@@ -83,6 +85,7 @@ RSpec.feature "User views their qualifications", type: :system do
 
   def and_my_npq_certificate_is_downloadable
     click_on "Download NPQH certificate"
+    and_i_wait_for_the_download_to_finish(filename: "Terry Walsh_npqh_certificate.pdf")
     expect(page.response_headers["content-type"]).to eq("application/pdf")
     expect(page.response_headers["content-disposition"]).to include(
                                                               "attachment"


### PR DESCRIPTION
### Context

Intermittent spec failures have been an ongoing problem in the repo and have been slowing down local testing as well as CI testing before PR's can be reviewed and merged.

### Changes proposed in this pull request

- Fix race in system specs
- Prevent time stubs leaking between examples
- Make DSI sign in steps deterministic
- Wait for the dashboard after qualifications sign in
- Synchronise certificate download assertions
- Clean up leaked onelogin auth mocks between examples
- Trigger certificate downloads via JavaScript clicks

### Guidance to review

- Verify that changes to specs do not change expectations
- Ensure tests are passing

### Ticket link

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/313

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
