### PR TITLE
Honour cuprite process_timeout in system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,20 +16,6 @@ require "dfe/analytics/rspec/matchers"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
-Capybara.register_driver(:cuprite) do |app|
-  # Without an explicit download path Chrome denies downloads, which can
-  # hang clicks on download links and leaves response_headers unset. The
-  # directory must exist or Chrome stalls the download instead.
-  download_path = Rails.root.join("tmp/capybara/downloads").to_s
-  FileUtils.mkdir_p(download_path)
-  Capybara::Cuprite::Driver.new(
-    app,
-    timeout: 200,
-    process_timeout: 120,
-    window_size: [1200, 800],
-    save_path: download_path
-  )
-end
 Capybara.default_driver = :cuprite
 Capybara.javascript_driver = :cuprite
 Capybara.app_host = "http://qualifications.localhost"
@@ -87,7 +73,23 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  config.before(:each, type: :system) { driven_by(:cuprite) }
+  config.before(:each, type: :system) do
+    # driven_by re-registers the :cuprite driver per example, so timeout and
+    # save_path must be passed here — a bare driven_by(:cuprite) reverts to
+    # Ferrum's short defaults (10s process_timeout), the CI startup-flake cause.
+    # Chrome also stalls downloads without an explicit, existing save path.
+    download_path = Rails.root.join("tmp/capybara/downloads").to_s
+    FileUtils.mkdir_p(download_path)
+    driven_by(
+      :cuprite,
+      screen_size: [1200, 800],
+      options: {
+        timeout: 200,
+        process_timeout: 120,
+        save_path: download_path
+      }
+    )
+  end
   config.before { Sidekiq::Worker.clear_all }
   config.before(:each) do
     stub_request(:any, /npq-registration-sandbox-web.teacherservices/).to_rack(FakeNpqQualificationsApi)


### PR DESCRIPTION
### Context

System specs (`spec/system/**`) fail intermittently in CI with browser-startup errors rather than assertion failures — `Ferrum::ProcessTimeoutError: "Browser did not produce websocket url within 10 seconds"`, `Ferrum::NoSuchTargetError`, and whole-suite `Ferrum::TimeoutError` cascades. The same commit passes on one run and fails on the next (e.g. #1116), and the failing bumps are JS-only lockfile changes that cannot touch Ruby — infrastructure flake, not a regression.

Root cause: the custom `:cuprite` registration (`process_timeout: 120`, `timeout: 200`, `save_path`) was silently discarded. The per-example `driven_by(:cuprite)` routes through `ActionDispatch::SystemTesting::Driver#use`, which treats `:cuprite` as registerable and **re-registers it with empty options on every example**, overwriting the custom registration. Ferrum then fell back to its defaults — a 10s `process_timeout` and 5s `timeout` — which lose the race to Chrome's websocket handshake under CI load.

### Changes proposed in this pull request

- Pass `timeout`, `process_timeout`, `screen_size`, and the download `save_path` through `driven_by(:cuprite, ...)` in the `before(:each, type: :system)` hook — the code path that actually registers the driver.
- Remove the now-dead standalone `Capybara.register_driver(:cuprite)` block so the options live in a single place.

This reproduces the original driver config exactly, now on the path that is used.

### Guidance to review

Verified in a system spec that `page.driver.options` reads `process_timeout: 120` / `timeout: 200` / the correct download `save_path` **after** the change (before it, both read `nil`, so Ferrum's short defaults applied). The full `spec/system` suite (excluding `smoke_spec`, which needs live hosting domains) ran green three consecutive times, 64 examples / 0 failures each.

Note: the 120s `process_timeout` directly addresses the dominant `ProcessTimeoutError` startup signature. The `NoSuchTargetError` / mid-suite cascades are downstream of the same short-default starvation and should improve, but the CI-load race does not reproduce locally, so broader browser-startup hardening is left as a possible follow-up.

### Link to Trello card

<!-- TODO: add Trello card link -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally