### PR TITLE
2855 - Corrects scheduled review app deletion error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ set-azure-account: ## Set the Azure account based on environment settings
 
 .PHONY: review
 review: test-cluster ## Setup review environment for AKS
+	$(eval PR_NUMBER ?= ${PULL_REQUEST_NUMBER})
 	$(if ${PR_NUMBER},,$(error Missing PR_NUMBER))
 	$(eval ENVIRONMENT=pr-${PR_NUMBER})
 	$(eval include global_config/review.sh)


### PR DESCRIPTION
## Context

We get quite a few rogue review apps - i.e. the PR has been merged or closed, but the review app wasn’t deleted.

There are various reasons this can occur, but we also now have a workflow that will check for rogue review apps and delete them: [Review app reconcile](https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/workflows/review-app-reconcile.yml)

However, there was an issue when running this workflow due to the fact that the Makefile expects a slightly different pull request variable name to that which is provided by the central GitHub action.

## Changes proposed in this pull request

Amends Makefile to set `PR_NUMBER` to the value of `PULL_REQUEST_NUMBER`, if not already defined (added to line 28):

`$(eval PR_NUMBER ?= ${PULL_REQUEST_NUMBER})`

## Guidance to review

Test the deletion of review apps by running the workflow manually with the dry run flag set. I completed a dry run and this worked fine: [My dry run](https://github.com/DFE-Digital/access-your-teaching-qualifications/actions/runs/29740742894/job/88346681167)

There will be no issue if it fails to delete the review apps on Sunday as this is what it is doing at the moment anyway. This will just need revisiting, if so.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [ ] Tested by running locally