### PR TITLE
Load users by UID, not email

### DIFF
--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -9,12 +9,12 @@ class DsiUser < ApplicationRecord
   CURRENT_TERMS_AND_CONDITIONS_VERSION = "1.0".freeze
 
   def self.create_or_update_from_dsi(dsi_payload, role: nil)
-    dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
+    dsi_user = find_or_initialize_by(uid: dsi_payload.uid)
 
     dsi_user.update!(
       first_name: dsi_payload.info.first_name,
       last_name: dsi_payload.info.last_name,
-      uid: dsi_payload.uid,
+      email: dsi_payload.info.fetch(:email)
     )
 
     if role.present?

--- a/spec/factories/dsi_users.rb
+++ b/spec/factories/dsi_users.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
 
     first_name { "Steven" }
     last_name { "Toast" }
-    uid { "123" }
+    uid { "123456" }
   end
 end

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DsiUser, type: :model do
   describe ".create_or_update_from_dsi" do
     let(:dsi_payload) do
       OmniAuth::AuthHash.new(
-        uid: "123456",
+        uid: uid,
         info: { email:, first_name: "John", last_name: "Doe" },
         extra: {
           raw_info: {
@@ -17,15 +17,17 @@ RSpec.describe DsiUser, type: :model do
       )
     end
     let(:email) { "test@example.com" }
+    let(:uid) { "123456" }
 
     context "when the user with the email exists" do
-      let!(:existing_user) { create(:dsi_user, email:) }
+      let!(:existing_user) { create(:dsi_user, uid:, email: "mail@example.com") }
 
       it "finds the existing user and updates the attributes" do
         result = described_class.create_or_update_from_dsi(dsi_payload)
 
         expect(result).to eq(existing_user)
         expect(result.uid).to eq dsi_payload.uid
+        expect(result.email).to eq email
         expect(result.first_name).to eq dsi_payload.info.first_name
         expect(result.last_name).to eq dsi_payload.info.last_name
       end


### PR DESCRIPTION
### Context

Raised as an issue during DROMOS report.

### Changes proposed in this pull request

- Update login so that user upsert occurs using UID rather than email as a key.

### Guidance to review

- Login as a DsiUser and confirm that login works

### Link to Github card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/354

### Checklist

- [x] Attach to Github card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
