### PR TITLE
Drop unique index on dsi_users email

### DIFF
--- a/db/migrate/20260729152804_remove_unique_index_from_dsi_users_email.rb
+++ b/db/migrate/20260729152804_remove_unique_index_from_dsi_users_email.rb
@@ -1,0 +1,9 @@
+class RemoveUniqueIndexFromDsiUsersEmail < ActiveRecord::Migration[7.2]
+  def up
+    remove_index :dsi_users, :email, name: "index_dsi_users_on_email"
+  end
+
+  def down
+    add_index :dsi_users, :email, unique: true, name: "index_dsi_users_on_email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_24_142404) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_29_152804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,7 +140,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_24_142404) do
     t.datetime "updated_at", null: false
     t.string "terms_and_conditions_version_accepted"
     t.datetime "terms_and_conditions_accepted_at"
-    t.index ["email"], name: "index_dsi_users_on_email", unique: true
   end
 
   create_table "feature_flags_features", force: :cascade do |t|


### PR DESCRIPTION
### Context

Follow-up to #1126, which switched `DsiUser` sign-in to key on `uid`
(`DsiUser.create_or_update_from_dsi` now looks up by `uid` and treats email as
mutable profile data). The `dsi_users.email` column still carried a `unique`
index, so when two DfE Sign-in subjects present the same email —
`update!(email:)` on a different `uid`'s record — the write raises
`ActiveRecord::RecordNotUnique` and sign-in errors. This mirrors the same fix
made for the qualifications `User` in #1127.

### Changes proposed in this pull request

- Drop the `unique` index `index_dsi_users_on_email`. Two DfE Sign-in subjects
  that share an email now each keep their own record, keyed on `uid`.
- The index is removed outright rather than replaced with a non-unique one:
  nothing in the app reads `dsi_users` by email (every lookup is by `uid` or
  `id`), so a plain index would only add write overhead. There is no
  model-level `uniqueness` validation on `DsiUser`, so the DB index was the
  only constraint.

Selection is still by `uid`, so this does not let a different subject select an
existing account by email — it only stops the collision on save.

### Guidance to review

- The migration is `db/migrate/20260729152804_remove_unique_index_from_dsi_users_email.rb`.
- Confirm nothing relies on `dsi_users.email` being unique: `create_or_update_from_dsi`
  keys on `uid`, and there are no `find_by(email:)` / `where(email:)` reads of
  `DsiUser` in the app.

### Link to Github card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/354

### Checklist

- [x] Attach to Github card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
