### PR TITLE
Tighten misconfigured CSP header (ITHC)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,20 +4,51 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
+require "uri"
+
+# form-action is enforced on every hop of the sign-in redirect chain, not just
+# the form's target, so 'self' alone blocks the OAuth round-trip. Allow the
+# configured providers (so it follows the env vars) plus the government domain
+# families they federate on to — notably One Login, which is fronted by a DfE
+# broker that hands the browser to account.gov.uk, a host in no env var.
+configured_provider_origins =
+  [
+    ENV["IDENTITY_API_DOMAIN"],
+    ENV["ONELOGIN_API_DOMAIN"],
+    ENV["DFE_SIGN_IN_ISSUER"],
+  ].filter_map do |value|
+    uri = URI.parse(value.to_s)
+    uri.origin if uri.is_a?(URI::HTTPS) && uri.host.present?
+  rescue URI::InvalidURIError
+    nil
+  end
+
+government_auth_families = %w[https://*.education.gov.uk https://*.account.gov.uk]
+
+auth_provider_form_actions = (government_auth_families + configured_provider_origins).uniq
+
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, :https
-    policy.font_src :self, :https, :data
-    policy.img_src :self, :https, :data
-    policy.object_src :none
-    policy.script_src :self, :https
-    policy.style_src :self, :https
+    # First-party only. The ITHC flagged the previous :https scheme (any HTTPS
+    # host, which also neutered the script-src nonce); everything is bundled
+    # locally, so :self suffices.
+    policy.default_src     :self
+    policy.base_uri        :self
+    policy.connect_src     :self
+    policy.font_src        :self
+    policy.form_action     :self, *auth_provider_form_actions
+    policy.frame_ancestors :none
+    policy.frame_src       :none
+    policy.img_src         :self
+    policy.object_src      :none
+    policy.script_src      :self
+    policy.style_src       :self
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end
 
-  # Generate session nonces for permitted importmap and inline scripts
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # Per-response random nonce — it must be unguessable now the policy enforces it.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy.

--- a/spec/initializers/content_security_policy_spec.rb
+++ b/spec/initializers/content_security_policy_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+# form-action is built once at boot from ENV, so reload the initializer with the
+# provider vars stubbed to exercise it, then reload again to restore.
+RSpec.describe "config/initializers/content_security_policy" do
+  def initializer_path
+    Rails.root.join("config/initializers/content_security_policy.rb")
+  end
+
+  def form_action_with_env(overrides)
+    with_env(overrides) do
+      load initializer_path
+      Rails.application.config.content_security_policy.directives.fetch("form-action").dup
+    end
+  ensure
+    load initializer_path # restore the policy built from the real (test) ENV
+  end
+
+  def with_env(overrides)
+    originals = overrides.to_h { |key, _value| [key, ENV[key]] }
+    overrides.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  it "always allows the government auth domain families" do
+    sources = form_action_with_env({})
+
+    expect(sources).to include(
+      "'self'",
+      "https://*.education.gov.uk",
+      "https://*.account.gov.uk",
+    )
+  end
+
+  # The families are decoupled from the env vars, so a provider pointed outside
+  # them must still be allowed via its derived exact origin.
+  it "also allows each configured provider origin, including ones outside the families" do
+    sources = form_action_with_env(
+      "IDENTITY_API_DOMAIN" => "https://identity.example.com/some/path",
+      "ONELOGIN_API_DOMAIN" => "https://oidc.account.gov.uk",
+      "DFE_SIGN_IN_ISSUER" => "https://pp-oidc.signin.education.gov.uk",
+    )
+
+    expect(sources).to include(
+      "https://identity.example.com",
+      "https://oidc.account.gov.uk",
+      "https://pp-oidc.signin.education.gov.uk",
+    )
+  end
+
+  it "ignores non-HTTPS or placeholder provider values" do
+    sources = form_action_with_env(
+      "IDENTITY_API_DOMAIN" => "override-locally",
+      "ONELOGIN_API_DOMAIN" => "",
+      "DFE_SIGN_IN_ISSUER" => "http://insecure.example.com",
+    )
+
+    expect(sources).to eq(
+      ["'self'", "https://*.education.gov.uk", "https://*.account.gov.uk"],
+    )
+  end
+
+  # Malformed values must be dropped, not turned into a junk "https://" source.
+  it "ignores unparseable or host-less provider values" do
+    sources = form_action_with_env(
+      "IDENTITY_API_DOMAIN" => "https://[", # unparseable -> URI::InvalidURIError
+      "ONELOGIN_API_DOMAIN" => "https:", # HTTPS scheme, no host
+      "DFE_SIGN_IN_ISSUER" => "https://", # HTTPS scheme, no host
+    )
+
+    expect(sources).to eq(
+      ["'self'", "https://*.education.gov.uk", "https://*.account.gov.uk"],
+    )
+  end
+end

--- a/spec/requests/security_headers_spec.rb
+++ b/spec/requests/security_headers_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Security headers", type: :request do
+  # The Content-Security-Policy is applied by Rails middleware to every
+  # response, so any unauthenticated route exercises it.
+  describe "Content-Security-Policy" do
+    let(:policy) do
+      get "/health"
+      response.headers["Content-Security-Policy"]
+    end
+
+    it "restricts every directive to first-party sources" do
+      expect(policy).to include("default-src 'self'")
+      expect(policy).to include("base-uri 'self'")
+      expect(policy).to include("connect-src 'self'")
+      expect(policy).to include("font-src 'self'")
+      expect(policy).to include("frame-ancestors 'none'")
+      expect(policy).to include("frame-src 'none'")
+      expect(policy).to include("img-src 'self'")
+      expect(policy).to include("object-src 'none'")
+      expect(policy).to include("style-src 'self'")
+    end
+
+    # form-action must allow the providers the sign-in forms redirect out to
+    # (see the initializer); browsers enforce it on every hop.
+    it "allows first-party and the government auth domain families in form-action" do
+      expect(policy).to include(
+        "form-action 'self' https://*.education.gov.uk https://*.account.gov.uk",
+      )
+    end
+
+    it "permits nonce-based inline scripts but no external scripts" do
+      expect(policy).to match(/script-src 'self' 'nonce-[^']+'/)
+    end
+
+    # Only the bare :https scheme is the finding; an explicit https://host
+    # origin (e.g. the auth providers) is fine.
+    it "does not allow the bare https: scheme as a source" do
+      expect(policy).not_to match(%r{https:(?!//)})
+    end
+
+    # Nothing in the compiled assets uses data: URIs, so the permissive
+    # scheme is dropped entirely.
+    it "does not allow the data: scheme as a source" do
+      expect(policy).not_to include("data:")
+    end
+  end
+
+  # A header-only check won't catch a nonce that fails to reach the markup, so
+  # render a real page and confirm it matches across meta tag, script and header.
+  describe "nonce injection in rendered pages" do
+    # App pages sit behind HTTP Basic auth in non-open environments.
+    let(:credentials) do
+      ActionController::HttpAuthentication::Basic.encode_credentials(
+        ENV.fetch("SUPPORT_USERNAME", "test"),
+        ENV.fetch("SUPPORT_PASSWORD", "test"),
+      )
+    end
+
+    shared_examples "a page with an end-to-end nonce" do |host, path|
+      before do
+        host! host
+        get path, headers: { "HTTP_AUTHORIZATION" => credentials }
+      end
+
+      let(:header_nonce) do
+        response.headers["Content-Security-Policy"][/script-src 'self' 'nonce-([^']+)'/, 1]
+      end
+      let(:meta_nonce) { response.body[/<meta name="csp-nonce" content="([^"]+)"/, 1] }
+      let(:script_nonce) { response.body[/<script nonce="([^"]+)"/, 1] }
+
+      it "renders successfully" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "injects the nonce into the csp_meta_tag and the inline script tag" do
+        expect(meta_nonce).to be_present
+        expect(script_nonce).to be_present
+      end
+
+      it "uses the same nonce in the meta tag, inline script and CSP header" do
+        expect(meta_nonce).to eq(header_nonce)
+        expect(script_nonce).to eq(header_nonce)
+      end
+    end
+
+    # The cookies page skips authentication and renders the base layout.
+    context "qualifications (base layout)" do
+      it_behaves_like "a page with an end-to-end nonce",
+                      "qualifications.localhost",
+                      "/qualifications/cookies"
+    end
+
+    # The terms and conditions page skips DfE Sign-in and renders the
+    # check_records layout.
+    context "check records (check_records layout)" do
+      it_behaves_like "a page with an end-to-end nonce",
+                      "check_records.localhost",
+                      "/check-records/terms-and-conditions"
+    end
+  end
+end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -2,7 +2,6 @@ module AuthenticationSteps
   def when_i_sign_in_via_dsi(authorised: true, internal: false, orgs: [organisation], accept_terms_and_conditions: true)
     given_dsi_auth_is_mocked(authorised:, internal:, orgs:,)
     when_i_visit_the_sign_in_page
-    and_wait_for_the_page_to_load
     and_i_accept_the_terms_and_conditions(accept_terms_and_conditions)
   end
   alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
@@ -98,17 +97,5 @@ module AuthenticationSteps
       click_on "Accept", wait: 10
       expect(page).to have_no_current_path(check_records_terms_and_conditions_path, wait: 10)
     end
-  end
-
-  # The sign in page POSTs to DSI via an auto-submitting form (see
-  # CheckRecords::SignInController#new). On the first request of a session the
-  # form's inline script is blocked by the Content-Security-Policy (the nonce
-  # is derived from the session id, which doesn't exist until the first
-  # response sets the session cookie), so the page never submits itself.
-  # Reloading once renders the form with a valid nonce. Only reload while
-  # still stuck on the form: reloading mid-redirect can abort the navigation
-  # and strand the test on a blank page.
-  def and_wait_for_the_page_to_load
-    page.driver.refresh unless page.has_no_css?("form[action*='/auth/']", wait: 2)
   end
 end


### PR DESCRIPTION
### Context

The AYTQ ITHC flagged the Content-Security-Policy header as too permissive and missing several protective directives. The `:https` scheme on `default-src`, `script-src` and `style-src` allowed resources to be loaded from *any* HTTPS host on the internet — which defeats the point of those directives and also neutered the `script-src` nonce (a browser accepts a script matching *either* the nonce or the broad source). `frame-ancestors`, `form-action`, `base-uri`, `connect-src` (and `frame-src`) were missing entirely (so `form-action` fell back to `default-src`, i.e. any `https:` host).

### Changes proposed in this pull request

Tightened `config/initializers/content_security_policy.rb`:

- Dropped the broad `:https` scheme to `:self` across `default-src`, `script-src`, `style-src`, `img-src` and `font-src`.
- Removed `:data` from `img-src`/`font-src` — a grep of the compiled assets, govuk-frontend 6.1.0 and the One Login service-header CSS confirmed nothing uses `data:` URIs.
- Added the missing protective directives: `base-uri 'self'`, `connect-src 'self'`, `frame-ancestors 'none'`, `frame-src 'none'` and `form-action` (see below).
- Replaced the predictable `session.id` nonce generator with a fresh per-response `SecureRandom.base64(16)`, so the now-enforced nonce is genuinely unguessable.
- Left `object-src :none` unchanged.

**`form-action` can't be `'self'` alone.** The OmniAuth sign-in/out forms POST to a first-party `/auth/*` path that 302-redirects to the identity provider, and browsers enforce `form-action` against **every hop** of that navigation — so `'self'` alone blocks the OAuth round-trip. It's built from two parts because the chains span hosts that aren't all in config:

1. **The configured provider origins** — derived from the same env vars `omniauth.rb` uses (`IDENTITY_API_DOMAIN`, `ONELOGIN_API_DOMAIN`, `DFE_SIGN_IN_ISSUER`). This keeps `form-action` following the env vars, so if an environment points a provider at a different host it's still allowed.
2. **The government auth domain families** `https://*.education.gov.uk` and `https://*.account.gov.uk` — the providers redirect *on* to further hosts that aren't in any env var: DfE Sign-in spreads across `signin.education.gov.uk` subdomains, and GOV.UK One Login is fronted by a DfE broker (`teaching-identity.education.gov.uk`) that federates the browser to `account.gov.uk` / `integration.account.gov.uk` for the credential UI. (An earlier attempt to derive only the exact origins missed that cross-host federation and was still blocked on the review app — the mocked specs never perform the real redirect.)

Both families are bounded to DfE/GOV.UK auth domains and remain a vast tightening over the previous any-`https:`-host fall-back.

This also fixes a latent bug: the `session.id` nonce was **empty on the very first request of a session** (before the session cookie was set), which blocked the auto-submitting DfE Sign-in form's inline script on a user's first visit. A system-test helper (`and_wait_for_the_page_to_load`) reloaded the page to work around it; the per-response nonce is always valid on the first request, so that workaround is removed and the check-records sign-in system specs pass without it.

The rest of the tightening is safe because everything else is first-party: all JS/CSS/fonts/images are bundled locally via esbuild and the asset pipeline, dfe-analytics and Sentry are server-side only (no client tracking), there are no client-side `fetch`/XHR calls, and no external iframes. `frame-ancestors`/`frame-src` are `'none'` as the app is standalone and never embedded.

Specs lock in the remediation:

- `spec/requests/security_headers_spec.rb` — asserts each directive is first-party, that `form-action` allows the government families, that the bare `https:`/`data:` schemes no longer appear, and (rendering the cookies and terms-and-conditions pages) that the per-response nonce is wired through end to end — identical in the `csp-nonce` meta tag, the inline `<script>` and the CSP header — across **both** layouts.
- `spec/initializers/content_security_policy_spec.rb` — reloads the initializer with provider env vars stubbed and asserts `form-action` includes both the static families and each configured provider origin, **including one pointed outside the families** (guarding the env-override path).

> Aligned with the sibling CBL remediation in [check-childrens-barred-list#583](https://github.com/DFE-Digital/check-childrens-barred-list/pull/583).

### Guidance to review

1. **Automated**: `bundle exec rspec spec/requests/security_headers_spec.rb spec/initializers/content_security_policy_spec.rb` and the check-records sign-in/system suite are green; rubocop/prettier clean.
2. **Manual / browser** (review app this PR deploys) — walk a full **sign-in / sign-out** for **all three** providers with the DevTools Console open and confirm **no `form-action` CSP violations**:
   - **GOV.UK One Login** (qualifications) — the cross-host `teaching-identity → account.gov.uk` journey.
   - **DfE Identity** (qualifications) — the originally-reported failure.
   - **DfE Sign-in** (check-records), incl. the **first visit of a fresh session** so the auto-submit form runs without a manual reload.
   - Also confirm no other CSP violations and that the GOV.UK feature-detection inline script runs (`<body>` gains `js-enabled govuk-frontend-supported`).

If any GOV.UK component injects inline `<style>` at runtime and is blocked, the follow-up fix is to add `style-src` to `content_security_policy_nonce_directives`.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)