### PR TITLE
Look up qualifications users by uid, allow duplicate emails

### DIFF
--- a/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/qualifications/users/omniauth_callbacks_controller.rb
@@ -15,6 +15,10 @@ module Qualifications
 
         log_auth_credentials_in_development(auth)
         redirect_to qualifications_dashboard_path
+      rescue User::AuthMissingUidError => e
+        Sentry.capture_exception(e)
+        flash[:warning] = I18n.t("validation_errors.generic_oauth_failure")
+        redirect_to qualifications_root_path
       end
 
       private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  class AuthMissingUidError < StandardError; end
+
   encrypts :email, deterministic: true
   encrypts :family_name, :given_name, :name
   encrypts :one_login_verified_name
@@ -7,22 +9,35 @@ class User < ApplicationRecord
   has_many :date_of_birth_changes
 
   def self.from_auth(auth_data)
+    uid = auth_data.uid
+    provider = auth_data.provider
     email = auth_data.info.email
-    user = find_or_initialize_by(email:)
+    raise AuthMissingUidError, "Auth response is missing a uid" if uid.blank?
+
+    # Select on the stable provider subject, never on the mutable email. Fall
+    # back to an unclaimed (no uid/provider) row so pre-cutover accounts are
+    # backfilled once. Email is set from the payload even when another row
+    # already holds it: two subjects sharing an email are distinct accounts.
+    user =
+      find_by(auth_provider: provider, auth_uuid: uid) ||
+      find_by(email:, auth_uuid: nil, auth_provider: nil) ||
+      new
 
     user.assign_attributes(
       # TODO: review how much of this PII we need to persist. We may no longer
       # have a requirement for it.
+      email:,
       date_of_birth: auth_data.extra.raw_info.birthdate,
       family_name: auth_data.info.last_name,
       given_name: auth_data.info.first_name,
       name: auth_data.info.name,
       trn: auth_data.extra.raw_info.trn,
-      auth_uuid: auth_data.uid,
-      auth_provider: auth_data.provider,
+      auth_uuid: uid,
+      auth_provider: provider,
       one_login_verified_name: auth_data.extra.raw_info.onelogin_verified_names&.first&.join(" "),
       one_login_verified_birth_date: auth_data.extra.raw_info.onelogin_verified_birthdates&.first
     )
+
     user.tap(&:save!)
   end
 

--- a/db/migrate/20260724133229_add_unique_index_on_auth_provider_and_auth_uuid_to_users.rb
+++ b/db/migrate/20260724133229_add_unique_index_on_auth_provider_and_auth_uuid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnAuthProviderAndAuthUuidToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_index :users, %i[auth_provider auth_uuid], unique: true
+  end
+end

--- a/db/migrate/20260724142404_remove_unique_index_from_users_email.rb
+++ b/db/migrate/20260724142404_remove_unique_index_from_users_email.rb
@@ -1,0 +1,11 @@
+class RemoveUniqueIndexFromUsersEmail < ActiveRecord::Migration[7.2]
+  def up
+    remove_index :users, :email, name: "index_users_on_email"
+    add_index :users, :email, name: "index_users_on_email"
+  end
+
+  def down
+    remove_index :users, :email, name: "index_users_on_email"
+    add_index :users, :email, unique: true, name: "index_users_on_email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_17_065402) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_24_142404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -215,7 +215,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_065402) do
     t.string "auth_provider"
     t.string "one_login_verified_name"
     t.date "one_login_verified_birth_date"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["auth_provider", "auth_uuid"], name: "index_users_on_auth_provider_and_auth_uuid", unique: true
+    t.index ["email"], name: "index_users_on_email"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     name { "John Smith" }
     trn { "1234567" }
     date_of_birth { Date.new(2000, 1, 1) }
+    auth_uuid { SecureRandom.uuid }
+    auth_provider { "onelogin" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,16 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe ".from_auth" do
+    let(:uid) { "123-abc" }
+    let(:provider) { "an-oauth2-provider" }
+    let(:email) { "test@example.com" }
     let(:auth_data) do
       OpenStruct.new(
-        uid: "123-abc",
-        provider: "an-oauth2-provider",
+        uid:,
+        provider:,
         info:
           OpenStruct.new(
-            email: "test@example.com",
+            email:,
             name: "Test User",
             first_name: "Test",
             last_name: "User"
@@ -24,28 +27,81 @@ RSpec.describe User, type: :model do
       )
     end
 
-    it "creates a new user with the auth data" do
-      user = described_class.from_auth(auth_data)
+    context "when no user matches the uid or email" do
+      it "creates a new user with the auth data" do
+        expect { described_class.from_auth(auth_data) }.to change(User, :count).by(1)
 
-      expect(user.email).to eq "test@example.com"
-      expect(user.name).to eq "Test User"
-      expect(user.given_name).to eq "Test"
-      expect(user.family_name).to eq "User"
-      expect(user.trn).to eq "123456"
-      expect(user.date_of_birth.to_s).to eq "1986-01-02"
-      expect(user.auth_uuid).to eq "123-abc"
-      expect(user.auth_provider).to eq "an-oauth2-provider"
-      expect(user.one_login_verified_name).to eq "Test User"
-      expect(user.one_login_verified_birth_date.to_s).to eq "1992-02-03"
+        user = User.last
+        expect(user.email).to eq "test@example.com"
+        expect(user.name).to eq "Test User"
+        expect(user.given_name).to eq "Test"
+        expect(user.family_name).to eq "User"
+        expect(user.trn).to eq "123456"
+        expect(user.date_of_birth.to_s).to eq "1986-01-02"
+        expect(user.auth_uuid).to eq "123-abc"
+        expect(user.auth_provider).to eq "an-oauth2-provider"
+        expect(user.one_login_verified_name).to eq "Test User"
+        expect(user.one_login_verified_birth_date.to_s).to eq "1992-02-03"
+      end
     end
 
-    context "a user exists" do
-      let!(:user) { create(:user, email: "test@example.com", given_name: "Ray") }
+    context "when a user already has the uid and provider" do
+      let!(:existing) do
+        create(:user, auth_uuid: uid, auth_provider: provider, email: "old@example.com", given_name: "Ray")
+      end
 
-      it "updates the user's details" do
+      it "returns the existing user without creating a new one" do
+        expect { expect(described_class.from_auth(auth_data)).to eq(existing) }
+          .not_to change(User, :count)
+      end
+
+      it "refreshes the mutable details from the auth payload" do
         described_class.from_auth(auth_data)
-        expect(user.reload.given_name).to eq "Test"
-        expect(User.count).to eq 1
+
+        expect(existing.reload.given_name).to eq "Test"
+        expect(existing.email).to eq email
+      end
+    end
+
+    context "when a user exists by email but has no uid yet (pre-cutover)" do
+      let!(:existing) do
+        create(:user, email:, auth_uuid: nil, auth_provider: nil, given_name: "Ray")
+      end
+
+      it "backfills the uid and provider onto that record" do
+        expect { described_class.from_auth(auth_data) }.not_to change(User, :count)
+        expect(existing.reload).to have_attributes(auth_uuid: uid, auth_provider: provider)
+      end
+    end
+
+    context "when the email already belongs to a user with a different uid" do
+      let!(:existing) do
+        create(:user, email:, auth_uuid: "other-uid", auth_provider: provider)
+      end
+
+      it "creates a separate user for the new subject, sharing the email" do
+        expect { described_class.from_auth(auth_data) }.to change(User, :count).by(1)
+
+        new_user = User.find_by(auth_uuid: uid)
+        expect(new_user).not_to eq(existing)
+        expect(new_user.email).to eq(email)
+        expect(new_user.auth_provider).to eq(provider)
+      end
+
+      it "leaves the existing user untouched" do
+        described_class.from_auth(auth_data)
+
+        expect(existing.reload).to have_attributes(auth_uuid: "other-uid", email:)
+      end
+    end
+
+    context "when the auth payload has no uid" do
+      let(:uid) { nil }
+
+      it "raises AuthMissingUidError" do
+        expect { described_class.from_auth(auth_data) }.to raise_error(
+          User::AuthMissingUidError
+        )
       end
     end
   end

--- a/spec/support/system/qualifications_authentication_steps.rb
+++ b/spec/support/system/qualifications_authentication_steps.rb
@@ -30,6 +30,7 @@ module QualificationAuthenticationSteps
     OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new(
       {
         provider:,
+        uid: "#{provider}-uid-123",
         info: {
           email: "test@example.com",
           first_name: "User",

--- a/spec/system/qualifications/user_views_their_qualifications_no_rtps_spec.rb
+++ b/spec/system/qualifications/user_views_their_qualifications_no_rtps_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "User views their qualifications", type: :system do
     OmniAuth.config.mock_auth[:identity] = OmniAuth::AuthHash.new(
       {
         provider: "identity",
+        uid: "identity-uid-123",
         info: {
           email: "test@example.com",
           email_verified: "True",


### PR DESCRIPTION
### Context

DROMOS vulnerability report `R061-F002`. The qualifications sign-in path
(`Qualifications::Users::OmniauthCallbacksController#complete` → `CurrentSession.create_session`
→ `User.from_auth`) selected the local `User` by email and then wrote the incoming
`auth_uuid`/`auth_provider` onto that row. If the identity provider ever issued the same email for
a different subject, sign-in rebound to the wrong account. This mirrors the fix already shipped for
`DsiUser` in #1126 and for `Staff` in [FLTRN #1305](https://github.com/DFE-Digital/find-a-lost-trn/pull/1305):
select on the stable provider subject, treat email as mutable profile data.

Two providers — `identity` and `onelogin` — both flow through the same `User.from_auth`, so a
teacher can legitimately hold the same email under two different subjects. Rather than block the
second sign-in, we allow two `User` rows to share an email; they are distinct accounts keyed on
their provider subject.

### Changes proposed in this pull request

- Rewrite `User.from_auth` to select on `auth_provider` + `auth_uuid` rather than email. It falls
  back to an unclaimed (NULL uid/provider) row matched by email so pre-cutover accounts are
  backfilled once, otherwise it builds a new record, and it always sets the email from the payload.
- A missing uid raises `User::AuthMissingUidError`, rescued in the callback: reported to Sentry and
  redirected to sign-in with the generic failure message.
- Add a composite `unique` index on `[auth_provider, auth_uuid]` as the identity key (nullable;
  Postgres keeps NULL rows distinct, so pre-cutover rows don't collide during the cutover).
- Drop the `unique` constraint on the email index — replaced with a plain index — so two subjects
  that share an email can each hold their own account.

**Security posture:** selection is by provider subject, so a different subject can never *select* a
victim's account by email (R061-F002 stays closed) — it only ever gets its own row. Allowing
duplicate emails is coexistence, not merge: a person signing in under a second provider gets a
second `User` row, and their name/DOB-change history splits across the two rows. Unifying them (a
`user_identities` table, or a merge step) would be separate work.

**Before merging:** the `[auth_provider, auth_uuid]` unique index build fails if any two rows
already share a non-NULL `(auth_provider, auth_uuid)` pair. Run this against production-shaped data
(a review app) and confirm the result is empty:

```ruby
User.where.not(auth_uuid: nil)
    .group(:auth_provider, :auth_uuid)
    .having("COUNT(*) > 1")
    .count
# => {} means safe to add the index.
```

### Guidance to review

- Start at `User.from_auth` — the provider-subject lookup, the pre-cutover fallback, and setting the
  email unconditionally are the core.
- `spec/models/user_spec.rb` covers create / return-by-uid+email-refresh / pre-cutover backfill /
  duplicate-email accounts / missing uid.
- Confirm nothing else relies on `users.email` being unique: the only `User`-by-email lookups in the
  app are inside `from_auth`; every other lookup is by `id`.

### Link to Github card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/353

### Checklist

- [x] Attach to Github card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
